### PR TITLE
PVC builder and auxiliary methods

### DIFF
--- a/pkg/storage/pvc.go
+++ b/pkg/storage/pvc.go
@@ -9,8 +9,16 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
 	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+var validPVCModesMap = map[string]string{
+	"ReadWriteOnce":    "ReadWriteOnce",
+	"ReadOnlyMany":     "ReadOnlyMany",
+	"ReadWriteMany":    "ReadWriteMany",
+	"ReadWriteOncePod": "ReadWriteOncePod",
+}
 
 // PVCBuilder provides struct for persistentvolumeclaim object containing connection
 // to the cluster and the persistentvolumeclaim definitions.
@@ -20,7 +28,149 @@ type PVCBuilder struct {
 	// Created persistentvolumeclaim object
 	Object *v1.PersistentVolumeClaim
 
+	errorMsg  string
 	apiClient *clients.Settings
+}
+
+// NewPVCBuilder creates a new structure for persistentvolumeclaim.
+func NewPVCBuilder(apiClient *clients.Settings, name, nsname string) *PVCBuilder {
+	glog.V(100).Infof("Creating PersistentVolumeClaim %s in namespace %s",
+		name, nsname)
+
+	builder := PVCBuilder{
+		Definition: &v1.PersistentVolumeClaim{
+			ObjectMeta: metaV1.ObjectMeta{
+				Name:      name,
+				Namespace: nsname,
+			},
+			Spec: v1.PersistentVolumeClaimSpec{},
+		},
+	}
+
+	builder.apiClient = apiClient
+
+	if name == "" {
+		glog.V(100).Infof("PVC name is empty")
+
+		builder.errorMsg = "PVC name is empty"
+	}
+
+	if nsname == "" {
+		glog.V(100).Infof("PVC namespace is empty")
+
+		builder.errorMsg = "PVC namespace is empty"
+	}
+
+	return &builder
+}
+
+// WithPVCAccessMode configure access mode for the PV.
+func (builder *PVCBuilder) WithPVCAccessMode(accessMode string) (*PVCBuilder, error) {
+	glog.V(100).Infof("Set PVC accessMode: %s", accessMode)
+
+	if accessMode == "" {
+		glog.V(100).Infof("Empty accessMode for PVC %s", builder.Definition.Name)
+		builder.errorMsg = "Empty accessMode for PVC requested"
+
+		return builder, fmt.Errorf(builder.errorMsg)
+	}
+
+	if !validatePVCAccessMode(accessMode) {
+		glog.V(100).Infof("Invalid accessMode for PVC %s", accessMode)
+		builder.errorMsg = fmt.Sprintf("Invalid accessMode for PVC %s", accessMode)
+
+		return builder, fmt.Errorf(builder.errorMsg)
+	}
+
+	if builder.Definition.Spec.AccessModes != nil {
+		builder.Definition.Spec.AccessModes = append(builder.Definition.Spec.AccessModes,
+			v1.PersistentVolumeAccessMode(accessMode))
+	} else {
+		builder.Definition.Spec.AccessModes = []v1.PersistentVolumeAccessMode{v1.PersistentVolumeAccessMode(accessMode)}
+	}
+
+	return builder, nil
+}
+
+// validatePVCAccessMode validates if requested mode is valid for PVC.
+func validatePVCAccessMode(accessMode string) bool {
+	glog.V(100).Info("Validating accessMode %s", accessMode)
+
+	_, ok := validPVCModesMap[accessMode]
+
+	return ok
+}
+
+// WithPVCCapacity configures the minimum resources the volume should have.
+func (builder *PVCBuilder) WithPVCCapacity(capacity string) (*PVCBuilder, error) {
+	if capacity == "" {
+		glog.V(100).Infof("Capacity of the PersistentVolumeClaim is empty")
+
+		builder.errorMsg = "Capacity of the PersistentVolumeClaim is empty"
+
+		return builder, fmt.Errorf(builder.errorMsg)
+	}
+
+	defer func() (*PVCBuilder, error) {
+		if r := recover(); r != nil {
+			glog.V(100).Infof("Failed to parse %v", capacity)
+			builder.errorMsg = fmt.Sprintf("Failed to parse: %v", capacity)
+
+			return builder, fmt.Errorf(fmt.Sprintf("Failed to parse: %v", capacity))
+		}
+
+		return builder, nil
+	}() //nolint:errcheck
+
+	capMap := make(map[v1.ResourceName]resource.Quantity)
+	capMap[v1.ResourceStorage] = resource.MustParse(capacity)
+
+	builder.Definition.Spec.Resources = v1.ResourceRequirements{Requests: capMap}
+
+	return builder, nil
+}
+
+// WithStorageClass configures storageClass required by the claim.
+func (builder *PVCBuilder) WithStorageClass(storageClass string) (*PVCBuilder, error) {
+	glog.V(100).Infof("Set storage class %s for the PersistentVolumeClaim", storageClass)
+
+	if storageClass == "" {
+		glog.V(100).Infof("Empty storageClass requested for the PersistentVolumeClaim", storageClass)
+
+		builder.errorMsg = fmt.Sprintf("Empty storageClass requested for the PersistentVolumeClaim %s",
+			builder.Definition.Name)
+
+		return builder, fmt.Errorf(builder.errorMsg)
+	}
+
+	builder.Definition.Spec.StorageClassName = &storageClass
+
+	return builder, nil
+}
+
+// Create generates a PVC in cluster and stores the created object in struct.
+func (builder *PVCBuilder) Create() (*PVCBuilder, error) {
+	if valid, _ := builder.validate(); !valid {
+		return builder, fmt.Errorf("invalid builder")
+	}
+
+	glog.V(100).Infof("Creating persistentVolumeClaim %s", builder.Definition.Name)
+
+	var err error
+	if !builder.Exists() {
+		builder.Object, err = builder.apiClient.PersistentVolumeClaims(builder.Definition.Namespace).Create(
+			context.TODO(), builder.Definition, metaV1.CreateOptions{})
+	}
+
+	if err != nil {
+		glog.V(100).Infof("Error creating persistentVolumeClaim %s - %v", builder.Definition.Name, err)
+
+		builder.errorMsg = fmt.Sprintf("failed to create PVC: %v", err)
+
+		return builder, err
+	}
+
+	return builder, nil
 }
 
 // PullPersistentVolumeClaim gets an existing PersistentVolumeClaim


### PR DESCRIPTION
Methods to works with _PersistentVolumeClaim_:
* _NewPVCBuilder_ -  builds a new _PVCBuilder_ structure
* _WithPVCAccessMode_ - configures _AccessModes_ for the Volume to have
* _WithPVCapacity_ - configures minimum resources that resource should have
* _WithStorageClass_ - configures `storageClass` required by a claim
* _Create_ - creates a `PVC` resources on the cluster