### PR TITLE
Add control-plane toleration func

### DIFF
--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -577,6 +577,30 @@ func (builder *Builder) WithTolerationToMaster() *Builder {
 	return builder
 }
 
+// WithTolerationToControlPlane sets toleration policy which allows pod to be running on control plane node.
+func (builder *Builder) WithTolerationToControlPlane() *Builder {
+	if valid, _ := builder.validate(); !valid {
+		return builder
+	}
+
+	glog.V(100).Infof("Appending pod's %s with toleration to control plane node", builder.Definition.Name)
+
+	builder.isMutationAllowed("toleration to control plane node")
+
+	if builder.errorMsg != "" {
+		return builder
+	}
+
+	builder.Definition.Spec.Tolerations = []v1.Toleration{
+		{
+			Key:    "node-role.kubernetes.io/control-plane",
+			Effect: "NoSchedule",
+		},
+	}
+
+	return builder
+}
+
 // WithToleration adds a toleration configuration inside the pod.
 func (builder *Builder) WithToleration(toleration v1.Toleration) *Builder {
 	if valid, _ := builder.validate(); !valid {


### PR DESCRIPTION
`node-role.kubernetes.io/master` was [deprecated](https://kubernetes.io/blog/2022/04/07/upcoming-changes-in-kubernetes-1-24/#api-removals-deprecations-and-other-changes-for-kubernetes-1-24) back in k8s 1.24.

This adds a function `WithTolerationToControlPlane` similar to the `WithTolerationToMaster` func.  Keeps the old func around for backwards compatibility.

Similar to: 
- https://github.com/openshift-kni/cnf-features-deploy/pull/1802
- https://github.com/test-network-function/cnf-certification-test/pull/512