### PR TITLE
clusterrole: remove rules verification for the empty fields

### DIFF
--- a/pkg/rbac/clusterrole.go
+++ b/pkg/rbac/clusterrole.go
@@ -79,22 +79,10 @@ func (builder *ClusterRoleBuilder) WithRules(rules []v1.PolicyRule) *ClusterRole
 	}
 
 	for _, rule := range rules {
-		if len(rule.APIGroups) == 0 {
-			glog.V(100).Infof("The clusterrole rule must contain at least one APIGroup entry")
-
-			builder.errorMsg = "clusterrole rule must contain at least one APIGroup entry"
-		}
-
 		if len(rule.Verbs) == 0 {
 			glog.V(100).Infof("The clusterrole rule must contain at least one Verb entry")
 
 			builder.errorMsg = "clusterrole rule must contain at least one Verb entry"
-		}
-
-		if len(rule.Resources) == 0 {
-			glog.V(100).Infof("The clusterrole rule must contain at least one Resource entry")
-
-			builder.errorMsg = "clusterrole rule must contain at least one Resource entry"
 		}
 
 		if builder.errorMsg != "" {


### PR DESCRIPTION
The rule does not include each available field; some can stay empty. As an example:

```go

apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: {{ cr_name }}
rules:
- apiGroups:
  - ""
  resources:
  - nodes
  - nodes/proxy
  - services
  - endpoints
  - pods
  - namespaces
  verbs:
  - get
  - list
  - watch
- nonResourceURLs:
  - /metrics
  - /federate
  verbs:
  - get
``` 