### PR TITLE
Add sriovfec pkg

### DIFF
--- a/pkg/sriov-fec/const.go
+++ b/pkg/sriov-fec/const.go
@@ -1,0 +1,8 @@
+package sriovfec
+
+const (
+	// APIGroup represents sriovfecnodeconfig api group.
+	APIGroup = "sriovfec.intel.com"
+	// APIVersion represents version of sriovfecnodeconfig api.
+	APIVersion = "v2"
+)

--- a/pkg/sriov-fec/nodeconfig.go
+++ b/pkg/sriov-fec/nodeconfig.go
@@ -1,0 +1,352 @@
+package sriovfec
+
+import (
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"context"
+	"fmt"
+
+	"github.com/golang/glog"
+	"github.com/openshift-kni/eco-goinfra/pkg/clients"
+	"github.com/openshift-kni/eco-goinfra/pkg/msg"
+	"github.com/openshift-kni/eco-goinfra/pkg/sriov-fec/sriovfectypes"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const (
+	sriovfecnodeconfig = "SriovFecNodeConfig"
+)
+
+// NodeConfigBuilder provides struct for the SriovFecNodeConfig object containing connection to
+// the cluster and the SriovFecNodeConfig definitions.
+type NodeConfigBuilder struct {
+	// SriovFecNodeConfig definition. Used to create SriovFecNodeConfig object.
+	Definition *sriovfectypes.SriovFecNodeConfig
+	// Create SriovFecNodeConfig object.
+	Object *sriovfectypes.SriovFecNodeConfig
+	// apiClient opens a connection to the cluster.
+	apiClient *clients.Settings
+	// Used in functions that define SriovFecNodeConfig definitions. errorMsg is processed before SriovFecNodeConfig
+	// object is created.
+	errorMsg string
+}
+
+// AdditionalOptions additional options for sriovfecnodeconfig object.
+type AdditionalOptions func(builder *NodeConfigBuilder) (*NodeConfigBuilder, error)
+
+// NewNodeConfigBuilder creates a new instance of NodeConfigBuilder.
+func NewNodeConfigBuilder(
+	apiClient *clients.Settings,
+	name, nsname string,
+	label map[string]string) *NodeConfigBuilder {
+	glog.V(100).Infof(
+		"Initializing new SriovFecNodeConfig structure with the following params: %s, %s, %v",
+		name, nsname, label)
+
+	builder := NodeConfigBuilder{
+		apiClient: apiClient,
+		Definition: &sriovfectypes.SriovFecNodeConfig{
+			TypeMeta: metaV1.TypeMeta{
+				Kind:       sriovfecnodeconfig,
+				APIVersion: fmt.Sprintf("%s/%s", APIGroup, APIVersion),
+			},
+			ObjectMeta: metaV1.ObjectMeta{
+				Name:      name,
+				Namespace: nsname,
+			},
+		},
+	}
+
+	if name == "" {
+		glog.V(100).Infof("The name of the SriovFecNodeConfig is empty")
+
+		builder.errorMsg = "SriovFecNodeConfig 'name' cannot be empty"
+	}
+
+	if nsname == "" {
+		glog.V(100).Infof("The namespace of the SriovFecNodeConfig is empty")
+
+		builder.errorMsg = "SriovFecNodeConfig 'nsname' cannot be empty"
+	}
+
+	return &builder
+}
+
+// Pull retrieves an existing SriovFecNodeConfig.io object from the cluster.
+func Pull(apiClient *clients.Settings, name, nsname string) (*NodeConfigBuilder, error) {
+	glog.V(100).Infof(
+		"Pulling SriovFecNodeConfig.io object name: %s in namespace: %s", name, nsname)
+
+	builder := NodeConfigBuilder{
+		apiClient: apiClient,
+		Definition: &sriovfectypes.SriovFecNodeConfig{
+			ObjectMeta: metaV1.ObjectMeta{
+				Name:      name,
+				Namespace: nsname,
+			},
+		},
+	}
+
+	if name == "" {
+		return nil, fmt.Errorf("the name of the SriovFecNodeConfig is empty")
+	}
+
+	if nsname == "" {
+		return nil, fmt.Errorf("the namespace of the SriovFecNodeConfig is empty")
+	}
+
+	if !builder.Exists() {
+		return nil, fmt.Errorf("SriovFecNodeConfig object %s doesn't exist in namespace %s", name, nsname)
+	}
+
+	builder.Definition = builder.Object
+
+	return &builder, nil
+}
+
+// Exists checks whether the given SriovFecNodeConfig exists.
+func (builder *NodeConfigBuilder) Exists() bool {
+	if valid, _ := builder.validate(); !valid {
+		return false
+	}
+
+	glog.V(100).Infof(
+		"Checking if SriovFecNodeConfig %s exists in namespace %s",
+		builder.Definition.Name, builder.Definition.Namespace)
+
+	var err error
+	builder.Object, err = builder.Get()
+
+	if err != nil {
+		glog.V(100).Infof("Failed to collect SriovFecNodeConfig object due to %s", err.Error())
+	}
+
+	return err == nil || !k8serrors.IsNotFound(err)
+}
+
+// Create makes a SriovFecNodeConfig in the cluster and stores the created object in struct.
+func (builder *NodeConfigBuilder) Create() (*NodeConfigBuilder, error) {
+	if valid, err := builder.validate(); !valid {
+		return builder, err
+	}
+
+	glog.V(100).Infof("Creating the sriovfecnodeconfig %s in namespace %s",
+		builder.Definition.Name, builder.Definition.Namespace,
+	)
+
+	var err error
+	if !builder.Exists() {
+		unstructuredSriovFecNodeConfig, err := runtime.DefaultUnstructuredConverter.ToUnstructured(builder.Definition)
+
+		if err != nil {
+			glog.V(100).Infof("Failed to convert structured SriovFecNodeConfig to unstructured object")
+
+			return nil, err
+		}
+
+		unsObject, err := builder.apiClient.Resource(
+			GetSriovFecNodeConfigIoGVR()).Namespace(builder.Definition.Namespace).Create(
+			context.TODO(), &unstructured.Unstructured{Object: unstructuredSriovFecNodeConfig}, metaV1.CreateOptions{})
+
+		if err != nil {
+			glog.V(100).Infof("Failed to create SriovFecNodeConfig")
+
+			return nil, err
+		}
+
+		builder.Object, err = builder.convertToStructured(unsObject)
+
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return builder, err
+}
+
+// Get returns SriovFecNodeConfig object if found.
+func (builder *NodeConfigBuilder) Get() (*sriovfectypes.SriovFecNodeConfig, error) {
+	if valid, err := builder.validate(); !valid {
+		return nil, err
+	}
+
+	glog.V(100).Infof(
+		"Collecting SriovFecNodeConfig object %s in namespace %s",
+		builder.Definition.Name, builder.Definition.Namespace)
+
+	unsObject, err := builder.apiClient.Resource(GetSriovFecNodeConfigIoGVR()).Namespace(builder.Definition.Namespace).Get(
+		context.TODO(), builder.Definition.Name, metaV1.GetOptions{})
+
+	if err != nil {
+		glog.V(100).Infof(
+			"SriovFecNodeConfig object %s doesn't exist in namespace %s",
+			builder.Definition.Name, builder.Definition.Namespace)
+
+		return nil, err
+	}
+
+	return builder.convertToStructured(unsObject)
+}
+
+// Delete removes SriovFecNodeConfig object from a cluster.
+func (builder *NodeConfigBuilder) Delete() (*NodeConfigBuilder, error) {
+	if valid, err := builder.validate(); !valid {
+		return builder, err
+	}
+
+	glog.V(100).Infof("Deleting the SriovFecNodeConfig object %s in namespace %s",
+		builder.Definition.Name, builder.Definition.Namespace,
+	)
+
+	if !builder.Exists() {
+		return builder, fmt.Errorf("SriovFecNodeConfig cannot be deleted because it does not exist")
+	}
+
+	err := builder.apiClient.Resource(
+		GetSriovFecNodeConfigIoGVR()).Namespace(builder.Definition.Namespace).Delete(
+		context.TODO(), builder.Definition.Name, metaV1.DeleteOptions{})
+
+	if err != nil {
+		return builder, fmt.Errorf("can not delete SriovFecNodeConfig: %w", err)
+	}
+
+	builder.Object = nil
+
+	return builder, nil
+}
+
+// Update renovates the existing SriovFecNodeConfig object with the SriovFecNodeConfig definition in builder.
+func (builder *NodeConfigBuilder) Update(force bool) (*NodeConfigBuilder, error) {
+	if valid, err := builder.validate(); !valid {
+		return builder, err
+	}
+
+	if !builder.Exists() {
+		return nil, fmt.Errorf("failed to update SriovFecNodeConfig, object doesn't exist on cluster")
+	}
+
+	glog.V(100).Infof("Updating the SriovFecNodeConfig object %s in namespace %s",
+		builder.Definition.Name, builder.Definition.Namespace,
+	)
+
+	if builder.errorMsg != "" {
+		return nil, fmt.Errorf(builder.errorMsg)
+	}
+
+	builder.Definition.ResourceVersion = builder.Object.ResourceVersion
+	builder.Definition.ObjectMeta.ResourceVersion = builder.Object.ObjectMeta.ResourceVersion
+
+	unstructuredSriovFecNodeConfig, err := runtime.DefaultUnstructuredConverter.ToUnstructured(builder.Definition)
+	if err != nil {
+		glog.V(100).Infof("Failed to convert structured SriovFecNodeConfig to unstructured object")
+
+		return nil, err
+	}
+
+	_, err = builder.apiClient.Resource(
+		GetSriovFecNodeConfigIoGVR()).Namespace(builder.Definition.Namespace).Update(
+		context.TODO(), &unstructured.Unstructured{Object: unstructuredSriovFecNodeConfig}, metaV1.UpdateOptions{})
+
+	if err != nil {
+		if force {
+			glog.V(100).Infof(
+				msg.FailToUpdateNotification("SriovFecNodeConfig", builder.Definition.Name, builder.Definition.Namespace))
+
+			builder, err := builder.Delete()
+
+			if err != nil {
+				glog.V(100).Infof(
+					msg.FailToUpdateError("SriovFecNodeConfig", builder.Definition.Name, builder.Definition.Namespace))
+
+				return nil, err
+			}
+
+			return builder.Create()
+		}
+	}
+
+	return builder, err
+}
+
+// WithOptions creates SriovFecNodeConfig with generic mutation options.
+func (builder *NodeConfigBuilder) WithOptions(options ...AdditionalOptions) *NodeConfigBuilder {
+	if valid, _ := builder.validate(); !valid {
+		return builder
+	}
+
+	glog.V(100).Infof("Setting SriovFecNodeConfig additional options")
+
+	for _, option := range options {
+		if option != nil {
+			builder, err := option(builder)
+
+			if err != nil {
+				glog.V(100).Infof("Error occurred in mutation function")
+
+				builder.errorMsg = err.Error()
+
+				return builder
+			}
+		}
+	}
+
+	return builder
+}
+
+// GetSriovFecNodeConfigIoGVR returns SriovFecNodeConfig's GroupVersionResource which could be used for Clean function.
+func GetSriovFecNodeConfigIoGVR() schema.GroupVersionResource {
+	return schema.GroupVersionResource{
+		Group: APIGroup, Version: APIVersion, Resource: "sriovfecnodeconfigs",
+	}
+}
+
+// validate will check that the builder and builder definition are properly initialized before
+// accessing any member fields.
+func (builder *NodeConfigBuilder) validate() (bool, error) {
+	resourceCRD := "SriovFecNodeConfig"
+
+	if builder == nil {
+		glog.V(100).Infof("The %s builder is uninitialized", resourceCRD)
+
+		return false, fmt.Errorf("error: received nil %s builder", resourceCRD)
+	}
+
+	if builder.Definition == nil {
+		glog.V(100).Infof("The %s is undefined", resourceCRD)
+
+		builder.errorMsg = msg.UndefinedCrdObjectErrString(resourceCRD)
+	}
+
+	if builder.apiClient == nil {
+		glog.V(100).Infof("The %s builder apiclient is nil", resourceCRD)
+
+		builder.errorMsg = fmt.Sprintf("%s builder cannot have nil apiClient", resourceCRD)
+	}
+
+	if builder.errorMsg != "" {
+		glog.V(100).Infof("The %s builder has error message: %s", resourceCRD, builder.errorMsg)
+
+		return false, fmt.Errorf(builder.errorMsg)
+	}
+
+	return true, nil
+}
+
+func (builder *NodeConfigBuilder) convertToStructured(unsObject *unstructured.Unstructured) (
+	*sriovfectypes.SriovFecNodeConfig, error) {
+	SriovFecNodeConfig := &sriovfectypes.SriovFecNodeConfig{}
+
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(unsObject.Object, SriovFecNodeConfig)
+	if err != nil {
+		glog.V(100).Infof(
+			"Failed to convert from unstructured to SriovFecNodeConfig object in namespace %s",
+			builder.Definition.Name, builder.Definition.Namespace)
+
+		return nil, err
+	}
+
+	return SriovFecNodeConfig, err
+}

--- a/pkg/sriov-fec/sriovfectypes/sriovfecclusterconfig_types.go
+++ b/pkg/sriov-fec/sriovfectypes/sriovfecclusterconfig_types.go
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2020-2023 Intel Corporation
+
+package sriovfectypes
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// SyncStatus type.
+type SyncStatus string
+
+var (
+	// InProgressSync indicates that the synchronization of the CR is in progress.
+	InProgressSync SyncStatus = "InProgress"
+	// SucceededSync indicates that the synchronization of the CR succeeded.
+	SucceededSync SyncStatus = "Succeeded"
+	// FailedSync indicates that the synchronization of the CR failed.
+	FailedSync SyncStatus = "Failed"
+	// IgnoredSync indicates that the CR is ignored.
+	IgnoredSync SyncStatus = "Ignored"
+)
+
+// UplinkDownlinkQueues struct.
+type UplinkDownlinkQueues struct {
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=32
+	VF0 int `json:"vf0"`
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=32
+	VF1 int `json:"vf1"`
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=32
+	VF2 int `json:"vf2"`
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=32
+	VF3 int `json:"vf3"`
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=32
+	VF4 int `json:"vf4"`
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=32
+	VF5 int `json:"vf5"`
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=32
+	VF6 int `json:"vf6"`
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=32
+	VF7 int `json:"vf7"`
+}
+
+// UplinkDownlink struct.
+type UplinkDownlink struct {
+	// +kubebuilder:validation:Minimum=0
+	Bandwidth int `json:"bandwidth"`
+	// +kubebuilder:validation:Minimum=0
+	LoadBalance int                  `json:"loadBalance"`
+	Queues      UplinkDownlinkQueues `json:"queues"`
+}
+
+// N3000BBDevConfig specifies variables to configure N3000 with.
+type N3000BBDevConfig struct {
+	// +kubebuilder:validation:Enum=FPGA_5GNR;FPGA_LTE
+	NetworkType string `json:"networkType"`
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default:false
+	// +kubebuilder:validation:Enum=false
+	PFMode bool `json:"pfMode,omitempty"`
+	// +kubebuilder:validation:Minimum=0
+	FLRTimeOut int            `json:"flrTimeout"`
+	Downlink   UplinkDownlink `json:"downlink"`
+	Uplink     UplinkDownlink `json:"uplink"`
+}
+
+// QueueGroupConfig struct.
+type QueueGroupConfig struct {
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=16
+	NumQueueGroups int `json:"numQueueGroups"`
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=16
+	NumAqsPerGroups int `json:"numAqsPerGroups"`
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=12
+	AqDepthLog2 int `json:"aqDepthLog2"`
+}
+
+// ACC100BBDevConfig specifies variables to configure ACC100 with.
+type ACC100BBDevConfig struct {
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default:false
+	// +kubebuilder:validation:Enum=false
+	PFMode bool `json:"pfMode,omitempty"`
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=16
+	NumVfBundles int `json:"numVfBundles"`
+	// +kubebuilder:validation:Minimum=1024
+	// +kubebuilder:validation:Maximum=1024
+	// +kubebuilder:default:1024
+	// +kubebuilder:validation:Optional
+	MaxQueueSize int              `json:"maxQueueSize,omitempty"`
+	Uplink4G     QueueGroupConfig `json:"uplink4G"`
+	Downlink4G   QueueGroupConfig `json:"downlink4G"`
+	Uplink5G     QueueGroupConfig `json:"uplink5G"`
+	Downlink5G   QueueGroupConfig `json:"downlink5G"`
+}
+
+// FFTLutParam specifies variables required to use custom fft bin file.
+type FFTLutParam struct {
+	// Path to .tar.gz SRS-FFT file
+	// +kubebuilder:validation:Pattern=`^((http|https)://.*\.tar\.gz)?$`
+	FftURL string `json:"fftUrl"`
+	// SHA-1 checksum of .tar.gz SRS-FFT File
+	// +kubebuilder:validation:Pattern=`^([a-fA-F0-9]{40})?$`
+	FftChecksum string `json:"fftChecksum"`
+}
+
+// ACC200BBDevConfig specifies variables to configure ACC200 with.
+type ACC200BBDevConfig struct {
+	ACC100BBDevConfig `json:",inline"`
+	QFFT              QueueGroupConfig `json:"qfft"`
+	FFTLut            FFTLutParam      `json:"fftLut,omitempty"`
+}
+
+// BBDevConfig is a struct containing configuration for various FEC cards.
+type BBDevConfig struct {
+	N3000  *N3000BBDevConfig  `json:"n3000,omitempty"`
+	ACC100 *ACC100BBDevConfig `json:"acc100,omitempty"`
+	ACC200 *ACC200BBDevConfig `json:"acc200,omitempty"`
+}
+
+// PhysicalFunctionConfig defines a possible configuration of a single Physical Function (PF), i.e. card.
+type PhysicalFunctionConfig struct {
+	// PFDriver to bound the PFs to
+	//+kubebuilder:validation:Pattern=`(pci-pf-stub|pci_pf_stub|igb_uio|vfio-pci)`
+	PFDriver string `json:"pfDriver"`
+	// VFDriver to bound the VFs to
+	VFDriver string `json:"vfDriver"`
+	// VFAmount is an amount of VFs to be created
+	// +kubebuilder:validation:Minimum=1
+	VFAmount int `json:"vfAmount"`
+	// BBDevConfig is a config for PF's queues
+	BBDevConfig BBDevConfig `json:"bbDevConfig"`
+}
+
+// PhysicalFunctionConfigExt struct.
+type PhysicalFunctionConfigExt struct {
+	// PCIAdress is a Physical Functions's PCI address that will be configured according to this spec
+	// +kubebuilder:validation:Pattern=`^[a-fA-F0-9]{4}:[a-fA-F0-9]{2}:[01][a-fA-F0-9]\.[0-7]$`
+	PCIAddress string `json:"pciAddress"`
+
+	// PFDriver to bound the PFs to
+	//+kubebuilder:validation:Pattern=`(pci-pf-stub|pci_pf_stub|igb_uio|vfio-pci)`
+	PFDriver string `json:"pfDriver"`
+
+	// VFDriver to bound the VFs to
+	VFDriver string `json:"vfDriver"`
+
+	// VFAmount is an amount of VFs to be created
+	// +kubebuilder:validation:Minimum=0
+	VFAmount int `json:"vfAmount"`
+
+	// BBDevConfig is a config for PF's queues
+	BBDevConfig BBDevConfig `json:"bbDevConfig"`
+}
+
+// SriovFecClusterConfigSpec defines the desired state of SriovFecClusterConfig.
+type SriovFecClusterConfigSpec struct {
+
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// Selector describes target node for this spec
+	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// Selector describes target accelerator for this spec
+	AcceleratorSelector AcceleratorSelector `json:"acceleratorSelector,omitempty"`
+
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// Physical function (card) config
+	PhysicalFunction PhysicalFunctionConfig `json:"physicalFunction"`
+
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// Higher priority policies can override lower ones.
+	Priority int `json:"priority,omitempty"`
+
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// Skips drain process when true; default false. Should be true if operator is running on SNO
+	DrainSkip bool `json:"drainSkip,omitempty"`
+}
+
+// AcceleratorSelector struct.
+type AcceleratorSelector struct {
+	VendorID string `json:"vendorID,omitempty"`
+	DeviceID string `json:"deviceID,omitempty"`
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Pattern=`^[a-fA-F0-9]{4}:[a-fA-F0-9]{2}:[01][a-fA-F0-9]\.[0-7]$`
+	PCIAddress string `json:"pciAddress,omitempty"`
+	//+kubebuilder:validation:Pattern=`(pci-pf-stub|pci_pf_stub|igb_uio|vfio-pci)`
+	PFDriver string `json:"driver,omitempty"`
+	MaxVFs   int    `json:"maxVirtualFunctions,omitempty"`
+}
+
+// SriovFecClusterConfigStatus defines the observed state of SriovFecClusterConfig.
+type SriovFecClusterConfigStatus struct {
+	// Indicates the synchronization status of the CR
+	// +operator-sdk:csv:customresourcedefinitions:type=status
+	SyncStatus    SyncStatus `json:"syncStatus,omitempty"`
+	LastSyncError string     `json:"lastSyncError,omitempty"`
+}
+
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +kubebuilder:storageversion
+// +kubebuilder:resource:shortName=sfcc
+
+// SriovFecClusterConfig is the Schema for the sriovfecclusterconfigs API.
+type SriovFecClusterConfig struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   SriovFecClusterConfigSpec   `json:"spec,omitempty"`
+	Status SriovFecClusterConfigStatus `json:"status,omitempty"`
+}
+
+// +kubebuilder:object:root=true
+
+// SriovFecClusterConfigList contains a list of SriovFecClusterConfig.
+type SriovFecClusterConfigList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []SriovFecClusterConfig `json:"items"`
+}

