### PR TITLE
Add copy method to pod pkg

### DIFF
--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -470,10 +470,6 @@ func (builder *Builder) Copy(path, containerName string, tar bool) (bytes.Buffer
 		return bytes.Buffer{}, err
 	}
 
-	if err != nil {
-		return bytes.Buffer{}, err
-	}
-
 	exec, err := remotecommand.NewSPDYExecutorForTransports(wrapper, upgradeRoundTripper, "POST", req.URL())
 
 	if err != nil {


### PR DESCRIPTION
Adds a copy method to the pod pkg which can copy files from one of the pod's containers. Has two options:
1. With tar - creates a tar archive of a path inside the container (good for copying directories if a container supports it)
2. Without tar - copies the contents of a single file