### PR TITLE
initialize kmm args/rawargs only when length is greater than 0

### DIFF
--- a/pkg/kmm/containers.go
+++ b/pkg/kmm/containers.go
@@ -60,19 +60,23 @@ func (builder *ModuleLoaderContainerBuilder) WithModprobeSpec(dirName, fwPath st
 	builder.definition.Modprobe.DirName = dirName
 	builder.definition.Modprobe.FirmwarePath = fwPath
 	builder.definition.Modprobe.Parameters = parameters
-
-	if builder.definition.Modprobe.Args == nil {
-		builder.definition.Modprobe.Args = &moduleV1Beta1.ModprobeArgs{}
-	}
-
-	builder.definition.Modprobe.Args.Load = args
-
-	if builder.definition.Modprobe.RawArgs == nil {
-		builder.definition.Modprobe.RawArgs = &moduleV1Beta1.ModprobeArgs{}
-	}
-
-	builder.definition.Modprobe.RawArgs.Load = rawargs
 	builder.definition.Modprobe.ModulesLoadingOrder = moduleLoadingOrder
+
+	if len(args) > 0 {
+		if builder.definition.Modprobe.Args == nil {
+			builder.definition.Modprobe.Args = &moduleV1Beta1.ModprobeArgs{}
+		}
+
+		builder.definition.Modprobe.Args.Load = args
+	}
+
+	if len(rawargs) > 0 {
+		if builder.definition.Modprobe.RawArgs == nil {
+			builder.definition.Modprobe.RawArgs = &moduleV1Beta1.ModprobeArgs{}
+		}
+
+		builder.definition.Modprobe.RawArgs.Load = rawargs
+	}
 
 	return builder
 }


### PR DESCRIPTION
Calling WithModprobeSpec will set empty args/rawArgs, causing module loading problem. 
