### PR TITLE
Add unit tests for deployment options pattern

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,6 +33,7 @@ linters-settings:
           - "open-cluster-management.io/governance-policy-propagator/api/v1beta1"
           - "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/placementrule/v1"
           - "sigs.k8s.io/controller-runtime"
+          - "github.com/stretchr/testify"
           - $gostd
           - "github.com/stretchr/testify"
   revive:


### PR DESCRIPTION
Adds unit tests for the `With...` options functions in the `deployment` package.  Modifies some of the functions to better return errors via `builder.ErrorMsg`.  Uses `stretchr/testify` to assert the expected values.