### PR TITLE
enable linter on exported functions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -115,6 +115,10 @@ linters:
 output:
   format: colored-line-number
 issues:
+  include:
+    - EXC0002 # disable excluding of issues about comments from golint
+    - EXC0012  # EXC0012 revive: Annoying issue about not having a comment. The rare codebase has such comments
+    - EXC0014  # EXC0014 revive: Annoying issue about not having a comment. The rare codebase has such comments
   exclude-rules:
     #- # Exclude some linters from running on tests files.
     - path: 'pkg/polarion'

--- a/pkg/argocd/applications.go
+++ b/pkg/argocd/applications.go
@@ -16,7 +16,9 @@ import (
 )
 
 const (
-	APIGroup   = "argoproj.io"
+	// APIGroup const definition.
+	APIGroup = "argoproj.io"
+	// APIVersion const definition.
 	APIVersion = "v1alpha1"
 )
 

--- a/pkg/kmm/module.go
+++ b/pkg/kmm/module.go
@@ -300,6 +300,7 @@ func (builder *ModuleBuilder) Create() (*ModuleBuilder, error) {
 	return builder, err
 }
 
+// Update modifies the existing module in the cluster.
 func (builder *ModuleBuilder) Update() (*ModuleBuilder, error) {
 	if valid, err := builder.validate(); !valid {
 		return builder, err

--- a/pkg/lca/seedgenerator.go
+++ b/pkg/lca/seedgenerator.go
@@ -15,7 +15,7 @@ import (
 	goclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// SeedGenerator provides struct for the seedgenerator object containing connection to
+// SeedGeneratorBuilder provides struct for the seedgenerator object containing connection to
 // the cluster and the seedgenerator definitions.
 type SeedGeneratorBuilder struct {
 	// SeedGenerator definition. Used to store the seedgenerator object.
@@ -31,7 +31,7 @@ type SeedGeneratorBuilder struct {
 // SeedGeneratorAdditionalOptions additional options for imagebasedupgrade object.
 type SeedGeneratorAdditionalOptions func(builder *SeedGeneratorBuilder) (*SeedGeneratorBuilder, error)
 
-// NewBuilder creates a new instance of SeedGenerator.
+// NewSeedGeneratorBuilder creates a new instance of SeedGenerator.
 func NewSeedGeneratorBuilder(
 	apiClient *clients.Settings,
 	name string,

--- a/pkg/machine/machineset.go
+++ b/pkg/machine/machineset.go
@@ -33,8 +33,11 @@ type SetBuilder struct {
 }
 
 const (
-	AwsCloud   = "aws"
-	GcpCloud   = "gcp"
+	// AwsCloud const definition.
+	AwsCloud = "aws"
+	// GcpCloud const definition.
+	GcpCloud = "gcp"
+	// AzureCloud const definition.
 	AzureCloud = "azure"
 )
 

--- a/pkg/mco/mcplist.go
+++ b/pkg/mco/mcplist.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
+// ListMCP returns a list of MachineConfigPoolBuilder.
 func ListMCP(apiClient *clients.Settings, options ...metav1.ListOptions) ([]*MCPBuilder, error) {
 	passedOptions := metav1.ListOptions{}
 	logMessage := "Listing all MCP resources"
@@ -53,6 +54,7 @@ func ListMCP(apiClient *clients.Settings, options ...metav1.ListOptions) ([]*MCP
 	return mcpObjects, nil
 }
 
+// ListMCPByMachineConfigSelector returns a list of MachineConfigurationPoolBuilders for given selector.
 func ListMCPByMachineConfigSelector(
 	apiClient *clients.Settings, mcpLabel string, options ...metav1.ListOptions) (*MCPBuilder, error) {
 	glog.V(100).Infof("GetByLabel returns MachineConfigPool with the specified label: %v", mcpLabel)
@@ -82,6 +84,7 @@ func ListMCPByMachineConfigSelector(
 	return nil, fmt.Errorf("cannot find MachineConfigPool that targets machineConfig with label: %s", mcpLabel)
 }
 
+// ListMCPWaitToBeStableFor waits for a given MachineConfigurationPool to be stable for a given period.
 func ListMCPWaitToBeStableFor(
 	apiClient *clients.Settings, stableDuration, timeout time.Duration, options ...metav1.ListOptions) error {
 	glog.V(100).Infof("WaitForMcpListToBeStableFor waits up to duration of %v for "+

--- a/pkg/metallb/mlbtypes/bpgpeer.go
+++ b/pkg/metallb/mlbtypes/bpgpeer.go
@@ -2,6 +2,7 @@ package mlbtypes
 
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+// MatchExpression definition.
 type MatchExpression struct {
 	Key      string `json:"key"`
 	Operator string `json:"operator"`
@@ -9,6 +10,7 @@ type MatchExpression struct {
 	Values []string `json:"values"`
 }
 
+// NodeSelector type definition.
 type NodeSelector struct {
 	// +optional
 	MatchLabels map[string]string `json:"matchLabels,omitempty"`
@@ -85,8 +87,8 @@ type BGPPeer struct {
 	Status BGPPeerStatus `json:"status,omitempty"`
 }
 
+// BGPPeerList contains a list of Peer.
 // +kubebuilder:object:root=true
-// PeerList contains a list of Peer.
 type BGPPeerList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/pkg/metallb/mlbtypes/metallb.go
+++ b/pkg/metallb/mlbtypes/metallb.go
@@ -8,6 +8,7 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
+// MetalLBLogLevel defines MetalLB Log Level.
 type MetalLBLogLevel string
 
 // MetalLBSpec defines the desired state of MetalLB.
@@ -59,6 +60,7 @@ type MetalLBSpec struct {
 	SpeakerConfig *Config `json:"speakerConfig,omitempty"`
 }
 
+// Config type definition.
 type Config struct {
 	// Define priority class name
 	// +optional

--- a/pkg/ocm/placementbinding.go
+++ b/pkg/ocm/placementbinding.go
@@ -13,6 +13,7 @@ import (
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// PlacementBindingBuilder type definition.
 type PlacementBindingBuilder struct {
 	// placementBinding Definition, used to create the placementBinding object.
 	Definition *policiesv1.PlacementBinding

--- a/pkg/ocm/placementrule.go
+++ b/pkg/ocm/placementrule.go
@@ -26,7 +26,7 @@ type PlacementRuleBuilder struct {
 	errorMsg string
 }
 
-// Pull pulls existing placementrule into Builder struct.
+// PullPlacementRule pulls existing placementrule into Builder struct.
 func PullPlacementRule(apiClient *clients.Settings, name, nsname string) (*PlacementRuleBuilder, error) {
 	glog.V(100).Infof("Pulling existing placementrule name %s under namespace %s from cluster", name, nsname)
 


### PR DESCRIPTION
- Enabled the enforcement of comments on exported functions.
- Added basic comments on existing checks that failed linter. 