### PR TITLE
Add CleanAllNetworksByTargetNamespace function to sriov package

### DIFF
--- a/pkg/sriov/network.go
+++ b/pkg/sriov/network.go
@@ -418,3 +418,46 @@ func (builder *NetworkBuilder) validate() (bool, error) {
 
 	return true, nil
 }
+
+// CleanAllNetworksByTargetNamespace deletes all networks matched by their NetworkNamespace spec.
+func CleanAllNetworksByTargetNamespace(
+	apiClient *clients.Settings,
+	operatornsname string,
+	targetnsname string,
+	options metaV1.ListOptions) error {
+	glog.V(100).Infof("Cleaning up sriov networks in the %s namespace with %s NetworkNamespace spec",
+		operatornsname, targetnsname)
+
+	if operatornsname == "" {
+		glog.V(100).Infof("'operatornsname' parameter can not be empty")
+
+		return fmt.Errorf("failed to clean up sriov networks, 'operatornsname' parameter is empty")
+	}
+
+	if targetnsname == "" {
+		glog.V(100).Infof("'targetnsname' parameter can not be empty")
+
+		return fmt.Errorf("failed to clean up sriov networks, 'targetnsname' parameter is empty")
+	}
+
+	networks, err := List(apiClient, operatornsname, options)
+
+	if err != nil {
+		glog.V(100).Infof("Failed to list sriov networks in namespace: %s", operatornsname)
+
+		return err
+	}
+
+	for _, network := range networks {
+		if network.Object.Spec.NetworkNamespace == targetnsname {
+			err = network.Delete()
+			if err != nil {
+				glog.V(100).Infof("Failed to delete sriov networks: %s", network.Object.Name)
+
+				return err
+			}
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Add function which deletes all sriov networks from the operator namespace which match a specific NetworkNamespace spec.