### PR TITLE
mco: fix mcp condition comparing definition, removing double quotes, …

### DIFF
--- a/pkg/mco/mcp.go
+++ b/pkg/mco/mcp.go
@@ -348,7 +348,7 @@ func (builder *MCPBuilder) IsInCondition(mcpConditionType mcov1.MachineConfigPoo
 
 	if builder.Exists() {
 		for _, condition := range builder.Object.Status.Conditions {
-			if condition.Type == mcpConditionType && condition.Status == "isTrue" {
+			if condition.Type == mcpConditionType && condition.Status == isTrue {
 				return true
 			}
 		}


### PR DESCRIPTION
mco: fix mcp condition comparing definition for IsInCondition method, removing double quotes, it is const value usage