### PR TITLE
Align delete method signatures for assisted resources

### DIFF
--- a/pkg/assisted/agent.go
+++ b/pkg/assisted/agent.go
@@ -329,27 +329,27 @@ func (builder *agentBuilder) Exists() bool {
 }
 
 // Delete removes an agent from the cluster.
-func (builder *agentBuilder) Delete() (*agentBuilder, error) {
+func (builder *agentBuilder) Delete() error {
 	if valid, err := builder.validate(); !valid {
-		return builder, err
+		return err
 	}
 
 	glog.V(100).Infof("Deleting the agent %s in namespace %s",
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	if !builder.Exists() {
-		return builder, fmt.Errorf("agent cannot be deleted because it does not exist")
+		return fmt.Errorf("agent cannot be deleted because it does not exist")
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
 
 	if err != nil {
-		return builder, fmt.Errorf("cannot delete agent: %w", err)
+		return fmt.Errorf("cannot delete agent: %w", err)
 	}
 
 	builder.Object = nil
 
-	return builder, nil
+	return nil
 }
 
 // validate will check that the builder and builder definition are properly initialized before

--- a/pkg/assisted/agentclusterinstall.go
+++ b/pkg/assisted/agentclusterinstall.go
@@ -587,27 +587,27 @@ func (builder *AgentClusterInstallBuilder) Update(force bool) (*AgentClusterInst
 }
 
 // Delete removes an agentclusterinstall from the cluster.
-func (builder *AgentClusterInstallBuilder) Delete() (*AgentClusterInstallBuilder, error) {
+func (builder *AgentClusterInstallBuilder) Delete() error {
 	if valid, err := builder.validate(); !valid {
-		return builder, err
+		return err
 	}
 
 	glog.V(100).Infof("Deleting the agentclusterinstall %s in namespace %s",
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	if !builder.Exists() {
-		return builder, fmt.Errorf("agentclusterinstall cannot be deleted because it does not exist")
+		return fmt.Errorf("agentclusterinstall cannot be deleted because it does not exist")
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
 
 	if err != nil {
-		return builder, fmt.Errorf("cannot delete agentclusterinstall: %w", err)
+		return fmt.Errorf("cannot delete agentclusterinstall: %w", err)
 	}
 
 	builder.Object = nil
 
-	return builder, nil
+	return nil
 }
 
 // DeleteAndWait deletes an agentclusterinstall and waits until it is removed from the cluster.
@@ -620,7 +620,7 @@ func (builder *AgentClusterInstallBuilder) DeleteAndWait(timeout time.Duration) 
 	waiting for the defined period until it's removed`,
 		builder.Definition.Name, builder.Definition.Namespace)
 
-	if _, err := builder.Delete(); err != nil {
+	if err := builder.Delete(); err != nil {
 		return err
 	}
 

--- a/pkg/assisted/agentserviceconfig.go
+++ b/pkg/assisted/agentserviceconfig.go
@@ -384,28 +384,28 @@ func (builder *AgentServiceConfigBuilder) Update(force bool) (*AgentServiceConfi
 }
 
 // Delete removes an agentserviceconfig from the cluster.
-func (builder *AgentServiceConfigBuilder) Delete() (*AgentServiceConfigBuilder, error) {
+func (builder *AgentServiceConfigBuilder) Delete() error {
 	if valid, err := builder.validate(); !valid {
-		return builder, err
+		return err
 	}
 
 	glog.V(100).Infof("Deleting the agentserviceconfig %s",
 		builder.Definition.Name)
 
 	if !builder.Exists() {
-		return builder, fmt.Errorf("agentserviceconfig cannot be deleted because it does not exist")
+		return fmt.Errorf("agentserviceconfig cannot be deleted because it does not exist")
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
 
 	if err != nil {
-		return builder, fmt.Errorf("cannot delete agentserviceconfig: %w", err)
+		return fmt.Errorf("cannot delete agentserviceconfig: %w", err)
 	}
 
 	builder.Object = nil
 	builder.Definition.ResourceVersion = ""
 
-	return builder, nil
+	return nil
 }
 
 // DeleteAndWait deletes an agentserviceconfig and waits until it is removed from the cluster.
@@ -418,7 +418,7 @@ func (builder *AgentServiceConfigBuilder) DeleteAndWait(timeout time.Duration) e
 	waiting for the defined period until it's removed`,
 		builder.Definition.Name)
 
-	if _, err := builder.Delete(); err != nil {
+	if err := builder.Delete(); err != nil {
 		return err
 	}
 

--- a/pkg/assisted/infraenv.go
+++ b/pkg/assisted/infraenv.go
@@ -811,27 +811,27 @@ func (builder *InfraEnvBuilder) Update(force bool) (*InfraEnvBuilder, error) {
 }
 
 // Delete removes an infraenv from the cluster.
-func (builder *InfraEnvBuilder) Delete() (*InfraEnvBuilder, error) {
+func (builder *InfraEnvBuilder) Delete() error {
 	if valid, err := builder.validate(); !valid {
-		return builder, err
+		return err
 	}
 
 	glog.V(100).Infof("Deleting the infraenv %s in namespace %s",
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	if !builder.Exists() {
-		return builder, fmt.Errorf("infraenv cannot be deleted because it does not exist")
+		return fmt.Errorf("infraenv cannot be deleted because it does not exist")
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
 
 	if err != nil {
-		return builder, fmt.Errorf("cannot delete infraenv: %w", err)
+		return fmt.Errorf("cannot delete infraenv: %w", err)
 	}
 
 	builder.Object = nil
 
-	return builder, nil
+	return nil
 }
 
 // DeleteAndWait deletes an InfraEnv and waits until it is removed from the cluster.
@@ -844,7 +844,7 @@ func (builder *InfraEnvBuilder) DeleteAndWait(timeout time.Duration) error {
 	waiting for the defined period until it's removed`,
 		builder.Definition.Name)
 
-	if _, err := builder.Delete(); err != nil {
+	if err := builder.Delete(); err != nil {
 		return err
 	}
 

--- a/pkg/assisted/nmstateconfig.go
+++ b/pkg/assisted/nmstateconfig.go
@@ -116,9 +116,9 @@ func (builder *NmStateConfigBuilder) Create() (*NmStateConfigBuilder, error) {
 }
 
 // Delete removes nmstateconfig object from a cluster.
-func (builder *NmStateConfigBuilder) Delete() (*NmStateConfigBuilder, error) {
+func (builder *NmStateConfigBuilder) Delete() error {
 	if valid, err := builder.validate(); !valid {
-		return builder, err
+		return err
 	}
 
 	glog.V(100).Infof("Deleting the nmstateconfig object %s in namespace: %s",
@@ -127,12 +127,12 @@ func (builder *NmStateConfigBuilder) Delete() (*NmStateConfigBuilder, error) {
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
 
 	if err != nil {
-		return builder, fmt.Errorf("can not delete nmstateconfig: %w", err)
+		return fmt.Errorf("can not delete nmstateconfig: %w", err)
 	}
 
 	builder.Object = nil
 
-	return builder, nil
+	return nil
 }
 
 // ListNmStateConfigsInAllNamespaces returns a cluster-wide NMStateConfig list.

--- a/pkg/hive/clusterdeployment.go
+++ b/pkg/hive/clusterdeployment.go
@@ -274,7 +274,7 @@ func (builder *ClusterDeploymentBuilder) Update(force bool) (*ClusterDeploymentB
 			glog.V(100).Infof(
 				msg.FailToUpdateNotification("clusterdeployment", builder.Definition.Name, builder.Definition.Namespace))
 
-			builder, err := builder.Delete()
+			err := builder.Delete()
 
 			if err != nil {
 				glog.V(100).Infof(
@@ -295,27 +295,27 @@ func (builder *ClusterDeploymentBuilder) Update(force bool) (*ClusterDeploymentB
 }
 
 // Delete removes a clusterdeployment from the cluster.
-func (builder *ClusterDeploymentBuilder) Delete() (*ClusterDeploymentBuilder, error) {
+func (builder *ClusterDeploymentBuilder) Delete() error {
 	if valid, err := builder.validate(); !valid {
-		return builder, err
+		return err
 	}
 
 	glog.V(100).Infof("Deleting the clusterdeployment %s in namespace %s",
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	if !builder.Exists() {
-		return builder, fmt.Errorf("clusterdeployment cannot be deleted because it does not exist")
+		return fmt.Errorf("clusterdeployment cannot be deleted because it does not exist")
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
 
 	if err != nil {
-		return builder, fmt.Errorf("cannot delete clusterdeployment: %w", err)
+		return fmt.Errorf("cannot delete clusterdeployment: %w", err)
 	}
 
 	builder.Object = nil
 
-	return builder, nil
+	return nil
 }
 
 // Exists checks if the defined clusterdeployment has already been created.

--- a/pkg/hive/clusterimageset.go
+++ b/pkg/hive/clusterimageset.go
@@ -194,7 +194,7 @@ func (builder *ClusterImageSetBuilder) Update(force bool) (*ClusterImageSetBuild
 			glog.V(100).Infof(
 				msg.FailToUpdateNotification("clusterimageset", builder.Definition.Name, builder.Definition.Namespace))
 
-			builder, err := builder.Delete()
+			err := builder.Delete()
 
 			if err != nil {
 				glog.V(100).Infof(
@@ -215,28 +215,28 @@ func (builder *ClusterImageSetBuilder) Update(force bool) (*ClusterImageSetBuild
 }
 
 // Delete removes a clusterimageset from the cluster.
-func (builder *ClusterImageSetBuilder) Delete() (*ClusterImageSetBuilder, error) {
+func (builder *ClusterImageSetBuilder) Delete() error {
 	if valid, err := builder.validate(); !valid {
-		return builder, err
+		return err
 	}
 
 	glog.V(100).Infof("Deleting the clusterimageset %s", builder.Definition.Name)
 
 	if !builder.Exists() {
-		return builder, fmt.Errorf("clusterimageset cannot be deleted because it does not exist")
+		return fmt.Errorf("clusterimageset cannot be deleted because it does not exist")
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
 
 	if err != nil {
-		return builder, fmt.Errorf("cannot delete clusterimageset: %w", err)
+		return fmt.Errorf("cannot delete clusterimageset: %w", err)
 	}
 
 	builder.Object = nil
 	builder.Definition.ResourceVersion = ""
 	builder.Definition.CreationTimestamp = metaV1.Time{}
 
-	return builder, nil
+	return nil
 }
 
 // Exists checks if the defined clusterimageset has already been created.


### PR DESCRIPTION
Aligns delete method signatures for assisted resources. These resources were previous out of alignment with other resources in the project