### PR TITLE
Add path for running unit-tests in Makefile

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -25,3 +25,6 @@ jobs:
 
       - name: Run lint
         run: make lint
+
+      - name: Run unit tests
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,6 @@ deps-update:
 install: deps-update
 	@echo "Installing needed dependencies"
 
+test:
+	go test ./...
+


### PR DESCRIPTION
Adds the path `make test` to the Makefile and to the Github workflow.

Lays the groundwork for being able to run unit tests locally and in the CI.