### PR TITLE
Limit scope of 'apiClient' var in builder in 'Node' package

### DIFF
--- a/pkg/nodes/list.go
+++ b/pkg/nodes/list.go
@@ -46,7 +46,7 @@ func List(apiClient *clients.Settings, options ...v1.ListOptions) ([]*Builder, e
 	for _, runningNode := range nodeList.Items {
 		copiedNode := runningNode
 		nodeBuilder := &Builder{
-			apiClient:  apiClient,
+			apiClient:  apiClient.K8sClient,
 			Object:     &copiedNode,
 			Definition: &copiedNode,
 		}


### PR DESCRIPTION
Building on ideas from #270 after talking with @kononovn 

Instead of copying the entire `client.Settings` struct, only keep around the `kubernetes.Interface` that you use during some of these `Node` operations.  This could also apply to all of the other k8s-related object funcs/pkgs.

This will help ease-of-use when writing unit tests that target this code as well because you don't have to worry about the other clients, just the `kubernetes.Fake` clientset.

Does not break any public functionality.