### PR TITLE
Import consistency

### DIFF
--- a/pkg/argocd/applications.go
+++ b/pkg/argocd/applications.go
@@ -9,7 +9,7 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -41,7 +41,7 @@ func PullApplication(apiClient *clients.Settings, name, nsname string) (*Applica
 	builder := ApplicationBuilder{
 		apiClient: apiClient,
 		Definition: &argocdtypes.Application{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			},
@@ -95,7 +95,7 @@ func (builder *ApplicationBuilder) Get() (*argocdtypes.Application, error) {
 
 	unsObject, err := builder.apiClient.Resource(
 		GetApplicationsGVR()).Namespace(builder.Definition.Namespace).Get(
-		context.TODO(), builder.Definition.Name, metaV1.GetOptions{})
+		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
 	if err != nil {
 		glog.V(100).Infof(
@@ -126,7 +126,7 @@ func (builder *ApplicationBuilder) Update(force bool) (*ApplicationBuilder, erro
 
 	_, err = builder.apiClient.Resource(
 		GetApplicationsGVR()).Namespace(builder.Definition.Namespace).Update(
-		context.TODO(), &unstructured.Unstructured{Object: unstructuredApplication}, metaV1.UpdateOptions{})
+		context.TODO(), &unstructured.Unstructured{Object: unstructuredApplication}, metav1.UpdateOptions{})
 
 	if err != nil {
 		if force {
@@ -160,7 +160,7 @@ func (builder *ApplicationBuilder) Delete() (*ApplicationBuilder, error) {
 
 	err := builder.apiClient.Resource(
 		GetApplicationsGVR()).Namespace(builder.Definition.Namespace).Delete(
-		context.TODO(), builder.Definition.Name, metaV1.DeleteOptions{})
+		context.TODO(), builder.Definition.Name, metav1.DeleteOptions{})
 
 	if err != nil {
 		return builder, fmt.Errorf("can not delete argocd application: %w", err)
@@ -192,7 +192,7 @@ func (builder *ApplicationBuilder) Create() (*ApplicationBuilder, error) {
 
 		unsObject, err := builder.apiClient.Resource(
 			GetApplicationsGVR()).Namespace(builder.Definition.Namespace).Create(
-			context.TODO(), &unstructured.Unstructured{Object: unstructuredApplication}, metaV1.CreateOptions{})
+			context.TODO(), &unstructured.Unstructured{Object: unstructuredApplication}, metav1.CreateOptions{})
 
 		if err != nil {
 			glog.V(100).Infof("Failed to create Application")

--- a/pkg/argocd/argocd.go
+++ b/pkg/argocd/argocd.go
@@ -9,7 +9,7 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	goclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -32,7 +32,7 @@ func NewBuilder(apiClient *clients.Settings, name, nsname string) *Builder {
 		apiClient: apiClient,
 		Definition: &argocdoperatorv1alpha1.ArgoCD{
 			Spec: argocdoperatorv1alpha1.ArgoCDSpec{},
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			},
@@ -61,7 +61,7 @@ func Pull(apiClient *clients.Settings, name, nsname string) (*Builder, error) {
 	builder := Builder{
 		apiClient: apiClient,
 		Definition: &argocdoperatorv1alpha1.ArgoCD{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			},

--- a/pkg/assisted/agent.go
+++ b/pkg/assisted/agent.go
@@ -11,7 +11,7 @@ import (
 	agentInstallV1Beta1 "github.com/openshift/assisted-service/api/v1beta1"
 	"github.com/openshift/assisted-service/models"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	goclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -58,7 +58,7 @@ func PullAgent(apiClient *clients.Settings, name, nsname string) (*agentBuilder,
 	builder := agentBuilder{
 		apiClient: apiClient,
 		Definition: &agentInstallV1Beta1.Agent{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			},

--- a/pkg/assisted/agentclusterinstall.go
+++ b/pkg/assisted/agentclusterinstall.go
@@ -16,9 +16,9 @@ import (
 	hiveextV1Beta1 "github.com/openshift/assisted-service/api/hiveextension/v1beta1"
 	"github.com/openshift/assisted-service/models"
 	v1 "github.com/openshift/hive/apis/hive/v1"
-	coreV1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	goclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -47,12 +47,12 @@ func NewAgentClusterInstallBuilder(
 	builder := AgentClusterInstallBuilder{
 		apiClient: apiClient,
 		Definition: &hiveextV1Beta1.AgentClusterInstall{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			},
 			Spec: hiveextV1Beta1.AgentClusterInstallSpec{
-				ClusterDeploymentRef: coreV1.LocalObjectReference{
+				ClusterDeploymentRef: corev1.LocalObjectReference{
 					Name: clusterDeployment,
 				},
 				Networking: network,
@@ -391,7 +391,7 @@ func (builder *AgentClusterInstallBuilder) WaitForConditionMessage(
 
 // WaitForConditionStatus waits the specified timeout for the given condition to report the specified status.
 func (builder *AgentClusterInstallBuilder) WaitForConditionStatus(
-	conditionType string, status coreV1.ConditionStatus, timeout time.Duration) error {
+	conditionType string, status corev1.ConditionStatus, timeout time.Duration) error {
 	return wait.PollUntilContextTimeout(
 		context.TODO(), retryInterval, timeout, false, func(ctx context.Context) (bool, error) {
 			condition, err := builder.getCondition(conditionType)
@@ -490,7 +490,7 @@ func PullAgentClusterInstall(apiClient *clients.Settings, name, nsname string) (
 	builder := AgentClusterInstallBuilder{
 		apiClient: apiClient,
 		Definition: &hiveextV1Beta1.AgentClusterInstall{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			},

--- a/pkg/assisted/agentserviceconfig.go
+++ b/pkg/assisted/agentserviceconfig.go
@@ -12,7 +12,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	goclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -49,7 +49,7 @@ func NewAgentServiceConfigBuilder(
 	builder := AgentServiceConfigBuilder{
 		apiClient: apiClient,
 		Definition: &agentInstallV1Beta1.AgentServiceConfig{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: agentServiceConfigName,
 			},
 			Spec: agentInstallV1Beta1.AgentServiceConfigSpec{
@@ -71,7 +71,7 @@ func NewDefaultAgentServiceConfigBuilder(apiClient *clients.Settings) *AgentServ
 	builder := AgentServiceConfigBuilder{
 		apiClient: apiClient,
 		Definition: &agentInstallV1Beta1.AgentServiceConfig{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: agentServiceConfigName,
 			},
 			Spec: agentInstallV1Beta1.AgentServiceConfigSpec{},
@@ -277,7 +277,7 @@ func PullAgentServiceConfig(apiClient *clients.Settings) (*AgentServiceConfigBui
 	builder := AgentServiceConfigBuilder{
 		apiClient: apiClient,
 		Definition: &agentInstallV1Beta1.AgentServiceConfig{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: agentServiceConfigName,
 			},
 		},
@@ -363,7 +363,7 @@ func (builder *AgentServiceConfigBuilder) Update(force bool) (*AgentServiceConfi
 
 			err = builder.DeleteAndWait(time.Second * 5)
 			builder.Definition.ResourceVersion = ""
-			builder.Definition.CreationTimestamp = metaV1.Time{}
+			builder.Definition.CreationTimestamp = metav1.Time{}
 
 			if err != nil {
 				glog.V(100).Infof(

--- a/pkg/assisted/infraenv.go
+++ b/pkg/assisted/infraenv.go
@@ -15,7 +15,7 @@ import (
 	hiveV1 "github.com/openshift/hive/apis/hive/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	goclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -48,7 +48,7 @@ func NewInfraEnvBuilder(apiClient *clients.Settings, name, nsname, psName string
 	builder := InfraEnvBuilder{
 		apiClient: apiClient,
 		Definition: &agentInstallV1Beta1.InfraEnv{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			},
@@ -171,7 +171,7 @@ func (builder *InfraEnvBuilder) WithProxy(proxy agentInstallV1Beta1.Proxy) *Infr
 
 // WithNmstateConfigLabelSelector adds a selector for identifying
 // nmstateconfigs that should be applied to this infraenv.
-func (builder *InfraEnvBuilder) WithNmstateConfigLabelSelector(selector metaV1.LabelSelector) *InfraEnvBuilder {
+func (builder *InfraEnvBuilder) WithNmstateConfigLabelSelector(selector metav1.LabelSelector) *InfraEnvBuilder {
 	if valid, _ := builder.validate(); !valid {
 		return builder
 	}
@@ -702,7 +702,7 @@ func PullInfraEnvInstall(apiClient *clients.Settings, name, nsname string) (*Inf
 	builder := InfraEnvBuilder{
 		apiClient: apiClient,
 		Definition: &agentInstallV1Beta1.InfraEnv{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			},

--- a/pkg/assisted/nmstateconfig.go
+++ b/pkg/assisted/nmstateconfig.go
@@ -11,7 +11,7 @@ import (
 	goclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // NmStateConfigBuilder provides struct for the NMStateConfig object containing connection to
@@ -34,7 +34,7 @@ func NewNmStateConfigBuilder(apiClient *clients.Settings, name, namespace string
 	builder := NmStateConfigBuilder{
 		apiClient: apiClient,
 		Definition: &assistedv1beta1.NMStateConfig{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: namespace,
 			},

--- a/pkg/bmh/baremetalhost.go
+++ b/pkg/bmh/baremetalhost.go
@@ -16,7 +16,7 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
 	"golang.org/x/exp/slices"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // BmhBuilder provides struct for the bmh object containing connection to
@@ -55,7 +55,7 @@ func NewBuilder(
 				Online:                true,
 				ExternallyProvisioned: false,
 			},
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			},
@@ -370,7 +370,7 @@ func Pull(apiClient *clients.Settings, name, nsname string) (*BmhBuilder, error)
 	builder := BmhBuilder{
 		apiClient: apiClient,
 		Definition: &bmhv1alpha1.BareMetalHost{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			},

--- a/pkg/cgu/cgu.go
+++ b/pkg/cgu/cgu.go
@@ -9,7 +9,7 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -33,7 +33,7 @@ func Pull(apiClient *clients.Settings, name, nsname string) (*CguBuilder, error)
 	builder := CguBuilder{
 		apiClient: apiClient,
 		Definition: &v1alpha1.ClusterGroupUpgrade{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			},

--- a/pkg/clusteroperator/clusteroperator.go
+++ b/pkg/clusteroperator/clusteroperator.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"fmt"
 
@@ -46,7 +46,7 @@ func (builder *Builder) Exists() bool {
 	_, err := builder.apiClient.ClusterOperators().Get(
 		context.Background(),
 		builder.Definition.Name,
-		metaV1.GetOptions{})
+		metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }
@@ -129,7 +129,7 @@ func (builder *Builder) WaitUntilConditionTrue(
 			builder.Object, err = builder.apiClient.ClusterOperators().Get(
 				context.Background(),
 				builder.Definition.Name,
-				metaV1.GetOptions{})
+				metav1.GetOptions{})
 
 			if err != nil {
 				return false, nil

--- a/pkg/clusteroperator/list.go
+++ b/pkg/clusteroperator/list.go
@@ -7,14 +7,14 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 // List returns clusterOperators inventory.
-func List(apiClient *clients.Settings, options ...metaV1.ListOptions) ([]*Builder, error) {
+func List(apiClient *clients.Settings, options ...metav1.ListOptions) ([]*Builder, error) {
 	logMessage := "Listing all clusterOperators"
-	passedOptions := metaV1.ListOptions{}
+	passedOptions := metav1.ListOptions{}
 
 	if len(options) > 1 {
 		glog.V(100).Infof("'options' parameter must be empty or single-valued")
@@ -55,7 +55,7 @@ func List(apiClient *clients.Settings, options ...metaV1.ListOptions) ([]*Builde
 
 // WaitForAllClusteroperatorsAvailable waits until all clusterOperators are in available state.
 func WaitForAllClusteroperatorsAvailable(
-	apiClient *clients.Settings, timeout time.Duration, options ...metaV1.ListOptions) (bool, error) {
+	apiClient *clients.Settings, timeout time.Duration, options ...metav1.ListOptions) (bool, error) {
 	glog.V(100).Info("Waiting for all clusterOperators to be in available state")
 
 	err := wait.PollUntilContextTimeout(context.TODO(), fiveScds, timeout, true, func(ctx context.Context) (bool, error) {
@@ -95,7 +95,7 @@ func WaitForAllClusteroperatorsAvailable(
 
 // WaitForAllClusteroperatorsStopProgressing waits until all clusterOperators stopped progressing.
 func WaitForAllClusteroperatorsStopProgressing(
-	apiClient *clients.Settings, timeout time.Duration, options ...metaV1.ListOptions) (bool, error) {
+	apiClient *clients.Settings, timeout time.Duration, options ...metav1.ListOptions) (bool, error) {
 	glog.V(100).Infof("Waiting for all clusteroperators to stop progressing")
 
 	coList, err := List(apiClient, options...)

--- a/pkg/clusterversion/clusterversion.go
+++ b/pkg/clusterversion/clusterversion.go
@@ -9,7 +9,7 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
 	v1 "github.com/openshift/api/config/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -33,7 +33,7 @@ func Pull(apiClient *clients.Settings) (*Builder, error) {
 	builder := Builder{
 		apiClient: apiClient,
 		Definition: &v1.ClusterVersion{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: clusterVersionName,
 			},
 		},
@@ -60,7 +60,7 @@ func (builder *Builder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.ConfigV1Interface.ClusterVersions().Get(
-		context.Background(), builder.Definition.Name, metaV1.GetOptions{})
+		context.Background(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }

--- a/pkg/configmap/configmap.go
+++ b/pkg/configmap/configmap.go
@@ -7,18 +7,18 @@ import (
 	"github.com/golang/glog"
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // Builder provides struct for configmap object containing connection to the cluster and the configmap definitions.
 type Builder struct {
 	// ConfigMap definition. Used to create configmap object.
-	Definition *v1.ConfigMap
+	Definition *corev1.ConfigMap
 	// Created configmap object.
-	Object *v1.ConfigMap
+	Object *corev1.ConfigMap
 	// Used in functions that defines or mutates configmap definition. errorMsg is processed before the configmap
 	// object is created.
 	errorMsg  string
@@ -32,8 +32,8 @@ type AdditionalOptions func(builder *Builder) (*Builder, error)
 func Pull(apiClient *clients.Settings, name, nsname string) (*Builder, error) {
 	builder := Builder{
 		apiClient: apiClient,
-		Definition: &v1.ConfigMap{
-			ObjectMeta: metaV1.ObjectMeta{
+		Definition: &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			},
@@ -71,8 +71,8 @@ func NewBuilder(apiClient *clients.Settings, name, nsname string) *Builder {
 
 	builder := Builder{
 		apiClient: apiClient,
-		Definition: &v1.ConfigMap{
-			ObjectMeta: metaV1.ObjectMeta{
+		Definition: &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			},
@@ -105,7 +105,7 @@ func (builder *Builder) Create() (*Builder, error) {
 	var err error
 	if !builder.Exists() {
 		builder.Object, err = builder.apiClient.ConfigMaps(builder.Definition.Namespace).Create(
-			context.TODO(), builder.Definition, metaV1.CreateOptions{})
+			context.TODO(), builder.Definition, metav1.CreateOptions{})
 	}
 
 	return builder, err
@@ -124,7 +124,7 @@ func (builder *Builder) Delete() error {
 	}
 
 	err := builder.apiClient.ConfigMaps(builder.Definition.Namespace).Delete(
-		context.TODO(), builder.Object.Name, metaV1.DeleteOptions{})
+		context.TODO(), builder.Object.Name, metav1.DeleteOptions{})
 
 	if err != nil {
 		return err
@@ -147,7 +147,7 @@ func (builder *Builder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.ConfigMaps(builder.Definition.Namespace).Get(
-		context.Background(), builder.Definition.Name, metaV1.GetOptions{})
+		context.Background(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }

--- a/pkg/console/console.go
+++ b/pkg/console/console.go
@@ -10,7 +10,7 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
 	v1 "github.com/openshift/api/config/v1"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Builder provides a struct for console object from the cluster and a console definition.
@@ -32,7 +32,7 @@ func NewBuilder(apiClient *clients.Settings, name string) *Builder {
 	builder := Builder{
 		apiClient: apiClient,
 		Definition: &v1.Console{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 			},
 		},
@@ -52,7 +52,7 @@ func Pull(apiClient *clients.Settings, name string) (*Builder, error) {
 	builder := Builder{
 		apiClient: apiClient,
 		Definition: &v1.Console{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 			},
 		},
@@ -86,7 +86,7 @@ func (builder *Builder) Create() (*Builder, error) {
 	var err error
 	if !builder.Exists() {
 		builder.Object, err = builder.apiClient.Consoles().Create(
-			context.Background(), builder.Definition, metaV1.CreateOptions{})
+			context.Background(), builder.Definition, metav1.CreateOptions{})
 	}
 
 	return builder, err
@@ -102,7 +102,7 @@ func (builder *Builder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.Consoles().Get(
-		context.Background(), builder.Definition.Name, metaV1.GetOptions{})
+		context.Background(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }
@@ -119,7 +119,7 @@ func (builder *Builder) Delete() error {
 		return fmt.Errorf("console cannot be deleted because it does not exist")
 	}
 
-	err := builder.apiClient.Consoles().Delete(context.Background(), builder.Definition.Name, metaV1.DeleteOptions{})
+	err := builder.apiClient.Consoles().Delete(context.Background(), builder.Definition.Name, metav1.DeleteOptions{})
 
 	if err != nil {
 		return fmt.Errorf("cannot delete console: %w", err)
@@ -140,7 +140,7 @@ func (builder *Builder) Update() (*Builder, error) {
 
 	var err error
 	builder.Object, err = builder.apiClient.Consoles().Update(context.Background(), builder.Definition,
-		metaV1.UpdateOptions{})
+		metav1.UpdateOptions{})
 
 	return builder, err
 }

--- a/pkg/deployment/list.go
+++ b/pkg/deployment/list.go
@@ -6,18 +6,18 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // List returns deployment inventory in the given namespace.
-func List(apiClient *clients.Settings, nsname string, options ...metaV1.ListOptions) ([]*Builder, error) {
+func List(apiClient *clients.Settings, nsname string, options ...metav1.ListOptions) ([]*Builder, error) {
 	if nsname == "" {
 		glog.V(100).Infof("deployment 'nsname' parameter can not be empty")
 
 		return nil, fmt.Errorf("failed to list deployments, 'nsname' parameter is empty")
 	}
 
-	passedOptions := metaV1.ListOptions{}
+	passedOptions := metav1.ListOptions{}
 	logMessage := fmt.Sprintf("Listing deployments in the namespace %s", nsname)
 
 	if len(options) > 1 {
@@ -58,8 +58,8 @@ func List(apiClient *clients.Settings, nsname string, options ...metaV1.ListOpti
 }
 
 // ListInAllNamespaces returns deployment inventory in the all the namespaces.
-func ListInAllNamespaces(apiClient *clients.Settings, options ...metaV1.ListOptions) ([]*Builder, error) {
-	passedOptions := metaV1.ListOptions{}
+func ListInAllNamespaces(apiClient *clients.Settings, options ...metav1.ListOptions) ([]*Builder, error) {
+	passedOptions := metav1.ListOptions{}
 	logMessage := "Listing deployments in all namespaces"
 
 	if len(options) > 1 {

--- a/pkg/hive/clusterdeployment.go
+++ b/pkg/hive/clusterdeployment.go
@@ -10,9 +10,9 @@ import (
 	hiveextV1Beta1 "github.com/openshift/assisted-service/api/hiveextension/v1beta1"
 	hiveV1 "github.com/openshift/hive/apis/hive/v1"
 	"github.com/openshift/hive/apis/hive/v1/agent"
-	coreV1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	goclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -37,7 +37,7 @@ func NewABMClusterDeploymentBuilder(
 	clusterName string,
 	baseDomain string,
 	clusterInstallRef string,
-	agentSelector metaV1.LabelSelector) *ClusterDeploymentBuilder {
+	agentSelector metav1.LabelSelector) *ClusterDeploymentBuilder {
 	glog.V(100).Infof(
 		`Initializing new agentbaremetal clusterdeployment structure with the following params: name: %s, namespace: %s,
 		  clusterName: %s, baseDomain: %s, clusterInstallRef: %s, agentSelector: %s`,
@@ -46,7 +46,7 @@ func NewABMClusterDeploymentBuilder(
 	builder := ClusterDeploymentBuilder{
 		apiClient: apiClient,
 		Definition: &hiveV1.ClusterDeployment{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			},
@@ -150,7 +150,7 @@ func (builder *ClusterDeploymentBuilder) WithPullSecret(psName string) *ClusterD
 		"Adding pull-secret ref %s to clusterdeployment %s in namespace %s",
 		psName, builder.Definition.Name, builder.Definition.Namespace)
 
-	builder.Definition.Spec.PullSecretRef = &coreV1.LocalObjectReference{Name: psName}
+	builder.Definition.Spec.PullSecretRef = &corev1.LocalObjectReference{Name: psName}
 
 	return builder
 }
@@ -184,7 +184,7 @@ func PullClusterDeployment(apiClient *clients.Settings, name, nsname string) (*C
 	builder := ClusterDeploymentBuilder{
 		apiClient: apiClient,
 		Definition: &hiveV1.ClusterDeployment{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			},

--- a/pkg/hive/clusterimageset.go
+++ b/pkg/hive/clusterimageset.go
@@ -9,7 +9,7 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
 	hiveV1 "github.com/openshift/hive/apis/hive/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	goclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -34,7 +34,7 @@ func NewClusterImageSetBuilder(apiClient *clients.Settings, name, releaseImage s
 	builder := ClusterImageSetBuilder{
 		apiClient: apiClient,
 		Definition: &hiveV1.ClusterImageSet{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 			},
 			Spec: hiveV1.ClusterImageSetSpec{
@@ -121,7 +121,7 @@ func PullClusterImageSet(apiClient *clients.Settings, name string) (*ClusterImag
 	builder := ClusterImageSetBuilder{
 		apiClient: apiClient,
 		Definition: &hiveV1.ClusterImageSet{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 			},
 		},
@@ -234,7 +234,7 @@ func (builder *ClusterImageSetBuilder) Delete() error {
 
 	builder.Object = nil
 	builder.Definition.ResourceVersion = ""
-	builder.Definition.CreationTimestamp = metaV1.Time{}
+	builder.Definition.CreationTimestamp = metav1.Time{}
 
 	return nil
 }

--- a/pkg/infrastructure/infrastructure.go
+++ b/pkg/infrastructure/infrastructure.go
@@ -9,7 +9,7 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
 	v1 "github.com/openshift/api/config/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -33,7 +33,7 @@ func Pull(apiClient *clients.Settings) (*Builder, error) {
 	builder := Builder{
 		apiClient: apiClient,
 		Definition: &v1.Infrastructure{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: infrastructureName,
 			},
 		},
@@ -58,7 +58,7 @@ func (builder *Builder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.ConfigV1Interface.Infrastructures().Get(
-		context.Background(), builder.Definition.Name, metaV1.GetOptions{})
+		context.Background(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }

--- a/pkg/ingress/ingresscontroller.go
+++ b/pkg/ingress/ingresscontroller.go
@@ -9,7 +9,7 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
 	v1 "github.com/openshift/api/operator/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	goclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -30,7 +30,7 @@ func Pull(apiClient *clients.Settings, name, nsname string) (*Builder, error) {
 	builder := Builder{
 		apiClient: apiClient,
 		Definition: &v1.IngressController{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			},
@@ -97,7 +97,7 @@ func (builder *Builder) Update() (*Builder, error) {
 			builder.Definition.Name, builder.Definition.Namespace)
 	}
 
-	builder.Definition.CreationTimestamp = metaV1.Time{}
+	builder.Definition.CreationTimestamp = metav1.Time{}
 	builder.Definition.ResourceVersion = ""
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)

--- a/pkg/kmm/containers.go
+++ b/pkg/kmm/containers.go
@@ -7,7 +7,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
 	moduleV1Beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // ModuleLoaderContainerBuilder provides struct for the module object containing the ModuleLoaderContainerSpec
@@ -119,7 +119,7 @@ func (builder *ModuleLoaderContainerBuilder) WithImagePullPolicy(policy string) 
 		return builder
 	}
 
-	builder.definition.ImagePullPolicy = v1.PullPolicy(policy)
+	builder.definition.ImagePullPolicy = corev1.PullPolicy(policy)
 
 	return builder
 }
@@ -262,7 +262,7 @@ func (builder *DevicePluginContainerBuilder) WithEnv(name, value string) *Device
 		return builder
 	}
 
-	builder.definition.Env = append(builder.definition.Env, v1.EnvVar{Name: name, Value: value})
+	builder.definition.Env = append(builder.definition.Env, corev1.EnvVar{Name: name, Value: value})
 
 	return builder
 }
@@ -294,7 +294,7 @@ func (builder *DevicePluginContainerBuilder) WithVolumeMount(mountPath, name str
 	}
 
 	builder.definition.VolumeMounts = append(
-		builder.definition.VolumeMounts, v1.VolumeMount{Name: name, MountPath: mountPath})
+		builder.definition.VolumeMounts, corev1.VolumeMount{Name: name, MountPath: mountPath})
 
 	return builder
 }

--- a/pkg/kmm/kernelmapping.go
+++ b/pkg/kmm/kernelmapping.go
@@ -6,7 +6,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
 	moduleV1Beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // KernelMappingBuilder builds kernelMapping struct based on given parameters.
@@ -152,7 +152,7 @@ func (builder *KernelMappingBuilder) WithBuildSecret(secret string) *KernelMappi
 	builder.addBuild()
 
 	builder.definition.Build.Secrets = append(
-		builder.definition.Build.Secrets, v1.LocalObjectReference{Name: secret})
+		builder.definition.Build.Secrets, corev1.LocalObjectReference{Name: secret})
 
 	return builder
 }
@@ -193,7 +193,7 @@ func (builder *KernelMappingBuilder) WithBuildDockerCfgFile(name string) *Kernel
 	}
 
 	builder.addBuild()
-	builder.definition.Build.DockerfileConfigMap = &v1.LocalObjectReference{Name: name}
+	builder.definition.Build.DockerfileConfigMap = &corev1.LocalObjectReference{Name: name}
 
 	return builder
 }
@@ -231,8 +231,8 @@ func (builder *KernelMappingBuilder) WithSign(certSecret, keySecret string, file
 	}
 
 	builder.definition.Sign = &moduleV1Beta1.Sign{
-		CertSecret:  &v1.LocalObjectReference{Name: certSecret},
-		KeySecret:   &v1.LocalObjectReference{Name: keySecret},
+		CertSecret:  &corev1.LocalObjectReference{Name: certSecret},
+		KeySecret:   &corev1.LocalObjectReference{Name: keySecret},
 		FilesToSign: fileToSign,
 	}
 

--- a/pkg/kmm/module.go
+++ b/pkg/kmm/module.go
@@ -8,9 +8,9 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
 	moduleV1Beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	goclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -39,7 +39,7 @@ func NewModuleBuilder(
 	builder := ModuleBuilder{
 		apiClient: apiClient,
 		Definition: &moduleV1Beta1.Module{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			},
@@ -126,7 +126,7 @@ func (builder *ModuleBuilder) WithImageRepoSecret(imageRepoSecret string) *Modul
 		return builder
 	}
 
-	builder.Definition.Spec.ImageRepoSecret = &v1.LocalObjectReference{Name: imageRepoSecret}
+	builder.Definition.Spec.ImageRepoSecret = &corev1.LocalObjectReference{Name: imageRepoSecret}
 
 	return builder
 }
@@ -153,11 +153,11 @@ func (builder *ModuleBuilder) WithDevicePluginVolume(name string, configMapName 
 		builder.Definition.Spec.DevicePlugin = &moduleV1Beta1.DevicePluginSpec{}
 	}
 
-	builder.Definition.Spec.DevicePlugin.Volumes = append(builder.Definition.Spec.DevicePlugin.Volumes, v1.Volume{
+	builder.Definition.Spec.DevicePlugin.Volumes = append(builder.Definition.Spec.DevicePlugin.Volumes, corev1.Volume{
 		Name: name,
-		VolumeSource: v1.VolumeSource{
-			ConfigMap: &v1.ConfigMapVolumeSource{
-				LocalObjectReference: v1.LocalObjectReference{
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
 					Name: configMapName},
 			},
 		},
@@ -254,7 +254,7 @@ func Pull(apiClient *clients.Settings, name, nsname string) (*ModuleBuilder, err
 	builder := ModuleBuilder{
 		apiClient: apiClient,
 		Definition: &moduleV1Beta1.Module{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			},

--- a/pkg/lca/imagebasedupgrade.go
+++ b/pkg/lca/imagebasedupgrade.go
@@ -15,7 +15,7 @@ import (
 	lcav1alpha1 "github.com/openshift-kni/lifecycle-agent/api/v1alpha1"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
@@ -50,7 +50,7 @@ func NewImageBasedUpgradeBuilder(
 	builder := ImageBasedUpgradeBuilder{
 		apiClient: apiClient,
 		Definition: &lcav1alpha1.ImageBasedUpgrade{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 			},
 		},
@@ -97,7 +97,7 @@ func PullImageBasedUpgrade(apiClient *clients.Settings, name string) (*ImageBase
 	builder := ImageBasedUpgradeBuilder{
 		apiClient: apiClient,
 		Definition: &lcav1alpha1.ImageBasedUpgrade{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 			},
 		},

--- a/pkg/lca/seedgenerator.go
+++ b/pkg/lca/seedgenerator.go
@@ -10,7 +10,7 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
 	lcasgv1alpha1 "github.com/openshift-kni/lifecycle-agent/api/seedgenerator/v1alpha1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	goclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -39,7 +39,7 @@ func NewSeedGeneratorBuilder(
 	builder := SeedGeneratorBuilder{
 		apiClient: apiClient,
 		Definition: &lcasgv1alpha1.SeedGenerator{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 			},
 		},
@@ -106,7 +106,7 @@ func PullSeedGenerator(apiClient *clients.Settings, name string) (*SeedGenerator
 	builder := SeedGeneratorBuilder{
 		apiClient: apiClient,
 		Definition: &lcasgv1alpha1.SeedGenerator{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 			},
 		},

--- a/pkg/metallb/addresspool.go
+++ b/pkg/metallb/addresspool.go
@@ -9,7 +9,7 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/metallb/mlbtypes"
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -41,11 +41,11 @@ func NewIPAddressPoolBuilder(
 	builder := IPAddressPoolBuilder{
 		apiClient: apiClient,
 		Definition: &mlbtypes.IPAddressPool{
-			TypeMeta: metaV1.TypeMeta{
+			TypeMeta: metav1.TypeMeta{
 				Kind:       ipAddressPoolKind,
 				APIVersion: fmt.Sprintf("%s/%s", APIGroup, APIVersion),
 			},
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			}, Spec: mlbtypes.IPAddressPoolSpec{
@@ -87,7 +87,7 @@ func (builder *IPAddressPoolBuilder) Get() (*mlbtypes.IPAddressPool, error) {
 
 	unsObject, err := builder.apiClient.Resource(
 		GetIPAddressPoolGVR()).Namespace(builder.Definition.Namespace).Get(
-		context.TODO(), builder.Definition.Name, metaV1.GetOptions{})
+		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
 	if err != nil {
 		glog.V(100).Infof(
@@ -123,7 +123,7 @@ func PullAddressPool(apiClient *clients.Settings, name, nsname string) (*IPAddre
 	builder := IPAddressPoolBuilder{
 		apiClient: apiClient,
 		Definition: &mlbtypes.IPAddressPool{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			},
@@ -173,7 +173,7 @@ func (builder *IPAddressPoolBuilder) Create() (*IPAddressPoolBuilder, error) {
 
 		unsObject, err := builder.apiClient.Resource(
 			GetIPAddressPoolGVR()).Namespace(builder.Definition.Namespace).Create(
-			context.TODO(), &unstructured.Unstructured{Object: unstructuredIPAddressPool}, metaV1.CreateOptions{})
+			context.TODO(), &unstructured.Unstructured{Object: unstructuredIPAddressPool}, metav1.CreateOptions{})
 
 		if err != nil {
 			glog.V(100).Infof("Failed to create IPAddressPool")
@@ -207,7 +207,7 @@ func (builder *IPAddressPoolBuilder) Delete() (*IPAddressPoolBuilder, error) {
 
 	err := builder.apiClient.Resource(
 		GetIPAddressPoolGVR()).Namespace(builder.Definition.Namespace).Delete(
-		context.TODO(), builder.Definition.Name, metaV1.DeleteOptions{})
+		context.TODO(), builder.Definition.Name, metav1.DeleteOptions{})
 
 	if err != nil {
 		return builder, fmt.Errorf("can not delete IPAddressPool: %w", err)
@@ -238,7 +238,7 @@ func (builder *IPAddressPoolBuilder) Update(force bool) (*IPAddressPoolBuilder, 
 
 	_, err = builder.apiClient.Resource(
 		GetIPAddressPoolGVR()).Namespace(builder.Definition.Namespace).Update(
-		context.TODO(), &unstructured.Unstructured{Object: unstructuredIPAddressPool}, metaV1.UpdateOptions{})
+		context.TODO(), &unstructured.Unstructured{Object: unstructuredIPAddressPool}, metav1.UpdateOptions{})
 
 	if err != nil {
 		if force {

--- a/pkg/metallb/bfdprofile.go
+++ b/pkg/metallb/bfdprofile.go
@@ -9,7 +9,7 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/metallb/mlbtypes"
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -40,11 +40,11 @@ func NewBFDBuilder(apiClient *clients.Settings, name, nsname string) *BFDBuilder
 	builder := BFDBuilder{
 		apiClient: apiClient,
 		Definition: &mlbtypes.BFDProfile{
-			TypeMeta: metaV1.TypeMeta{
+			TypeMeta: metav1.TypeMeta{
 				Kind:       bfdProfileKind,
 				APIVersion: fmt.Sprintf("%s/%s", APIGroup, APIVersion),
 			},
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			},
@@ -78,7 +78,7 @@ func (builder *BFDBuilder) Get() (*mlbtypes.BFDProfile, error) {
 
 	unsObject, err := builder.apiClient.Resource(
 		GetBFDProfileGVR()).Namespace(builder.Definition.Namespace).Get(
-		context.TODO(), builder.Definition.Name, metaV1.GetOptions{})
+		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
 	if err != nil {
 		glog.V(100).Infof(
@@ -114,7 +114,7 @@ func PullBFDProfile(apiClient *clients.Settings, name, nsname string) (*BFDBuild
 	builder := BFDBuilder{
 		apiClient: apiClient,
 		Definition: &mlbtypes.BFDProfile{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			},
@@ -164,7 +164,7 @@ func (builder *BFDBuilder) Create() (*BFDBuilder, error) {
 
 		unsObject, err := builder.apiClient.Resource(
 			GetBFDProfileGVR()).Namespace(builder.Definition.Namespace).Create(
-			context.TODO(), &unstructured.Unstructured{Object: unstructuredBfdProfile}, metaV1.CreateOptions{})
+			context.TODO(), &unstructured.Unstructured{Object: unstructuredBfdProfile}, metav1.CreateOptions{})
 
 		if err != nil {
 			glog.V(100).Infof("Failed to create BFDProfile")
@@ -198,7 +198,7 @@ func (builder *BFDBuilder) Delete() (*BFDBuilder, error) {
 
 	err := builder.apiClient.Resource(
 		GetBFDProfileGVR()).Namespace(builder.Definition.Namespace).Delete(
-		context.TODO(), builder.Definition.Name, metaV1.DeleteOptions{})
+		context.TODO(), builder.Definition.Name, metav1.DeleteOptions{})
 
 	if err != nil {
 		return builder, fmt.Errorf("can not delete BFDProfile: %w", err)
@@ -229,7 +229,7 @@ func (builder *BFDBuilder) Update(force bool) (*BFDBuilder, error) {
 
 	_, err = builder.apiClient.Resource(
 		GetBFDProfileGVR()).Namespace(builder.Definition.Namespace).Update(
-		context.TODO(), &unstructured.Unstructured{Object: unstructuredBfdProfile}, metaV1.UpdateOptions{})
+		context.TODO(), &unstructured.Unstructured{Object: unstructuredBfdProfile}, metav1.UpdateOptions{})
 
 	if err != nil {
 		if force {

--- a/pkg/metallb/bgpadvertisement.go
+++ b/pkg/metallb/bgpadvertisement.go
@@ -9,7 +9,7 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/metallb/mlbtypes"
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -40,11 +40,11 @@ func NewBGPAdvertisementBuilder(apiClient *clients.Settings, name, nsname string
 	builder := BGPAdvertisementBuilder{
 		apiClient: apiClient,
 		Definition: &mlbtypes.BGPAdvertisement{
-			TypeMeta: metaV1.TypeMeta{
+			TypeMeta: metav1.TypeMeta{
 				Kind:       bpgAdvertisementKind,
 				APIVersion: fmt.Sprintf("%s/%s", APIGroup, APIVersion),
 			},
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			}, Spec: mlbtypes.BGPAdvertisementSpec{},
@@ -94,7 +94,7 @@ func (builder *BGPAdvertisementBuilder) Get() (*mlbtypes.BGPAdvertisement, error
 
 	unsObject, err := builder.apiClient.Resource(
 		GetBGPAdvertisementGVR()).Namespace(builder.Definition.Namespace).Get(
-		context.TODO(), builder.Definition.Name, metaV1.GetOptions{})
+		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
 	if err != nil {
 		glog.V(100).Infof(
@@ -114,7 +114,7 @@ func PullBGPAdvertisement(apiClient *clients.Settings, name, nsname string) (*BG
 	builder := BGPAdvertisementBuilder{
 		apiClient: apiClient,
 		Definition: &mlbtypes.BGPAdvertisement{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			},
@@ -164,7 +164,7 @@ func (builder *BGPAdvertisementBuilder) Create() (*BGPAdvertisementBuilder, erro
 
 		unsObject, err := builder.apiClient.Resource(
 			GetBGPAdvertisementGVR()).Namespace(builder.Definition.Namespace).Create(
-			context.TODO(), &unstructured.Unstructured{Object: unstructuredBgpAdvertisement}, metaV1.CreateOptions{})
+			context.TODO(), &unstructured.Unstructured{Object: unstructuredBgpAdvertisement}, metav1.CreateOptions{})
 
 		if err != nil {
 			glog.V(100).Infof("Failed to create BGPAdvertisement")
@@ -198,7 +198,7 @@ func (builder *BGPAdvertisementBuilder) Delete() (*BGPAdvertisementBuilder, erro
 
 	err := builder.apiClient.Resource(
 		GetBGPAdvertisementGVR()).Namespace(builder.Definition.Namespace).Delete(
-		context.TODO(), builder.Definition.Name, metaV1.DeleteOptions{})
+		context.TODO(), builder.Definition.Name, metav1.DeleteOptions{})
 
 	if err != nil {
 		return builder, fmt.Errorf("can not delete BGPAdvertisement: %w", err)
@@ -240,7 +240,7 @@ func (builder *BGPAdvertisementBuilder) Update(force bool) (*BGPAdvertisementBui
 
 	_, err = builder.apiClient.Resource(
 		GetBGPAdvertisementGVR()).Namespace(builder.Definition.Namespace).Update(
-		context.TODO(), &unstructured.Unstructured{Object: unstructuredBgpAdvert}, metaV1.UpdateOptions{})
+		context.TODO(), &unstructured.Unstructured{Object: unstructuredBgpAdvert}, metav1.UpdateOptions{})
 
 	if err != nil {
 		if force {
@@ -374,7 +374,7 @@ func (builder *BGPAdvertisementBuilder) WithIPAddressPools(ipAddressPools []stri
 
 // WithIPAddressPoolsSelectors adds the specified IPAddressPoolSelectors to the BGPAdvertisement.
 func (builder *BGPAdvertisementBuilder) WithIPAddressPoolsSelectors(
-	poolSelector []metaV1.LabelSelector) *BGPAdvertisementBuilder {
+	poolSelector []metav1.LabelSelector) *BGPAdvertisementBuilder {
 	if valid, _ := builder.validate(); !valid {
 		return builder
 	}
@@ -399,7 +399,7 @@ func (builder *BGPAdvertisementBuilder) WithIPAddressPoolsSelectors(
 
 // WithNodeSelector adds the specified NodeSelectors to the BGPAdvertisement.
 func (builder *BGPAdvertisementBuilder) WithNodeSelector(
-	nodeSelectors []metaV1.LabelSelector) *BGPAdvertisementBuilder {
+	nodeSelectors []metav1.LabelSelector) *BGPAdvertisementBuilder {
 	if valid, _ := builder.validate(); !valid {
 		return builder
 	}

--- a/pkg/metallb/bgppeer.go
+++ b/pkg/metallb/bgppeer.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -43,11 +43,11 @@ func NewBPGPeerBuilder(
 	builder := BGPPeerBuilder{
 		apiClient: apiClient,
 		Definition: &mlbtypes.BGPPeer{
-			TypeMeta: metaV1.TypeMeta{
+			TypeMeta: metav1.TypeMeta{
 				Kind:       bpgPeerKind,
 				APIVersion: fmt.Sprintf("%s/%s", APIGroup, APIVersion),
 			},
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			}, Spec: mlbtypes.BGPPeerSpec{
@@ -91,7 +91,7 @@ func (builder *BGPPeerBuilder) Get() (*mlbtypes.BGPPeer, error) {
 
 	unsObject, err := builder.apiClient.Resource(
 		GetBGPPeerGVR()).Namespace(builder.Definition.Namespace).Get(
-		context.TODO(), builder.Definition.Name, metaV1.GetOptions{})
+		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
 	if err != nil {
 		glog.V(100).Infof(
@@ -127,7 +127,7 @@ func PullBGPPeer(apiClient *clients.Settings, name, nsname string) (*BGPPeerBuil
 	builder := BGPPeerBuilder{
 		apiClient: apiClient,
 		Definition: &mlbtypes.BGPPeer{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			},
@@ -177,7 +177,7 @@ func (builder *BGPPeerBuilder) Create() (*BGPPeerBuilder, error) {
 
 		unsObject, err := builder.apiClient.Resource(
 			GetBGPPeerGVR()).Namespace(builder.Definition.Namespace).Create(
-			context.TODO(), &unstructured.Unstructured{Object: unstructuredBgpPeer}, metaV1.CreateOptions{})
+			context.TODO(), &unstructured.Unstructured{Object: unstructuredBgpPeer}, metav1.CreateOptions{})
 
 		if err != nil {
 			glog.V(100).Infof("Failed to create BGPPeer")
@@ -211,7 +211,7 @@ func (builder *BGPPeerBuilder) Delete() (*BGPPeerBuilder, error) {
 
 	err := builder.apiClient.Resource(
 		GetBGPPeerGVR()).Namespace(builder.Definition.Namespace).Delete(
-		context.TODO(), builder.Definition.Name, metaV1.DeleteOptions{})
+		context.TODO(), builder.Definition.Name, metav1.DeleteOptions{})
 
 	if err != nil {
 		return builder, fmt.Errorf("can not delete BGPPeer: %w", err)
@@ -242,7 +242,7 @@ func (builder *BGPPeerBuilder) Update(force bool) (*BGPPeerBuilder, error) {
 
 	_, err = builder.apiClient.Resource(
 		GetBGPPeerGVR()).Namespace(builder.Definition.Namespace).Update(
-		context.TODO(), &unstructured.Unstructured{Object: unstructuredBgpPeer}, metaV1.UpdateOptions{})
+		context.TODO(), &unstructured.Unstructured{Object: unstructuredBgpPeer}, metav1.UpdateOptions{})
 
 	if err != nil {
 		if force {
@@ -358,7 +358,7 @@ func (builder *BGPPeerBuilder) WithPort(port uint16) *BGPPeerBuilder {
 }
 
 // WithHoldTime defines the holdTime placed in the BGPPeer spec.
-func (builder *BGPPeerBuilder) WithHoldTime(holdTime metaV1.Duration) *BGPPeerBuilder {
+func (builder *BGPPeerBuilder) WithHoldTime(holdTime metav1.Duration) *BGPPeerBuilder {
 	if valid, _ := builder.validate(); !valid {
 		return builder
 	}
@@ -373,7 +373,7 @@ func (builder *BGPPeerBuilder) WithHoldTime(holdTime metaV1.Duration) *BGPPeerBu
 }
 
 // WithKeepalive defines the keepAliveTime placed in the BGPPeer spec.
-func (builder *BGPPeerBuilder) WithKeepalive(keepalive metaV1.Duration) *BGPPeerBuilder {
+func (builder *BGPPeerBuilder) WithKeepalive(keepalive metav1.Duration) *BGPPeerBuilder {
 	if valid, _ := builder.validate(); !valid {
 		return builder
 	}

--- a/pkg/metallb/metallb.go
+++ b/pkg/metallb/metallb.go
@@ -9,7 +9,7 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/metallb/mlbtypes"
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -40,11 +40,11 @@ func NewBuilder(apiClient *clients.Settings, name, nsname string, label map[stri
 	builder := Builder{
 		apiClient: apiClient,
 		Definition: &mlbtypes.MetalLB{
-			TypeMeta: metaV1.TypeMeta{
+			TypeMeta: metav1.TypeMeta{
 				Kind:       metalLb,
 				APIVersion: fmt.Sprintf("%s/%s", APIGroup, APIVersion),
 			},
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			},
@@ -77,7 +77,7 @@ func Pull(apiClient *clients.Settings, name, nsname string) (*Builder, error) {
 	builder := Builder{
 		apiClient: apiClient,
 		Definition: &mlbtypes.MetalLB{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			},
@@ -136,7 +136,7 @@ func (builder *Builder) Get() (*mlbtypes.MetalLB, error) {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	unsObject, err := builder.apiClient.Resource(GetMetalLbIoGVR()).Namespace(builder.Definition.Namespace).Get(
-		context.TODO(), builder.Definition.Name, metaV1.GetOptions{})
+		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
 	if err != nil {
 		glog.V(100).Infof(
@@ -171,7 +171,7 @@ func (builder *Builder) Create() (*Builder, error) {
 
 		unsObject, err := builder.apiClient.Resource(
 			GetMetalLbIoGVR()).Namespace(builder.Definition.Namespace).Create(
-			context.TODO(), &unstructured.Unstructured{Object: unstructuredMetalLb}, metaV1.CreateOptions{})
+			context.TODO(), &unstructured.Unstructured{Object: unstructuredMetalLb}, metav1.CreateOptions{})
 
 		if err != nil {
 			glog.V(100).Infof("Failed to create MetalLb")
@@ -205,7 +205,7 @@ func (builder *Builder) Delete() (*Builder, error) {
 
 	err := builder.apiClient.Resource(
 		GetMetalLbIoGVR()).Namespace(builder.Definition.Namespace).Delete(
-		context.TODO(), builder.Definition.Name, metaV1.DeleteOptions{})
+		context.TODO(), builder.Definition.Name, metav1.DeleteOptions{})
 
 	if err != nil {
 		return builder, fmt.Errorf("can not delete metallb: %w", err)
@@ -246,7 +246,7 @@ func (builder *Builder) Update(force bool) (*Builder, error) {
 
 	_, err = builder.apiClient.Resource(
 		GetMetalLbIoGVR()).Namespace(builder.Definition.Namespace).Update(
-		context.TODO(), &unstructured.Unstructured{Object: unstructuredMetalLb}, metaV1.UpdateOptions{})
+		context.TODO(), &unstructured.Unstructured{Object: unstructuredMetalLb}, metav1.UpdateOptions{})
 
 	if err != nil {
 		if force {

--- a/pkg/nad/builder.go
+++ b/pkg/nad/builder.go
@@ -6,7 +6,7 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"context"
@@ -39,7 +39,7 @@ func NewBuilder(apiClient *clients.Settings, name, nsname string) *Builder {
 	builder := Builder{
 		apiClient: apiClient,
 		Definition: &nadV1.NetworkAttachmentDefinition{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			},
@@ -68,7 +68,7 @@ func Pull(apiClient *clients.Settings, name, nsname string) (*Builder, error) {
 	builder := Builder{
 		apiClient: apiClient,
 		Definition: &nadV1.NetworkAttachmentDefinition{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			},
@@ -119,7 +119,7 @@ func (builder *Builder) Create() (*Builder, error) {
 
 	if !builder.Exists() {
 		builder.Object, err = builder.apiClient.NetworkAttachmentDefinitions(builder.Definition.Namespace).
-			Create(context.Background(), builder.Definition, metaV1.CreateOptions{})
+			Create(context.Background(), builder.Definition, metav1.CreateOptions{})
 		if err != nil {
 			return builder, fmt.Errorf("fail to create NAD object due to: " + err.Error())
 		}
@@ -144,7 +144,7 @@ func (builder *Builder) Delete() error {
 	}
 
 	err := builder.apiClient.NetworkAttachmentDefinitions(builder.Definition.Namespace).Delete(
-		context.Background(), builder.Definition.Namespace, metaV1.DeleteOptions{})
+		context.Background(), builder.Definition.Namespace, metav1.DeleteOptions{})
 
 	if err != nil {
 		return fmt.Errorf("fail to delete NAD object due to: %w", err)
@@ -166,11 +166,11 @@ func (builder *Builder) Update() (*Builder, error) {
 
 	var err error
 
-	builder.Definition.CreationTimestamp = metaV1.Time{}
+	builder.Definition.CreationTimestamp = metav1.Time{}
 	builder.Definition.ResourceVersion = builder.Object.ResourceVersion
 
 	builder.Object, err = builder.apiClient.NetworkAttachmentDefinitions(builder.Definition.Namespace).Update(
-		context.TODO(), builder.Definition, metaV1.UpdateOptions{})
+		context.TODO(), builder.Definition, metav1.UpdateOptions{})
 
 	return builder, err
 }
@@ -188,7 +188,7 @@ func (builder *Builder) Exists() bool {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	_, err := builder.apiClient.NetworkAttachmentDefinitions(builder.Definition.Namespace).Get(context.Background(),
-		builder.Definition.Name, metaV1.GetOptions{})
+		builder.Definition.Name, metav1.GetOptions{})
 
 	return nil == err || !k8serrors.IsNotFound(err)
 }

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -9,7 +9,7 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
 	v1 "github.com/openshift/api/config/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -33,7 +33,7 @@ func PullConfig(apiClient *clients.Settings) (*ConfigBuilder, error) {
 	builder := ConfigBuilder{
 		apiClient: apiClient,
 		Definition: &v1.Network{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: clusterNetworkName,
 			},
 		},
@@ -60,7 +60,7 @@ func (builder *ConfigBuilder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.ConfigV1Interface.Networks().Get(
-		context.Background(), builder.Definition.Name, metaV1.GetOptions{})
+		context.Background(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }

--- a/pkg/network/operator.go
+++ b/pkg/network/operator.go
@@ -10,7 +10,7 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
 	operatorV1 "github.com/openshift/api/operator/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	goclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -33,7 +33,7 @@ func PullOperator(apiClient *clients.Settings) (*OperatorBuilder, error) {
 	builder := OperatorBuilder{
 		apiClient: apiClient,
 		Definition: &operatorV1.Network{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: clusterNetworkName,
 			},
 		},

--- a/pkg/networkpolicy/multinetegressrule.go
+++ b/pkg/networkpolicy/multinetegressrule.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/k8snetworkplumbingwg/multi-networkpolicy/pkg/apis/k8s.cni.cncf.io/v1beta1"
-	v1 "k8s.io/api/core/v1"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -35,7 +35,7 @@ func NewEgressRuleBuilder() *EgressRuleBuilder {
 }
 
 // WithPortAndProtocol adds port and protocol to Egress rule.
-func (builder *EgressRuleBuilder) WithPortAndProtocol(port uint16, protocol v1.Protocol) *EgressRuleBuilder {
+func (builder *EgressRuleBuilder) WithPortAndProtocol(port uint16, protocol corev1.Protocol) *EgressRuleBuilder {
 	glog.V(100).Infof("Adding port %d and protocol %s to EgressRule", port, protocol)
 
 	if port == 0 {
@@ -78,7 +78,7 @@ func (builder *EgressRuleBuilder) WithOptions(options ...EgressAdditionalOptions
 }
 
 // WithPeerPodSelector adds pod selector to Egress rule.
-func (builder *EgressRuleBuilder) WithPeerPodSelector(podSelector metaV1.LabelSelector) *EgressRuleBuilder {
+func (builder *EgressRuleBuilder) WithPeerPodSelector(podSelector metav1.LabelSelector) *EgressRuleBuilder {
 	glog.V(100).Infof("Adding peer pod selector %v to EgressRule", podSelector)
 
 	if builder.errorMsg != "" {
@@ -92,7 +92,7 @@ func (builder *EgressRuleBuilder) WithPeerPodSelector(podSelector metaV1.LabelSe
 
 // WithPeerPodSelectorAndCIDR adds pod selector and CIDR to Egress rule.
 func (builder *EgressRuleBuilder) WithPeerPodSelectorAndCIDR(
-	podSelector metaV1.LabelSelector, cidr string, except ...[]string) *EgressRuleBuilder {
+	podSelector metav1.LabelSelector, cidr string, except ...[]string) *EgressRuleBuilder {
 	glog.V(100).Infof("Adding peer pod selector %v to EgressRule", podSelector)
 
 	_, _, err := net.ParseCIDR(cidr)

--- a/pkg/networkpolicy/multinetingressrule.go
+++ b/pkg/networkpolicy/multinetingressrule.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/k8snetworkplumbingwg/multi-networkpolicy/pkg/apis/k8s.cni.cncf.io/v1beta1"
-	v1 "k8s.io/api/core/v1"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -34,7 +34,7 @@ func NewIngressRuleBuilder() *IngressRuleBuilder {
 }
 
 // WithPortAndProtocol adds port and protocol to Ingress rule.
-func (builder *IngressRuleBuilder) WithPortAndProtocol(port uint16, protocol v1.Protocol) *IngressRuleBuilder {
+func (builder *IngressRuleBuilder) WithPortAndProtocol(port uint16, protocol corev1.Protocol) *IngressRuleBuilder {
 	glog.V(100).Infof("Adding port %d protocol %s to IngressRule", port, protocol)
 
 	if port == 0 {
@@ -77,7 +77,7 @@ func (builder *IngressRuleBuilder) WithOptions(options ...IngressAdditionalOptio
 }
 
 // WithPeerPodSelector adds peer pod selector to Ingress rule.
-func (builder *IngressRuleBuilder) WithPeerPodSelector(podSelector metaV1.LabelSelector) *IngressRuleBuilder {
+func (builder *IngressRuleBuilder) WithPeerPodSelector(podSelector metav1.LabelSelector) *IngressRuleBuilder {
 	glog.V(100).Infof("Adding peer pod selector %v to Ingress Rule", podSelector)
 
 	if builder.errorMsg != "" {
@@ -128,7 +128,7 @@ func (builder *IngressRuleBuilder) WithCIDR(cidr string, except ...[]string) *In
 
 // WithPeerPodSelectorAndCIDR adds port and protocol,CIDR to Ingress rule.
 func (builder *IngressRuleBuilder) WithPeerPodSelectorAndCIDR(
-	podSelector metaV1.LabelSelector, cidr string, except ...[]string) *IngressRuleBuilder {
+	podSelector metav1.LabelSelector, cidr string, except ...[]string) *IngressRuleBuilder {
 	glog.V(100).Infof("Adding peer pod selector %v and CIDR %s to IngressRule", podSelector, cidr)
 
 	if builder.errorMsg != "" {

--- a/pkg/nfd/nodefeaturediscovery.go
+++ b/pkg/nfd/nodefeaturediscovery.go
@@ -9,7 +9,7 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
 	nfdv1 "github.com/openshift/cluster-nfd-operator/api/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/json"
 	goclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -92,7 +92,7 @@ func Pull(apiClient *clients.Settings, name, namespace string) (*Builder, error)
 	builder := Builder{
 		apiClient: apiClient,
 		Definition: &nfdv1.NodeFeatureDiscovery{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: namespace,
 			},

--- a/pkg/nmstate/nmstate.go
+++ b/pkg/nmstate/nmstate.go
@@ -12,7 +12,7 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	goclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -36,7 +36,7 @@ func NewBuilder(apiClient *clients.Settings, name string) *Builder {
 	builder := Builder{
 		apiClient: apiClient,
 		Definition: &nmstateV1.NMState{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 			},
 		},
@@ -165,7 +165,7 @@ func PullNMstate(apiClient *clients.Settings, name string) (*Builder, error) {
 	builder := Builder{
 		apiClient: apiClient,
 		Definition: &nmstateV1.NMState{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 			},
 		},

--- a/pkg/nmstate/nodenetworkstate.go
+++ b/pkg/nmstate/nodenetworkstate.go
@@ -15,7 +15,7 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	goclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -186,7 +186,7 @@ func PullNodeNetworkState(apiClient *clients.Settings, name string) (*StateBuild
 	stateBuilder := StateBuilder{
 		apiClient: apiClient,
 		Object: &nmstateV1alpha1.NodeNetworkState{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 			},
 		},

--- a/pkg/nmstate/policy.go
+++ b/pkg/nmstate/policy.go
@@ -15,9 +15,9 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
 
-	coreV1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/utils/strings/slices"
 	goclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -52,7 +52,7 @@ func NewPolicyBuilder(apiClient *clients.Settings, name string, nodeSelector map
 	builder := PolicyBuilder{
 		apiClient: apiClient,
 		Definition: &nmstateV1.NodeNetworkConfigurationPolicy{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 			}, Spec: nmstateShared.NodeNetworkConfigurationPolicySpec{
 				NodeSelector: nodeSelector,
@@ -378,7 +378,7 @@ func (builder *PolicyBuilder) WaitUntilCondition(condition nmstateShared.Conditi
 			}
 
 			for _, cond := range builder.Object.Status.Conditions {
-				if cond.Type == condition && cond.Status == coreV1.ConditionTrue {
+				if cond.Type == condition && cond.Status == corev1.ConditionTrue {
 					return true, nil
 				}
 			}

--- a/pkg/nodes/node.go
+++ b/pkg/nodes/node.go
@@ -14,8 +14,8 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
-	v1 "k8s.io/api/core/v1"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubectl/pkg/drain"
 )
 
@@ -25,8 +25,8 @@ const (
 
 // Builder provides struct for Node object containing connection to the cluster and the list of Node definitions.
 type Builder struct {
-	Definition  *v1.Node
-	Object      *v1.Node
+	Definition  *corev1.Node
+	Object      *corev1.Node
 	apiClient   *clients.Settings
 	errorMsg    string
 	drainHelper *drain.Helper
@@ -118,8 +118,8 @@ func Pull(apiClient *clients.Settings, nodeName string) (*Builder, error) {
 
 	builder := Builder{
 		apiClient: apiClient,
-		Definition: &v1.Node{
-			ObjectMeta: metaV1.ObjectMeta{
+		Definition: &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: nodeName,
 			},
 		},
@@ -146,12 +146,12 @@ func (builder *Builder) Update() (*Builder, error) {
 		return nil, fmt.Errorf("node %s object doesn't exist", builder.Definition.Name)
 	}
 
-	builder.Definition.CreationTimestamp = metaV1.Time{}
+	builder.Definition.CreationTimestamp = metav1.Time{}
 	builder.Definition.ResourceVersion = ""
 
 	var err error
 	builder.Object, err = builder.apiClient.CoreV1Interface.Nodes().Update(
-		context.TODO(), builder.Definition, metaV1.UpdateOptions{})
+		context.TODO(), builder.Definition, metav1.UpdateOptions{})
 
 	return builder, err
 }
@@ -166,7 +166,7 @@ func (builder *Builder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.CoreV1Interface.Nodes().Get(
-		context.Background(), builder.Definition.Name, metaV1.GetOptions{})
+		context.Background(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }
@@ -186,7 +186,7 @@ func (builder *Builder) Delete() error {
 	err := builder.apiClient.CoreV1Interface.Nodes().Delete(
 		context.Background(),
 		builder.Definition.Name,
-		metaV1.DeleteOptions{})
+		metav1.DeleteOptions{})
 
 	if err != nil {
 		return fmt.Errorf("can not delete node %s due to %w", builder.Definition.Name, err)
@@ -315,7 +315,7 @@ func (builder *Builder) IsReady() (bool, error) {
 	}
 
 	for _, condition := range builder.Object.Status.Conditions {
-		if condition.Type == v1.NodeReady {
+		if condition.Type == corev1.NodeReady {
 			return condition.Status == isTrue, nil
 		}
 	}
@@ -325,7 +325,7 @@ func (builder *Builder) IsReady() (bool, error) {
 
 // WaitUntilConditionTrue waits for timeout duration or until node gets to a specific status.
 func (builder *Builder) WaitUntilConditionTrue(
-	conditionType v1.NodeConditionType, timeout time.Duration) error {
+	conditionType corev1.NodeConditionType, timeout time.Duration) error {
 	if valid, err := builder.validate(); !valid {
 		return err
 	}
@@ -356,7 +356,7 @@ func (builder *Builder) WaitUntilConditionTrue(
 
 // WaitUntilConditionUnknown waits for timeout duration or until node change specific status.
 func (builder *Builder) WaitUntilConditionUnknown(
-	conditionType v1.NodeConditionType, timeout time.Duration) error {
+	conditionType corev1.NodeConditionType, timeout time.Duration) error {
 	if valid, err := builder.validate(); !valid {
 		return err
 	}
@@ -387,12 +387,12 @@ func (builder *Builder) WaitUntilConditionUnknown(
 
 // WaitUntilReady waits for timeout duration or until node is Ready.
 func (builder *Builder) WaitUntilReady(timeout time.Duration) error {
-	return builder.WaitUntilConditionTrue(v1.NodeReady, timeout)
+	return builder.WaitUntilConditionTrue(corev1.NodeReady, timeout)
 }
 
 // WaitUntilNotReady waits for timeout duration or until node is NotReady.
 func (builder *Builder) WaitUntilNotReady(timeout time.Duration) error {
-	return builder.WaitUntilConditionUnknown(v1.NodeReady, timeout)
+	return builder.WaitUntilConditionUnknown(corev1.NodeReady, timeout)
 }
 
 // validate will check that the builder and builder definition are properly initialized before

--- a/pkg/nto/performanceprofile.go
+++ b/pkg/nto/performanceprofile.go
@@ -11,7 +11,7 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
 	v2 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/performanceprofile/v2"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	goclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -40,7 +40,7 @@ func NewBuilder(
 	builder := &Builder{
 		apiClient: apiClient,
 		Definition: &v2.PerformanceProfile{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 			},
 			Spec: v2.PerformanceProfileSpec{
@@ -87,7 +87,7 @@ func Pull(apiClient *clients.Settings, name string) (*Builder, error) {
 	builder := Builder{
 		apiClient: apiClient,
 		Definition: &v2.PerformanceProfile{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 			},
 		},

--- a/pkg/nvidiagpu/clusterpolicy.go
+++ b/pkg/nvidiagpu/clusterpolicy.go
@@ -9,7 +9,7 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/json"
 	goclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -91,7 +91,7 @@ func Pull(apiClient *clients.Settings, name string) (*Builder, error) {
 	builder := Builder{
 		apiClient: apiClient,
 		Definition: &nvidiagpuv1.ClusterPolicy{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 			},
 		},

--- a/pkg/ocm/placementbinding.go
+++ b/pkg/ocm/placementbinding.go
@@ -8,7 +8,7 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -32,7 +32,7 @@ func PullPlacementBinding(apiClient *clients.Settings, name, nsname string) (*Pl
 	builder := PlacementBindingBuilder{
 		apiClient: apiClient,
 		Definition: &policiesv1.PlacementBinding{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			},

--- a/pkg/ocm/placementrule.go
+++ b/pkg/ocm/placementrule.go
@@ -8,7 +8,7 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	placementrulev1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/placementrule/v1"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -33,7 +33,7 @@ func PullPlacementRule(apiClient *clients.Settings, name, nsname string) (*Place
 	builder := PlacementRuleBuilder{
 		apiClient: apiClient,
 		Definition: &placementrulev1.PlacementRule{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			},

--- a/pkg/ocm/policy.go
+++ b/pkg/ocm/policy.go
@@ -8,7 +8,7 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -33,7 +33,7 @@ func PullPolicy(apiClient *clients.Settings, name, nsname string) (*PolicyBuilde
 	builder := PolicyBuilder{
 		apiClient: apiClient,
 		Definition: &policiesv1.Policy{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			},

--- a/pkg/ocm/policyset.go
+++ b/pkg/ocm/policyset.go
@@ -8,7 +8,7 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	policiesv1beta1 "open-cluster-management.io/governance-policy-propagator/api/v1beta1"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -33,7 +33,7 @@ func PullPolicySet(apiClient *clients.Settings, name, nsname string) (*PolicySet
 	builder := PolicySetBuilder{
 		apiClient: apiClient,
 		Definition: &policiesv1beta1.PolicySet{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			},

--- a/pkg/olm/catalogsource.go
+++ b/pkg/olm/catalogsource.go
@@ -9,7 +9,7 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
 	oplmV1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // CatalogSourceBuilder provides a struct for catalogsource object
@@ -33,7 +33,7 @@ func NewCatalogSourceBuilder(apiClient *clients.Settings, name, nsname string) *
 	builder := CatalogSourceBuilder{
 		apiClient: apiClient,
 		Definition: &oplmV1alpha1.CatalogSource{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			},
@@ -63,7 +63,7 @@ func PullCatalogSource(apiClient *clients.Settings, name, nsname string) (*Catal
 	builder := CatalogSourceBuilder{
 		apiClient: apiClient,
 		Definition: &oplmV1alpha1.CatalogSource{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			},
@@ -99,7 +99,7 @@ func (builder *CatalogSourceBuilder) Create() (*CatalogSourceBuilder, error) {
 	var err error
 	if !builder.Exists() {
 		builder.Object, err = builder.apiClient.CatalogSources(builder.Definition.Namespace).Create(context.Background(),
-			builder.Definition, metaV1.CreateOptions{})
+			builder.Definition, metav1.CreateOptions{})
 	}
 
 	return builder, err
@@ -118,7 +118,7 @@ func (builder *CatalogSourceBuilder) Exists() bool {
 	var err error
 	builder.Object, err = builder.apiClient.OperatorsV1alpha1Interface.CatalogSources(
 		builder.Definition.Namespace).Get(
-		context.Background(), builder.Definition.Name, metaV1.GetOptions{})
+		context.Background(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }
@@ -137,7 +137,7 @@ func (builder *CatalogSourceBuilder) Delete() error {
 	}
 
 	err := builder.apiClient.CatalogSources(builder.Definition.Namespace).Delete(context.TODO(),
-		builder.Object.Name, metaV1.DeleteOptions{})
+		builder.Object.Name, metav1.DeleteOptions{})
 
 	if err != nil {
 		return err

--- a/pkg/olm/catalogsourcelist.go
+++ b/pkg/olm/catalogsourcelist.go
@@ -6,21 +6,21 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // ListCatalogSources returns catalogsource inventory in the given namespace.
 func ListCatalogSources(
 	apiClient *clients.Settings,
 	nsname string,
-	options ...metaV1.ListOptions) ([]*CatalogSourceBuilder, error) {
+	options ...metav1.ListOptions) ([]*CatalogSourceBuilder, error) {
 	if nsname == "" {
 		glog.V(100).Infof("catalogsource 'namespace' parameter can not be empty")
 
 		return nil, fmt.Errorf("failed to list catalogsource, 'namespace' parameter is empty")
 	}
 
-	passedOptions := metaV1.ListOptions{}
+	passedOptions := metav1.ListOptions{}
 	logMessage := fmt.Sprintf("Listing catalogsource in the namespace %s", nsname)
 
 	if len(options) > 1 {

--- a/pkg/olm/clusterserviceversion.go
+++ b/pkg/olm/clusterserviceversion.go
@@ -10,7 +10,7 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
 	oplmV1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // ClusterServiceVersionBuilder provides a struct for clusterserviceversion object
@@ -35,7 +35,7 @@ func PullClusterServiceVersion(apiClient *clients.Settings, name, namespace stri
 	builder := ClusterServiceVersionBuilder{
 		apiClient: apiClient,
 		Definition: &oplmV1alpha1.ClusterServiceVersion{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: namespace,
 			},
@@ -72,7 +72,7 @@ func (builder *ClusterServiceVersionBuilder) Exists() bool {
 	var err error
 	builder.Object, err = builder.apiClient.OperatorsV1alpha1Interface.ClusterServiceVersions(
 		builder.Definition.Namespace).Get(
-		context.Background(), builder.Definition.Name, metaV1.GetOptions{})
+		context.Background(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }
@@ -91,7 +91,7 @@ func (builder *ClusterServiceVersionBuilder) Delete() error {
 	}
 
 	err := builder.apiClient.ClusterServiceVersions(builder.Definition.Namespace).Delete(context.TODO(),
-		builder.Object.Name, metaV1.DeleteOptions{})
+		builder.Object.Name, metav1.DeleteOptions{})
 
 	if err != nil {
 		return err

--- a/pkg/olm/clusterserviceversionlist.go
+++ b/pkg/olm/clusterserviceversionlist.go
@@ -7,21 +7,21 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // ListClusterServiceVersion returns clusterserviceversion inventory in the given namespace.
 func ListClusterServiceVersion(
 	apiClient *clients.Settings,
 	nsname string,
-	options ...metaV1.ListOptions) ([]*ClusterServiceVersionBuilder, error) {
+	options ...metav1.ListOptions) ([]*ClusterServiceVersionBuilder, error) {
 	if nsname == "" {
 		glog.V(100).Infof("clusterserviceversion 'nsname' parameter can not be empty")
 
 		return nil, fmt.Errorf("failed to list clusterserviceversion, 'nsname' parameter is empty")
 	}
 
-	passedOptions := metaV1.ListOptions{}
+	passedOptions := metav1.ListOptions{}
 	logMessage := fmt.Sprintf("Listing clusterserviceversion in the namespace %s", nsname)
 
 	if len(options) > 1 {
@@ -68,7 +68,7 @@ func ListClusterServiceVersionWithNamePattern(
 	apiClient *clients.Settings,
 	namePattern string,
 	nsname string,
-	options ...metaV1.ListOptions) ([]*ClusterServiceVersionBuilder, error) {
+	options ...metav1.ListOptions) ([]*ClusterServiceVersionBuilder, error) {
 	if namePattern == "" {
 		glog.V(100).Info(
 			"The namePattern field to filter out all relevant clusterserviceversion cannot be empty")
@@ -103,8 +103,8 @@ func ListClusterServiceVersionWithNamePattern(
 // ListClusterServiceVersionInAllNamespaces returns cluster-wide clusterserviceversion inventory.
 func ListClusterServiceVersionInAllNamespaces(
 	apiClient *clients.Settings,
-	options ...metaV1.ListOptions) ([]*ClusterServiceVersionBuilder, error) {
-	passedOptions := metaV1.ListOptions{}
+	options ...metav1.ListOptions) ([]*ClusterServiceVersionBuilder, error) {
+	passedOptions := metav1.ListOptions{}
 	logMessage := "Listing CSVs in all namespaces"
 
 	if len(options) > 1 {

--- a/pkg/olm/installplan.go
+++ b/pkg/olm/installplan.go
@@ -10,7 +10,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // InstallPlanBuilder provides a struct for installplan object from the cluster and an installplan definition.
@@ -33,7 +33,7 @@ func NewInstallPlanBuilder(apiClient *clients.Settings, name, nsname string) *In
 	builder := InstallPlanBuilder{
 		apiClient: apiClient,
 		Definition: &v1alpha1.InstallPlan{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			},
@@ -67,7 +67,7 @@ func (builder *InstallPlanBuilder) Create() (*InstallPlanBuilder, error) {
 	var err error
 	if !builder.Exists() {
 		builder.Object, err = builder.apiClient.InstallPlans(builder.Definition.Namespace).Create(context.Background(),
-			builder.Definition, metaV1.CreateOptions{})
+			builder.Definition, metav1.CreateOptions{})
 	}
 
 	return builder, err
@@ -84,7 +84,7 @@ func (builder *InstallPlanBuilder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.InstallPlans(builder.Definition.Namespace).Get(
-		context.Background(), builder.Definition.Name, metaV1.GetOptions{})
+		context.Background(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }
@@ -103,7 +103,7 @@ func (builder *InstallPlanBuilder) Delete() error {
 	}
 
 	err := builder.apiClient.InstallPlans(builder.Definition.Namespace).Delete(context.TODO(),
-		builder.Object.Name, metaV1.DeleteOptions{})
+		builder.Object.Name, metav1.DeleteOptions{})
 
 	if err != nil {
 		return err
@@ -125,7 +125,7 @@ func (builder *InstallPlanBuilder) Update() (*InstallPlanBuilder, error) {
 
 	var err error
 	builder.Object, err = builder.apiClient.InstallPlans(builder.Definition.Namespace).Update(
-		context.TODO(), builder.Definition, metaV1.UpdateOptions{})
+		context.TODO(), builder.Definition, metav1.UpdateOptions{})
 
 	return builder, err
 }

--- a/pkg/olm/packagemanifest.go
+++ b/pkg/olm/packagemanifest.go
@@ -9,7 +9,7 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
 	pkgManifestV1 "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apis/operators/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // PackageManifestBuilder provides a struct for PackageManifest object from the cluster
@@ -33,7 +33,7 @@ func PullPackageManifest(apiClient *clients.Settings, name, nsname string) (*Pac
 	builder := &PackageManifestBuilder{
 		apiClient: apiClient,
 		Definition: &pkgManifestV1.PackageManifest{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			},
@@ -67,7 +67,7 @@ func PullPackageManifestByCatalog(apiClient *clients.Settings, name, nsname,
 	glog.V(100).Infof("Pulling existing PackageManifest name %s in namespace %s and from catalog %s",
 		name, nsname, catalog)
 
-	packageManifests, err := ListPackageManifest(apiClient, nsname, metaV1.ListOptions{
+	packageManifests, err := ListPackageManifest(apiClient, nsname, metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("catalog=%s", catalog),
 		FieldSelector: fmt.Sprintf("metadata.name=%s", name),
 	})
@@ -105,7 +105,7 @@ func (builder *PackageManifestBuilder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.PackageManifestInterface.PackageManifests(
-		builder.Definition.Namespace).Get(context.Background(), builder.Definition.Name, metaV1.GetOptions{})
+		builder.Definition.Namespace).Get(context.Background(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }
@@ -124,7 +124,7 @@ func (builder *PackageManifestBuilder) Delete() error {
 	}
 
 	err := builder.apiClient.PackageManifestInterface.PackageManifests(builder.Definition.Namespace).Delete(
-		context.TODO(), builder.Object.Name, metaV1.DeleteOptions{})
+		context.TODO(), builder.Object.Name, metav1.DeleteOptions{})
 
 	if err != nil {
 		return err

--- a/pkg/olm/packagemanifestlist.go
+++ b/pkg/olm/packagemanifestlist.go
@@ -6,21 +6,21 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // ListPackageManifest returns PackageManifest inventory in the given namespace.
 func ListPackageManifest(
 	apiClient *clients.Settings,
 	nsname string,
-	options ...metaV1.ListOptions) ([]*PackageManifestBuilder, error) {
+	options ...metav1.ListOptions) ([]*PackageManifestBuilder, error) {
 	if nsname == "" {
 		glog.V(100).Infof("packagemanifest 'nsname' parameter can not be empty")
 
 		return nil, fmt.Errorf("failed to list packagemanifests, 'nsname' parameter is empty")
 	}
 
-	passedOptions := metaV1.ListOptions{}
+	passedOptions := metav1.ListOptions{}
 	logMessage := fmt.Sprintf("Listing PackageManifests in the namespace %s", nsname)
 
 	if len(options) > 1 {

--- a/pkg/pod/container.go
+++ b/pkg/pod/container.go
@@ -6,7 +6,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/golang/glog"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/strings/slices"
 )
 
@@ -15,14 +15,14 @@ var (
 	AllowedSCList          = []string{"NET_RAW", "NET_ADMIN", "SYS_ADMIN", "IPC_LOCK", "ALL"}
 	falseVar               = false
 	trueVar                = true
-	capabilityAll          = []v1.Capability{"ALL"}
+	capabilityAll          = []corev1.Capability{"ALL"}
 	defaultGroupID         = int64(3000)
 	defaultUserID          = int64(2000)
-	defaultSecurityContext = &v1.SecurityContext{
+	defaultSecurityContext = &corev1.SecurityContext{
 		AllowPrivilegeEscalation: &falseVar,
 		RunAsNonRoot:             &trueVar,
-		SeccompProfile:           &v1.SeccompProfile{Type: "RuntimeDefault"},
-		Capabilities: &v1.Capabilities{
+		SeccompProfile:           &corev1.SeccompProfile{Type: "RuntimeDefault"},
+		Capabilities: &corev1.Capabilities{
 			Drop: capabilityAll,
 		},
 		RunAsGroup: &defaultGroupID,
@@ -33,7 +33,7 @@ var (
 // ContainerBuilder provides a struct for container's object definition.
 type ContainerBuilder struct {
 	// Container definition, used to create the Container object.
-	definition *v1.Container
+	definition *corev1.Container
 	// Used to store latest error message upon defining or mutating container definition.
 	errorMsg string
 }
@@ -44,7 +44,7 @@ func NewContainerBuilder(name, image string, cmd []string) *ContainerBuilder {
 		"name: %s, image: %s, cmd: %v", name, image, cmd)
 
 	builder := &ContainerBuilder{
-		definition: &v1.Container{
+		definition: &corev1.Container{
 			Name:            name,
 			Image:           image,
 			Command:         cmd,
@@ -99,13 +99,13 @@ func (builder *ContainerBuilder) WithSecurityCapabilities(sCapabilities []string
 		return builder
 	}
 
-	var sCapabilitiesList []v1.Capability
+	var sCapabilitiesList []corev1.Capability
 	for _, capability := range sCapabilities {
-		sCapabilitiesList = append(sCapabilitiesList, v1.Capability(capability))
+		sCapabilitiesList = append(sCapabilitiesList, corev1.Capability(capability))
 	}
 
-	builder.definition.SecurityContext = &v1.SecurityContext{
-		Capabilities: &v1.Capabilities{
+	builder.definition.SecurityContext = &corev1.SecurityContext{
+		Capabilities: &corev1.Capabilities{
 			Add: sCapabilitiesList,
 		},
 	}
@@ -128,9 +128,9 @@ func (builder *ContainerBuilder) WithDropSecurityCapabilities(sCapabilities []st
 		return builder
 	}
 
-	var sCapabilitiesList []v1.Capability
+	var sCapabilitiesList []corev1.Capability
 	for _, capability := range sCapabilities {
-		sCapabilitiesList = append(sCapabilitiesList, v1.Capability(capability))
+		sCapabilitiesList = append(sCapabilitiesList, corev1.Capability(capability))
 	}
 
 	// filter possible duplicated capabilities from user's input
@@ -163,13 +163,13 @@ func (builder *ContainerBuilder) WithDropSecurityCapabilities(sCapabilities []st
 	if builder.definition.SecurityContext == nil {
 		glog.V(100).Infof("SecurityContext is nil. Initializing one")
 
-		builder.definition.SecurityContext = new(v1.SecurityContext)
+		builder.definition.SecurityContext = new(corev1.SecurityContext)
 	}
 
 	if builder.definition.SecurityContext.Capabilities == nil {
 		glog.V(100).Infof("Capabilities are nil. Initializing one")
 
-		builder.definition.SecurityContext.Capabilities = new(v1.Capabilities)
+		builder.definition.SecurityContext.Capabilities = new(corev1.Capabilities)
 	}
 
 	if !redefine {
@@ -190,7 +190,7 @@ func (builder *ContainerBuilder) WithDropSecurityCapabilities(sCapabilities []st
 }
 
 // WithSecurityContext applies security Context on container.
-func (builder *ContainerBuilder) WithSecurityContext(securityContext *v1.SecurityContext) *ContainerBuilder {
+func (builder *ContainerBuilder) WithSecurityContext(securityContext *corev1.SecurityContext) *ContainerBuilder {
 	glog.V(100).Infof("Applying custom securityContext %v", securityContext)
 
 	if securityContext == nil {
@@ -235,7 +235,7 @@ func (builder *ContainerBuilder) WithResourceLimit(hugePages, memory string, cpu
 		return builder
 	}
 
-	builder.definition.Resources.Limits = v1.ResourceList{
+	builder.definition.Resources.Limits = corev1.ResourceList{
 		"hugepages-1Gi": resource.MustParse(hugePages),
 		"memory":        resource.MustParse(memory),
 		"cpu":           *resource.NewQuantity(cpu, resource.DecimalSI),
@@ -271,7 +271,7 @@ func (builder *ContainerBuilder) WithResourceRequest(hugePages, memory string, c
 		return builder
 	}
 
-	builder.definition.Resources.Requests = v1.ResourceList{
+	builder.definition.Resources.Requests = corev1.ResourceList{
 		"hugepages-1Gi": resource.MustParse(hugePages),
 		"memory":        resource.MustParse(memory),
 		"cpu":           *resource.NewQuantity(cpu, resource.DecimalSI),
@@ -281,7 +281,7 @@ func (builder *ContainerBuilder) WithResourceRequest(hugePages, memory string, c
 }
 
 // WithCustomResourcesLimits applies custom resource limit struct on container.
-func (builder *ContainerBuilder) WithCustomResourcesLimits(resourceList v1.ResourceList) *ContainerBuilder {
+func (builder *ContainerBuilder) WithCustomResourcesLimits(resourceList corev1.ResourceList) *ContainerBuilder {
 	glog.V(100).Infof("Applying custom resource limit to container: %v", resourceList)
 
 	if len(resourceList) == 0 {
@@ -300,7 +300,7 @@ func (builder *ContainerBuilder) WithCustomResourcesLimits(resourceList v1.Resou
 }
 
 // WithImagePullPolicy applies specific image pull policy on container.
-func (builder *ContainerBuilder) WithImagePullPolicy(pullPolicy v1.PullPolicy) *ContainerBuilder {
+func (builder *ContainerBuilder) WithImagePullPolicy(pullPolicy corev1.PullPolicy) *ContainerBuilder {
 	glog.V(100).Infof("Applying image pull policy to container: %s", pullPolicy)
 
 	if len(pullPolicy) == 0 {
@@ -339,18 +339,18 @@ func (builder *ContainerBuilder) WithEnvVar(name, value string) *ContainerBuilde
 	}
 
 	if builder.definition.Env != nil {
-		builder.definition.Env = append(builder.definition.Env, v1.EnvVar{Name: name, Value: value})
+		builder.definition.Env = append(builder.definition.Env, corev1.EnvVar{Name: name, Value: value})
 
 		return builder
 	}
 
-	builder.definition.Env = []v1.EnvVar{{Name: name, Value: value}}
+	builder.definition.Env = []corev1.EnvVar{{Name: name, Value: value}}
 
 	return builder
 }
 
 // WithVolumeMount adds a pod volume mount inside the container.
-func (builder *ContainerBuilder) WithVolumeMount(volMount v1.VolumeMount) *ContainerBuilder {
+func (builder *ContainerBuilder) WithVolumeMount(volMount corev1.VolumeMount) *ContainerBuilder {
 	glog.V(100).Infof("Adding VolumeMount to the %s container's definition", builder.definition.Name)
 
 	if volMount.Name == "" {
@@ -376,7 +376,7 @@ func (builder *ContainerBuilder) WithVolumeMount(volMount v1.VolumeMount) *Conta
 }
 
 // GetContainerCfg returns Container struct.
-func (builder *ContainerBuilder) GetContainerCfg() (*v1.Container, error) {
+func (builder *ContainerBuilder) GetContainerCfg() (*corev1.Container, error) {
 	glog.V(100).Infof("Returning configuration for container %s", builder.definition.Name)
 
 	if builder.errorMsg != "" {
@@ -401,9 +401,9 @@ func areCapabilitiesValid(capabilities []string) bool {
 }
 
 // uniqueCapabilities filters duplicated Security Capabilities from the provided list.
-func uniqueCapabilities(sCap []v1.Capability) []v1.Capability {
-	uniqMap := make(map[v1.Capability]bool)
-	uniqSlice := []v1.Capability{}
+func uniqueCapabilities(sCap []corev1.Capability) []corev1.Capability {
+	uniqMap := make(map[corev1.Capability]bool)
+	uniqSlice := []corev1.Capability{}
 
 	for _, val := range sCap {
 		uniqMap[val] = true
@@ -417,8 +417,8 @@ func uniqueCapabilities(sCap []v1.Capability) []v1.Capability {
 }
 
 // capabilitiesIntersection returns an intersection of 2 Security Capabilities lists.
-func capabilitiesIntersection(aCaps, bCaps []v1.Capability) []v1.Capability {
-	var resultCaps []v1.Capability
+func capabilitiesIntersection(aCaps, bCaps []corev1.Capability) []corev1.Capability {
+	var resultCaps []corev1.Capability
 
 	for _, bVal := range bCaps {
 		found := false
@@ -440,8 +440,8 @@ func capabilitiesIntersection(aCaps, bCaps []v1.Capability) []v1.Capability {
 }
 
 // capabilitiesDifference returns a difference of 2 Security Capabilities lists.
-func capabilitiesDifference(aCaps, bCaps []v1.Capability) []v1.Capability {
-	var resultCaps []v1.Capability
+func capabilitiesDifference(aCaps, bCaps []corev1.Capability) []corev1.Capability {
+	var resultCaps []corev1.Capability
 
 	for _, bVal := range bCaps {
 		found := false

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -9,7 +9,7 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
 	v1 "github.com/openshift/api/config/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -33,7 +33,7 @@ func Pull(apiClient *clients.Settings) (*Builder, error) {
 	builder := Builder{
 		apiClient: apiClient,
 		Definition: &v1.Proxy{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: clusterProxyName,
 			},
 		},
@@ -60,7 +60,7 @@ func (builder *Builder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.ConfigV1Interface.Proxies().Get(
-		context.Background(), builder.Definition.Name, metaV1.GetOptions{})
+		context.Background(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }

--- a/pkg/rbac/clusterrole.go
+++ b/pkg/rbac/clusterrole.go
@@ -9,7 +9,7 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
 	v1 "k8s.io/api/rbac/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 /*
@@ -41,7 +41,7 @@ func NewClusterRoleBuilder(apiClient *clients.Settings, name string, rule v1.Pol
 	builder := ClusterRoleBuilder{
 		apiClient: apiClient,
 		Definition: &v1.ClusterRole{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 			},
 			Rules: []v1.PolicyRule{rule},
@@ -133,7 +133,7 @@ func PullClusterRole(apiClient *clients.Settings, name string) (*ClusterRoleBuil
 	builder := ClusterRoleBuilder{
 		apiClient: apiClient,
 		Definition: &v1.ClusterRole{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 			},
 		},
@@ -166,7 +166,7 @@ func (builder *ClusterRoleBuilder) Create() (*ClusterRoleBuilder, error) {
 	var err error
 	if !builder.Exists() {
 		builder.Object, err = builder.apiClient.ClusterRoles().Create(
-			context.TODO(), builder.Definition, metaV1.CreateOptions{})
+			context.TODO(), builder.Definition, metav1.CreateOptions{})
 	}
 
 	return builder, err
@@ -186,7 +186,7 @@ func (builder *ClusterRoleBuilder) Delete() error {
 	}
 
 	err := builder.apiClient.ClusterRoles().Delete(
-		context.TODO(), builder.Object.Name, metaV1.DeleteOptions{})
+		context.TODO(), builder.Object.Name, metav1.DeleteOptions{})
 
 	if err != nil {
 		return err
@@ -208,7 +208,7 @@ func (builder *ClusterRoleBuilder) Update() (*ClusterRoleBuilder, error) {
 
 	var err error
 	builder.Object, err = builder.apiClient.ClusterRoles().Update(
-		context.TODO(), builder.Definition, metaV1.UpdateOptions{})
+		context.TODO(), builder.Definition, metav1.UpdateOptions{})
 
 	return builder, err
 }
@@ -224,7 +224,7 @@ func (builder *ClusterRoleBuilder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.ClusterRoles().Get(
-		context.Background(), builder.Definition.Name, metaV1.GetOptions{})
+		context.Background(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }

--- a/pkg/rbac/clusterrolebinding.go
+++ b/pkg/rbac/clusterrolebinding.go
@@ -10,7 +10,7 @@ import (
 	"golang.org/x/exp/slices"
 	v1 "k8s.io/api/rbac/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // ClusterRoleBindingBuilder provides struct for clusterrolebinding object
@@ -40,7 +40,7 @@ func NewClusterRoleBindingBuilder(
 	builder := ClusterRoleBindingBuilder{
 		apiClient: apiClient,
 		Definition: &v1.ClusterRoleBinding{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 			},
 			RoleRef: v1.RoleRef{
@@ -137,7 +137,7 @@ func PullClusterRoleBinding(apiClient *clients.Settings, name string) (*ClusterR
 	builder := ClusterRoleBindingBuilder{
 		apiClient: apiClient,
 		Definition: &v1.ClusterRoleBinding{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 			},
 		},
@@ -170,7 +170,7 @@ func (builder *ClusterRoleBindingBuilder) Create() (*ClusterRoleBindingBuilder, 
 	var err error
 	if !builder.Exists() {
 		builder.Object, err = builder.apiClient.ClusterRoleBindings().Create(
-			context.TODO(), builder.Definition, metaV1.CreateOptions{})
+			context.TODO(), builder.Definition, metav1.CreateOptions{})
 	}
 
 	return builder, err
@@ -190,7 +190,7 @@ func (builder *ClusterRoleBindingBuilder) Delete() error {
 	}
 
 	err := builder.apiClient.ClusterRoleBindings().Delete(
-		context.TODO(), builder.Object.Name, metaV1.DeleteOptions{})
+		context.TODO(), builder.Object.Name, metav1.DeleteOptions{})
 
 	if err != nil {
 		return err
@@ -212,7 +212,7 @@ func (builder *ClusterRoleBindingBuilder) Update() (*ClusterRoleBindingBuilder, 
 
 	var err error
 	builder.Object, err = builder.apiClient.ClusterRoleBindings().Update(
-		context.TODO(), builder.Definition, metaV1.UpdateOptions{})
+		context.TODO(), builder.Definition, metav1.UpdateOptions{})
 
 	return builder, err
 }
@@ -228,7 +228,7 @@ func (builder *ClusterRoleBindingBuilder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.ClusterRoleBindings().Get(
-		context.Background(), builder.Definition.Name, metaV1.GetOptions{})
+		context.Background(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }

--- a/pkg/rbac/role.go
+++ b/pkg/rbac/role.go
@@ -9,7 +9,7 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
 	v1 "k8s.io/api/rbac/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // RoleBuilder provides a struct for role object containing connection to the cluster and the role definitions.
@@ -37,7 +37,7 @@ func NewRoleBuilder(apiClient *clients.Settings, name, nsname string, rule v1.Po
 	builder := RoleBuilder{
 		apiClient: apiClient,
 		Definition: &v1.Role{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			},
@@ -146,7 +146,7 @@ func PullRole(apiClient *clients.Settings, name, nsname string) (*RoleBuilder, e
 	builder := RoleBuilder{
 		apiClient: apiClient,
 		Definition: &v1.Role{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			},
@@ -186,7 +186,7 @@ func (builder *RoleBuilder) Create() (*RoleBuilder, error) {
 	var err error
 	if !builder.Exists() {
 		builder.Object, err = builder.apiClient.Roles(builder.Definition.Namespace).Create(
-			context.TODO(), builder.Definition, metaV1.CreateOptions{})
+			context.TODO(), builder.Definition, metav1.CreateOptions{})
 	}
 
 	return builder, err
@@ -206,7 +206,7 @@ func (builder *RoleBuilder) Delete() error {
 	}
 
 	err := builder.apiClient.Roles(builder.Definition.Namespace).Delete(
-		context.TODO(), builder.Object.Name, metaV1.DeleteOptions{})
+		context.TODO(), builder.Object.Name, metav1.DeleteOptions{})
 
 	if err != nil {
 		return err
@@ -228,7 +228,7 @@ func (builder *RoleBuilder) Update() (*RoleBuilder, error) {
 
 	var err error
 	builder.Object, err = builder.apiClient.Roles(builder.Definition.Namespace).Update(
-		context.TODO(), builder.Definition, metaV1.UpdateOptions{})
+		context.TODO(), builder.Definition, metav1.UpdateOptions{})
 
 	return builder, err
 }
@@ -244,7 +244,7 @@ func (builder *RoleBuilder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.Roles(builder.Definition.Namespace).Get(
-		context.Background(), builder.Definition.Name, metaV1.GetOptions{})
+		context.Background(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }

--- a/pkg/rbac/rolebinding.go
+++ b/pkg/rbac/rolebinding.go
@@ -10,7 +10,7 @@ import (
 	"golang.org/x/exp/slices"
 	v1 "k8s.io/api/rbac/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // RoleBindingBuilder provides struct for RoleBinding object containing connection
@@ -41,7 +41,7 @@ func NewRoleBindingBuilder(apiClient *clients.Settings,
 	builder := RoleBindingBuilder{
 		apiClient: apiClient,
 		Definition: &v1.RoleBinding{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			},
@@ -143,7 +143,7 @@ func PullRoleBinding(apiClient *clients.Settings, name, nsname string) (*RoleBin
 	builder := RoleBindingBuilder{
 		apiClient: apiClient,
 		Definition: &v1.RoleBinding{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			},
@@ -183,7 +183,7 @@ func (builder *RoleBindingBuilder) Create() (*RoleBindingBuilder, error) {
 	var err error
 	if !builder.Exists() {
 		builder.Object, err = builder.apiClient.RoleBindings(builder.Definition.Namespace).Create(
-			context.TODO(), builder.Definition, metaV1.CreateOptions{})
+			context.TODO(), builder.Definition, metav1.CreateOptions{})
 	}
 
 	return builder, err
@@ -203,7 +203,7 @@ func (builder *RoleBindingBuilder) Delete() error {
 	}
 
 	err := builder.apiClient.RoleBindings(builder.Definition.Namespace).Delete(
-		context.TODO(), builder.Object.Name, metaV1.DeleteOptions{})
+		context.TODO(), builder.Object.Name, metav1.DeleteOptions{})
 
 	builder.Object = nil
 
@@ -221,7 +221,7 @@ func (builder *RoleBindingBuilder) Update() (*RoleBindingBuilder, error) {
 
 	var err error
 	builder.Object, err = builder.apiClient.RoleBindings(builder.Definition.Namespace).Update(
-		context.TODO(), builder.Definition, metaV1.UpdateOptions{})
+		context.TODO(), builder.Definition, metav1.UpdateOptions{})
 
 	return builder, err
 }
@@ -237,7 +237,7 @@ func (builder *RoleBindingBuilder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.RoleBindings(builder.Definition.Namespace).Get(
-		context.Background(), builder.Definition.Name, metaV1.GetOptions{})
+		context.Background(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }

--- a/pkg/scc/scc.go
+++ b/pkg/scc/scc.go
@@ -8,9 +8,9 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
 	securityV1 "github.com/openshift/api/security/v1"
-	coreV1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const redefiningMsg = "Redefining SecurityContextConstraints"
@@ -40,7 +40,7 @@ func NewBuilder(apiClient *clients.Settings, name, runAsUser, selinuxContext str
 	builder := Builder{
 		apiClient: apiClient,
 		Definition: &securityV1.SecurityContextConstraints{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 			},
 			RunAsUser: securityV1.RunAsUserStrategyOptions{
@@ -80,7 +80,7 @@ func Pull(apiClient *clients.Settings, name string) (*Builder, error) {
 	builder := Builder{
 		apiClient: apiClient,
 		Definition: &securityV1.SecurityContextConstraints{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 			},
 		},
@@ -213,7 +213,7 @@ func (builder *Builder) WithReadOnlyRootFilesystem(readOnlyRootFilesystem bool) 
 }
 
 // WithDropCapabilities adds list of drop capabilities to SecurityContextConstraints.
-func (builder *Builder) WithDropCapabilities(requiredDropCapabilities []coreV1.Capability) *Builder {
+func (builder *Builder) WithDropCapabilities(requiredDropCapabilities []corev1.Capability) *Builder {
 	if valid, _ := builder.validate(); !valid {
 		return builder
 	}
@@ -242,7 +242,7 @@ func (builder *Builder) WithDropCapabilities(requiredDropCapabilities []coreV1.C
 }
 
 // WithAllowCapabilities adds list of allow capabilities to SecurityContextConstraints.
-func (builder *Builder) WithAllowCapabilities(allowCapabilities []coreV1.Capability) *Builder {
+func (builder *Builder) WithAllowCapabilities(allowCapabilities []corev1.Capability) *Builder {
 	if valid, _ := builder.validate(); !valid {
 		return builder
 	}
@@ -270,7 +270,7 @@ func (builder *Builder) WithAllowCapabilities(allowCapabilities []coreV1.Capabil
 }
 
 // WithDefaultAddCapabilities adds list of defaultAddCapabilities to SecurityContextConstraints.
-func (builder *Builder) WithDefaultAddCapabilities(defaultAddCapabilities []coreV1.Capability) *Builder {
+func (builder *Builder) WithDefaultAddCapabilities(defaultAddCapabilities []corev1.Capability) *Builder {
 	if valid, _ := builder.validate(); !valid {
 		return builder
 	}
@@ -503,7 +503,7 @@ func (builder *Builder) Create() (*Builder, error) {
 	var err error
 	if !builder.Exists() {
 		builder.Object, err = builder.apiClient.SecurityContextConstraints().Create(
-			context.TODO(), builder.Definition, metaV1.CreateOptions{})
+			context.TODO(), builder.Definition, metav1.CreateOptions{})
 	}
 
 	return builder, err
@@ -522,7 +522,7 @@ func (builder *Builder) Delete() error {
 	}
 
 	err := builder.apiClient.SecurityContextConstraints().Delete(
-		context.TODO(), builder.Object.Name, metaV1.DeleteOptions{})
+		context.TODO(), builder.Object.Name, metav1.DeleteOptions{})
 
 	builder.Object = nil
 
@@ -539,7 +539,7 @@ func (builder *Builder) Update() (*Builder, error) {
 
 	var err error
 	builder.Object, err = builder.apiClient.SecurityContextConstraints().Update(
-		context.TODO(), builder.Definition, metaV1.UpdateOptions{})
+		context.TODO(), builder.Definition, metav1.UpdateOptions{})
 
 	return builder, err
 }
@@ -554,7 +554,7 @@ func (builder *Builder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.SecurityContextConstraints().Get(
-		context.Background(), builder.Definition.Name, metaV1.GetOptions{})
+		context.Background(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }

--- a/pkg/secret/secret.go
+++ b/pkg/secret/secret.go
@@ -7,17 +7,17 @@ import (
 	"github.com/golang/glog"
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Builder provides struct for secret object containing connection to the cluster and the secret definitions.
 type Builder struct {
 	// Secret definition. Used to store the secret object.
-	Definition *v1.Secret
+	Definition *corev1.Secret
 	// Created secret object.
-	Object *v1.Secret
+	Object *corev1.Secret
 	// Used in functions that define or mutate secret definitions. errorMsg is processed before the secret
 	// object is created.
 	errorMsg  string
@@ -28,15 +28,15 @@ type Builder struct {
 type AdditionalOptions func(builder *Builder) (*Builder, error)
 
 // NewBuilder creates a new instance of Builder.
-func NewBuilder(apiClient *clients.Settings, name, nsname string, secretType v1.SecretType) *Builder {
+func NewBuilder(apiClient *clients.Settings, name, nsname string, secretType corev1.SecretType) *Builder {
 	glog.V(100).Infof(
 		"Initializing new secret structure with the following params: %s, %s, %s",
 		name, nsname, string(secretType))
 
 	builder := Builder{
 		apiClient: apiClient,
-		Definition: &v1.Secret{
-			ObjectMeta: metaV1.ObjectMeta{
+		Definition: &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			},
@@ -65,8 +65,8 @@ func Pull(apiClient *clients.Settings, name, nsname string) (*Builder, error) {
 
 	builder := Builder{
 		apiClient: apiClient,
-		Definition: &v1.Secret{
-			ObjectMeta: metaV1.ObjectMeta{
+		Definition: &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			},
@@ -101,7 +101,7 @@ func (builder *Builder) Create() (*Builder, error) {
 	var err error
 	if !builder.Exists() {
 		builder.Object, err = builder.apiClient.Secrets(builder.Definition.Namespace).Create(
-			context.TODO(), builder.Definition, metaV1.CreateOptions{})
+			context.TODO(), builder.Definition, metav1.CreateOptions{})
 	}
 
 	return builder, err
@@ -120,7 +120,7 @@ func (builder *Builder) Delete() error {
 	}
 
 	err := builder.apiClient.Secrets(builder.Definition.Namespace).Delete(
-		context.TODO(), builder.Object.Name, metaV1.DeleteOptions{})
+		context.TODO(), builder.Object.Name, metav1.DeleteOptions{})
 
 	if err != nil {
 		return err
@@ -143,7 +143,7 @@ func (builder *Builder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.Secrets(builder.Definition.Namespace).Get(
-		context.Background(), builder.Definition.Name, metaV1.GetOptions{})
+		context.Background(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }
@@ -160,7 +160,7 @@ func (builder *Builder) Update() (*Builder, error) {
 
 	var err error
 	builder.Object, err = builder.apiClient.Secrets(builder.Definition.Namespace).Update(
-		context.TODO(), builder.Definition, metaV1.UpdateOptions{})
+		context.TODO(), builder.Definition, metav1.UpdateOptions{})
 
 	return builder, err
 }

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -18,9 +18,9 @@ import (
 // Builder provides struct for service object containing connection to the cluster and the service definitions.
 type Builder struct {
 	// Service definition. Used to create a service object
-	Definition *v1.Service
+	Definition *corev1.Service
 	// Created service object
-	Object *v1.Service
+	Object *corev1.Service
 	// Used in functions that define or mutate the service definition.
 	// errorMsg is processed before the service object is created
 	errorMsg  string
@@ -38,20 +38,20 @@ func NewBuilder(
 	name string,
 	nsname string,
 	labels map[string]string,
-	servicePort v1.ServicePort) *Builder {
+	servicePort corev1.ServicePort) *Builder {
 	glog.V(100).Infof(
 		"Initializing new service structure with the following params: %s, %s", name, nsname)
 
 	builder := Builder{
 		apiClient: apiClient,
-		Definition: &v1.Service{
-			ObjectMeta: metaV1.ObjectMeta{
+		Definition: &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			},
-			Spec: v1.ServiceSpec{
+			Spec: corev1.ServiceSpec{
 				Selector: labels,
-				Ports:    []v1.ServicePort{servicePort},
+				Ports:    []corev1.ServicePort{servicePort},
 			},
 		},
 	}
@@ -96,8 +96,8 @@ func Pull(apiClient *clients.Settings, name, nsname string) (*Builder, error) {
 
 	builder := Builder{
 		apiClient: apiClient,
-		Definition: &v1.Service{
-			ObjectMeta: metaV1.ObjectMeta{
+		Definition: &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			},
@@ -132,7 +132,7 @@ func (builder *Builder) Create() (*Builder, error) {
 	var err error
 	if !builder.Exists() {
 		builder.Object, err = builder.apiClient.Services(builder.Definition.Namespace).Create(
-			context.TODO(), builder.Definition, metaV1.CreateOptions{})
+			context.TODO(), builder.Definition, metav1.CreateOptions{})
 	}
 
 	return builder, err
@@ -150,7 +150,7 @@ func (builder *Builder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.Services(builder.Definition.Namespace).Get(
-		context.Background(), builder.Definition.Name, metaV1.GetOptions{})
+		context.Background(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }
@@ -168,7 +168,7 @@ func (builder *Builder) Delete() error {
 	}
 
 	err := builder.apiClient.Services(builder.Definition.Namespace).Delete(
-		context.TODO(), builder.Object.Name, metaV1.DeleteOptions{})
+		context.TODO(), builder.Object.Name, metav1.DeleteOptions{})
 
 	if err != nil {
 		return err
@@ -205,7 +205,7 @@ func (builder *Builder) WithOptions(options ...AdditionalOptions) *Builder {
 }
 
 // WithExternalTrafficPolicy redefines the service with ServiceExternalTrafficPolicy type.
-func (builder *Builder) WithExternalTrafficPolicy(policyType v1.ServiceExternalTrafficPolicyType) *Builder {
+func (builder *Builder) WithExternalTrafficPolicy(policyType corev1.ServiceExternalTrafficPolicyType) *Builder {
 	if valid, _ := builder.validate(); !valid {
 		return builder
 	}
@@ -259,7 +259,7 @@ func (builder *Builder) WithAnnotation(annotation map[string]string) *Builder {
 }
 
 // WithIPFamily redefines the service with IPFamilies type.
-func (builder *Builder) WithIPFamily(ipFamily []v1.IPFamily, ipStackPolicy v1.IPFamilyPolicyType) *Builder {
+func (builder *Builder) WithIPFamily(ipFamily []corev1.IPFamily, ipStackPolicy corev1.IPFamilyPolicyType) *Builder {
 	if valid, _ := builder.validate(); !valid {
 		return builder
 	}
@@ -291,7 +291,7 @@ func (builder *Builder) WithIPFamily(ipFamily []v1.IPFamily, ipStackPolicy v1.IP
 }
 
 // DefineServicePort helper for creating a Service with a ServicePort.
-func DefineServicePort(port, targetPort int32, protocol v1.Protocol) (*v1.ServicePort, error) {
+func DefineServicePort(port, targetPort int32, protocol corev1.Protocol) (*corev1.ServicePort, error) {
 	glog.V(100).Infof(
 		"Defining ServicePort with port %d and targetport %d", port, targetPort)
 
@@ -303,7 +303,7 @@ func DefineServicePort(port, targetPort int32, protocol v1.Protocol) (*v1.Servic
 		return nil, fmt.Errorf("invalid target port number")
 	}
 
-	return &v1.ServicePort{
+	return &corev1.ServicePort{
 		Protocol: protocol,
 		Port:     port,
 		TargetPort: intstr.IntOrString{

--- a/pkg/serviceaccount/serviceaccount.go
+++ b/pkg/serviceaccount/serviceaccount.go
@@ -7,18 +7,18 @@ import (
 	"github.com/golang/glog"
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Builder provides struct for serviceaccount object containing connection to the cluster and the
 // serviceaccount definitions.
 type Builder struct {
 	// ServiceAccount definition. Used to create serviceaccount object.
-	Definition *v1.ServiceAccount
+	Definition *corev1.ServiceAccount
 	// Created serviceaccount object.
-	Object *v1.ServiceAccount
+	Object *corev1.ServiceAccount
 	// Used in functions that defines or mutates configmap definition. errorMsg is processed before the configmap
 	// object is created.
 	errorMsg  string
@@ -34,8 +34,8 @@ func NewBuilder(apiClient *clients.Settings, name, nsname string) *Builder {
 
 	builder := Builder{
 		apiClient: apiClient,
-		Definition: &v1.ServiceAccount{
-			ObjectMeta: metaV1.ObjectMeta{
+		Definition: &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			},
@@ -63,8 +63,8 @@ func Pull(apiClient *clients.Settings, name, nsname string) (*Builder, error) {
 
 	builder := Builder{
 		apiClient: apiClient,
-		Definition: &v1.ServiceAccount{
-			ObjectMeta: metaV1.ObjectMeta{
+		Definition: &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			},
@@ -101,7 +101,7 @@ func (builder *Builder) Create() (*Builder, error) {
 	var err error
 	if !builder.Exists() {
 		builder.Object, err = builder.apiClient.ServiceAccounts(builder.Definition.Namespace).Create(
-			context.TODO(), builder.Definition, metaV1.CreateOptions{})
+			context.TODO(), builder.Definition, metav1.CreateOptions{})
 	}
 
 	return builder, err
@@ -122,7 +122,7 @@ func (builder *Builder) Delete() error {
 	}
 
 	err := builder.apiClient.ServiceAccounts(builder.Definition.Namespace).Delete(
-		context.TODO(), builder.Definition.Name, metaV1.DeleteOptions{})
+		context.TODO(), builder.Definition.Name, metav1.DeleteOptions{})
 
 	if err != nil {
 		return err
@@ -145,7 +145,7 @@ func (builder *Builder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.ServiceAccounts(builder.Definition.Namespace).Get(
-		context.Background(), builder.Definition.Name, metaV1.GetOptions{})
+		context.Background(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }

--- a/pkg/sriov/network.go
+++ b/pkg/sriov/network.go
@@ -14,7 +14,7 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"golang.org/x/exp/slices"
 
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // NetworkBuilder provides struct for srIovNetwork object which contains connection to cluster and
@@ -40,7 +40,7 @@ func NewNetworkBuilder(
 	builder := NetworkBuilder{
 		apiClient: apiClient,
 		Definition: &srIovV1.SriovNetwork{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			},
@@ -248,7 +248,7 @@ func PullNetwork(apiClient *clients.Settings, name, nsname string) (*NetworkBuil
 	builder := NetworkBuilder{
 		apiClient: apiClient,
 		Definition: &srIovV1.SriovNetwork{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			},
@@ -285,7 +285,7 @@ func (builder *NetworkBuilder) Create() (*NetworkBuilder, error) {
 	if !builder.Exists() {
 		var err error
 		builder.Object, err = builder.apiClient.SriovNetworks(builder.Definition.Namespace).Create(
-			context.TODO(), builder.Definition, metaV1.CreateOptions{},
+			context.TODO(), builder.Definition, metav1.CreateOptions{},
 		)
 
 		if err != nil {
@@ -307,7 +307,7 @@ func (builder *NetworkBuilder) Delete() error {
 	}
 
 	err := builder.apiClient.SriovNetworks(builder.Definition.Namespace).Delete(
-		context.TODO(), builder.Object.Name, metaV1.DeleteOptions{})
+		context.TODO(), builder.Object.Name, metav1.DeleteOptions{})
 
 	if err != nil {
 		return err
@@ -326,7 +326,7 @@ func (builder *NetworkBuilder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.SriovNetworks(builder.Definition.Namespace).Get(
-		context.Background(), builder.Definition.Name, metaV1.GetOptions{})
+		context.Background(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }

--- a/pkg/sriov/networklist.go
+++ b/pkg/sriov/networklist.go
@@ -6,18 +6,18 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // List returns sriov networks in the given namespace.
-func List(apiClient *clients.Settings, nsname string, options ...metaV1.ListOptions) ([]*NetworkBuilder, error) {
+func List(apiClient *clients.Settings, nsname string, options ...metav1.ListOptions) ([]*NetworkBuilder, error) {
 	if nsname == "" {
 		glog.V(100).Infof("sriov network 'nsname' parameter can not be empty")
 
 		return nil, fmt.Errorf("failed to list sriov networks, 'nsname' parameter is empty")
 	}
 
-	passedOptions := metaV1.ListOptions{}
+	passedOptions := metav1.ListOptions{}
 	logMessage := fmt.Sprintf("Listing sriov networks in the namespace %s", nsname)
 
 	if len(options) > 1 {
@@ -62,7 +62,7 @@ func CleanAllNetworksByTargetNamespace(
 	apiClient *clients.Settings,
 	operatornsname string,
 	targetnsname string,
-	options ...metaV1.ListOptions) error {
+	options ...metav1.ListOptions) error {
 	glog.V(100).Infof("Cleaning up sriov networks in the %s namespace with %s NetworkNamespace spec",
 		operatornsname, targetnsname)
 

--- a/pkg/sriov/networknodestatelist.go
+++ b/pkg/sriov/networknodestatelist.go
@@ -6,12 +6,12 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // ListNetworkNodeState returns SriovNetworkNodeStates inventory in the given namespace.
 func ListNetworkNodeState(
-	apiClient *clients.Settings, nsname string, options ...metaV1.ListOptions) ([]*NetworkNodeStateBuilder, error) {
+	apiClient *clients.Settings, nsname string, options ...metav1.ListOptions) ([]*NetworkNodeStateBuilder, error) {
 	if nsname == "" {
 		glog.V(100).Infof("SriovNetworkNodeStates 'nsname' parameter can not be empty")
 
@@ -19,7 +19,7 @@ func ListNetworkNodeState(
 	}
 
 	logMessage := fmt.Sprintf("Listing SriovNetworkNodeStates in the namespace %s", nsname)
-	passedOptions := metaV1.ListOptions{}
+	passedOptions := metav1.ListOptions{}
 
 	if len(options) > 1 {
 		glog.V(100).Infof("'options' parameter must be empty or single-valued")

--- a/pkg/sriov/policy.go
+++ b/pkg/sriov/policy.go
@@ -11,7 +11,7 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"golang.org/x/exp/slices"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // PolicyBuilder provides struct for srIovPolicy object containing connection to the cluster and the srIovPolicy
@@ -43,7 +43,7 @@ func NewPolicyBuilder(
 	builder := PolicyBuilder{
 		apiClient: apiClient,
 		Definition: &srIovV1.SriovNetworkNodePolicy{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			},
@@ -219,7 +219,7 @@ func PullPolicy(apiClient *clients.Settings, name, nsname string) (*PolicyBuilde
 	builder := PolicyBuilder{
 		apiClient: apiClient,
 		Definition: &srIovV1.SriovNetworkNodePolicy{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			},
@@ -256,7 +256,7 @@ func (builder *PolicyBuilder) Create() (*PolicyBuilder, error) {
 	if !builder.Exists() {
 		var err error
 		builder.Object, err = builder.apiClient.SriovNetworkNodePolicies(builder.Definition.Namespace).Create(
-			context.TODO(), builder.Definition, metaV1.CreateOptions{},
+			context.TODO(), builder.Definition, metav1.CreateOptions{},
 		)
 
 		if err != nil {
@@ -278,7 +278,7 @@ func (builder *PolicyBuilder) Delete() error {
 	}
 
 	err := builder.apiClient.SriovNetworkNodePolicies(builder.Definition.Namespace).Delete(
-		context.TODO(), builder.Definition.Name, metaV1.DeleteOptions{})
+		context.TODO(), builder.Definition.Name, metav1.DeleteOptions{})
 
 	if err != nil {
 		return err
@@ -297,7 +297,7 @@ func (builder *PolicyBuilder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.SriovNetworkNodePolicies(builder.Definition.Namespace).Get(
-		context.Background(), builder.Definition.Name, metaV1.GetOptions{})
+		context.Background(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }

--- a/pkg/sriov/policylist.go
+++ b/pkg/sriov/policylist.go
@@ -6,18 +6,18 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // ListPolicy returns SriovNetworkNodePolicies inventory in the given namespace.
-func ListPolicy(apiClient *clients.Settings, nsname string, options ...metaV1.ListOptions) ([]*PolicyBuilder, error) {
+func ListPolicy(apiClient *clients.Settings, nsname string, options ...metav1.ListOptions) ([]*PolicyBuilder, error) {
 	if nsname == "" {
 		glog.V(100).Infof("SriovNetworkNodePolicies 'nsname' parameter can not be empty")
 
 		return nil, fmt.Errorf("failed to list SriovNetworkNodePolicies, 'nsname' parameter is empty")
 	}
 
-	passedOptions := metaV1.ListOptions{}
+	passedOptions := metav1.ListOptions{}
 	logMessage := fmt.Sprintf("Listing SriovNetworkNodePolicies in the namespace %s", nsname)
 
 	if len(options) > 1 {
@@ -59,7 +59,7 @@ func ListPolicy(apiClient *clients.Settings, nsname string, options ...metaV1.Li
 
 // CleanAllNetworkNodePolicies removes all SriovNetworkNodePolicies that are not set as default.
 func CleanAllNetworkNodePolicies(
-	apiClient *clients.Settings, operatornsname string, options ...metaV1.ListOptions) error {
+	apiClient *clients.Settings, operatornsname string, options ...metav1.ListOptions) error {
 	glog.V(100).Infof("Cleaning up SriovNetworkNodePolicies in the %s namespace", operatornsname)
 
 	if operatornsname == "" {

--- a/pkg/statefulset/list.go
+++ b/pkg/statefulset/list.go
@@ -6,18 +6,18 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // List returns statefulset inventory in the given namespace.
-func List(apiClient *clients.Settings, nsname string, options ...metaV1.ListOptions) ([]*Builder, error) {
+func List(apiClient *clients.Settings, nsname string, options ...metav1.ListOptions) ([]*Builder, error) {
 	if nsname == "" {
 		glog.V(100).Infof("statefulset 'nsname' parameter can not be empty")
 
 		return nil, fmt.Errorf("failed to list statefulsets, 'nsname' parameter is empty")
 	}
 
-	passedOptions := metaV1.ListOptions{}
+	passedOptions := metav1.ListOptions{}
 	logMessage := fmt.Sprintf("Listing statefulsets in the namespace %s", nsname)
 
 	if len(options) > 1 {

--- a/pkg/storage/pv.go
+++ b/pkg/storage/pv.go
@@ -7,18 +7,18 @@ import (
 	"github.com/golang/glog"
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // PVBuilder provides struct for persistentvolume object containing connection
 // to the cluster and the persistentvolume definitions.
 type PVBuilder struct {
 	// PersistentVolume definition. Used to create a persistentvolume object
-	Definition *v1.PersistentVolume
+	Definition *corev1.PersistentVolume
 	// Created persistentvolume object
-	Object *v1.PersistentVolume
+	Object *corev1.PersistentVolume
 
 	apiClient *clients.Settings
 }
@@ -29,8 +29,8 @@ func PullPersistentVolume(apiClient *clients.Settings, persistentVolume string) 
 
 	builder := PVBuilder{
 		apiClient: apiClient,
-		Definition: &v1.PersistentVolume{
-			ObjectMeta: metaV1.ObjectMeta{
+		Definition: &corev1.PersistentVolume{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: persistentVolume,
 			},
 		},
@@ -55,7 +55,7 @@ func (builder *PVBuilder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.PersistentVolumes().Get(
-		context.Background(), builder.Definition.Name, metaV1.GetOptions{})
+		context.Background(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }

--- a/pkg/storage/storageclass.go
+++ b/pkg/storage/storageclass.go
@@ -7,10 +7,10 @@ import (
 	"github.com/golang/glog"
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	storageV1 "k8s.io/api/storage/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // ClassBuilder provides struct for storageclass object containing
@@ -38,7 +38,7 @@ func NewClassBuilder(apiClient *clients.Settings, name, provisioner string) *Cla
 	builder := ClassBuilder{
 		apiClient: apiClient,
 		Definition: &storageV1.StorageClass{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 			},
 			Provisioner: provisioner,
@@ -62,7 +62,7 @@ func NewClassBuilder(apiClient *clients.Settings, name, provisioner string) *Cla
 
 // WithReclaimPolicy adds a reclaimPolicy to the storageclass definition.
 func (builder *ClassBuilder) WithReclaimPolicy(
-	reclaimPolicy v1.PersistentVolumeReclaimPolicy) *ClassBuilder {
+	reclaimPolicy corev1.PersistentVolumeReclaimPolicy) *ClassBuilder {
 	if valid, _ := builder.validate(); !valid {
 		return builder
 	}
@@ -171,7 +171,7 @@ func (builder *ClassBuilder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.StorageClasses().Get(
-		context.TODO(), builder.Definition.Name, metaV1.GetOptions{})
+		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }
@@ -187,7 +187,7 @@ func (builder *ClassBuilder) Create() (*ClassBuilder, error) {
 	var err error
 	if !builder.Exists() {
 		builder.Object, err = builder.apiClient.StorageClasses().Create(
-			context.TODO(), builder.Definition, metaV1.CreateOptions{})
+			context.TODO(), builder.Definition, metav1.CreateOptions{})
 	}
 
 	return builder, err
@@ -206,7 +206,7 @@ func (builder *ClassBuilder) Delete() error {
 	}
 
 	err := builder.apiClient.StorageClasses().Delete(
-		context.TODO(), builder.Object.Name, metaV1.DeleteOptions{})
+		context.TODO(), builder.Object.Name, metav1.DeleteOptions{})
 
 	if err != nil {
 		return err

--- a/pkg/webhook/mutatingwebhook.go
+++ b/pkg/webhook/mutatingwebhook.go
@@ -9,7 +9,7 @@ import (
 
 	admregv1 "k8s.io/api/admissionregistration/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	goclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -34,7 +34,7 @@ func PullMutatingConfiguration(apiClient *clients.Settings, name string) (*Mutat
 	builder := MutatingConfigurationBuilder{
 		apiClient: apiClient,
 		Definition: &admregv1.MutatingWebhookConfiguration{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 			},
 		},

--- a/pkg/webhook/validatingwebhook.go
+++ b/pkg/webhook/validatingwebhook.go
@@ -9,7 +9,7 @@ import (
 
 	admregv1 "k8s.io/api/admissionregistration/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	goclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -35,7 +35,7 @@ func PullValidatingConfiguration(apiClient *clients.Settings, name string) (
 	builder := ValidatingConfigurationBuilder{
 		apiClient: apiClient,
 		Definition: &admregv1.ValidatingWebhookConfiguration{
-			ObjectMeta: metaV1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 			},
 		},


### PR DESCRIPTION
Be more consistent in import naming.  No functional changes.
- `metaV1` to `metav1`.
- `coreV1` to `corev1`.

Similar to: 
- https://github.com/test-network-function/cnf-certification-test/pull/618
- https://github.com/test-network-function/cnfcert-tests-verification/pull/229