### PR TITLE
Remove GO111MODULE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-# Export GO111MODULE=on to enable project to be built from within GOPATH/src
-export GO111MODULE=on
 GO_PACKAGES=$(shell go list ./... | grep -v vendor)
 .PHONY: lint \
         deps-update \


### PR DESCRIPTION
Similar to: https://github.com/openshift-kni/cnf-features-deploy/pull/1784

`GO111MODULE=on` is the default behavior as of Go 1.16.  Not needed anymore.