### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+# dependabot config
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Similar to: https://github.com/openshift-kni/eco-gosystem/pull/63 

This will update any Github Actions that this repo is using automatically.

EDIT: After talking with @kononovn I removed the go.mod updates and kept the github actions updates.