### PR TITLE
Remove clusterimageset metadata from definition when it is deleted

### DIFF
--- a/pkg/hive/clusterimageset.go
+++ b/pkg/hive/clusterimageset.go
@@ -238,6 +238,8 @@ func (builder *ClusterImageSetBuilder) Delete() (*ClusterImageSetBuilder, error)
 	}
 
 	builder.Object = nil
+	builder.Definition.ResourceVersion = ""
+	builder.Definition.CreationTimestamp = metaV1.Time{}
 
 	return builder, nil
 }


### PR DESCRIPTION
Removes resourceVersion and creationTimestamp from clusterimageset when the object is successfully deleted. Needed to re-use initial clusterimageset builder struct