### PR TITLE
pod: modified ExecCommand method's glog Infof

### DIFF
--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -357,9 +357,6 @@ func (builder *Builder) ExecCommand(command []string, containerName ...string) (
 		return bytes.Buffer{}, err
 	}
 
-	glog.V(100).Infof("Execute command %v in the pod",
-		command)
-
 	var (
 		buffer bytes.Buffer
 		cName  string
@@ -370,6 +367,9 @@ func (builder *Builder) ExecCommand(command []string, containerName ...string) (
 	} else {
 		cName = builder.Definition.Spec.Containers[0].Name
 	}
+
+	glog.V(100).Infof("Execute command %v in the pod %s container %s in namespace %s",
+		command, builder.Object.Name, cName, builder.Object.Namespace)
 
 	req := builder.apiClient.CoreV1Interface.RESTClient().
 		Post().


### PR DESCRIPTION
Minor modification to ExecCommand method's glog to help during troubleshooting.

Logs to include namespace, pod name and container name in which command is being executed.