### PR TITLE
Fix KMM WithImageRepoSecret function

### DIFF
--- a/pkg/kmm/module.go
+++ b/pkg/kmm/module.go
@@ -126,7 +126,7 @@ func (builder *ModuleBuilder) WithImageRepoSecret(imageRepoSecret string) *Modul
 		return builder
 	}
 
-	builder.Definition.Spec.ImageRepoSecret.Name = imageRepoSecret
+	builder.Definition.Spec.ImageRepoSecret = &v1.LocalObjectReference{Name: imageRepoSecret}
 
 	return builder
 }


### PR DESCRIPTION
In the current format, the call to WithImageRepoSecret fails with:

```
  [PANICKED] Test Panicked
  In [It] at: /home/cvultur/sdk/go1.19.3/src/runtime/panic.go:260 @ 07/26/23 11:59:45.932

  runtime error: invalid memory address or nil pointer dereference
```

Verified the solution in the test itself and seems to work properly