--- a/pkg/sriov-fec/sriovfectypes/sriovfecnodeconfig_types.go
+++ b/pkg/sriov-fec/sriovfectypes/sriovfecnodeconfig_types.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2020-2023 Intel Corporation
+
+package sriovfectypes
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// VF struct.
+type VF struct {
+	PCIAddress string `json:"pciAddress"`
+	Driver     string `json:"driver"`
+	DeviceID   string `json:"deviceID"`
+}
+
+// SriovAccelerator struct.
+type SriovAccelerator struct {
+	VendorID   string `json:"vendorID"`
+	DeviceID   string `json:"deviceID"`
+	PCIAddress string `json:"pciAddress"`
+	PFDriver   string `json:"driver"`
+	MaxVFs     int    `json:"maxVirtualFunctions"`
+	VFs        []VF   `json:"virtualFunctions"`
+}
+
+// NodeInventory struct.
+type NodeInventory struct {
+	SriovAccelerators []SriovAccelerator `json:"sriovAccelerators,omitempty"`
+}
+
+// SriovFecNodeConfigSpec defines the desired state of SriovFecNodeConfig.
+type SriovFecNodeConfigSpec struct {
+	// List of PhysicalFunctions configs
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	PhysicalFunctions []PhysicalFunctionConfigExt `json:"physicalFunctions"`
+
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// Skips drain process when true; default false. Should be true if operator is running on SNO
+	DrainSkip bool `json:"drainSkip,omitempty"`
+}
+
+// SriovFecNodeConfigStatus defines the observed state of SriovFecNodeConfig.
+type SriovFecNodeConfigStatus struct {
+	// Provides information about device update status
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
+	// Provides information about FPGA inventory on the node
+	// +operator-sdk:csv:customresourcedefinitions:type=status
+	Inventory NodeInventory `json:"inventory,omitempty"`
+}
+
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Configured",type=string,JSONPath=`.status.conditions[?(@.type=="Configured")].reason`
+// +kubebuilder:storageversion
+// +kubebuilder:resource:shortName=sfnc
+
+// SriovFecNodeConfig is the Schema for the sriovfecnodeconfigs API.
+type SriovFecNodeConfig struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   SriovFecNodeConfigSpec   `json:"spec,omitempty"`
+	Status SriovFecNodeConfigStatus `json:"status,omitempty"`
+}
+
+// +kubebuilder:object:root=true
+
+// SriovFecNodeConfigList contains a list of SriovFecNodeConfig.
+type SriovFecNodeConfigList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []SriovFecNodeConfig `json:"items"`
+}


### PR DESCRIPTION
Add sriovfec pkg together with sriov-fec-operator API. This is needed since vendoring doesn't work due to older version of sigs.k8s.io/controller-runtime pkg[0] than what is used in eco-goinfra.

[0] https://github.com/smart-edge-open/sriov-fec-operator/blob/main/go.mod#L27