### PR TITLE
pod pkg, fixing Exists function comment

### DIFF
--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -490,7 +490,7 @@ func (builder *Builder) Copy(path, containerName string, tar bool) (bytes.Buffer
 	return buffer, nil
 }
 
-// Exists checks whether the given namespace exists.
+// Exists checks whether the given pod exists.
 func (builder *Builder) Exists() bool {
 	if valid, _ := builder.validate(); !valid {
 		return false


### PR DESCRIPTION
The initial comment seems to be copy pasted from namespace package

// Exists checks whether the given namespace exists.

Should be

//Exists checks whether the given pod exists.