### PR TITLE
daemonset: IsReady method evaluation modified

### DIFF
--- a/pkg/daemonset/daemonset.go
+++ b/pkg/daemonset/daemonset.go
@@ -396,7 +396,8 @@ func (builder *Builder) IsReady(timeout time.Duration) bool {
 				return true, nil
 			}
 
-			if builder.Object.Status.NumberReady == builder.Object.Status.UpdatedNumberScheduled {
+			if builder.Object.Status.NumberReady == builder.Object.Status.UpdatedNumberScheduled &&
+				builder.Object.Status.UpdatedNumberScheduled != 0 {
 				return true, nil
 			}
 


### PR DESCRIPTION
In cases, when DS cannot be scheduled, IsReady is returning true. Added one more evaluation to ensure reliable result.

_Example:_
```
Desired Number of Nodes Scheduled: 2                                                                                                                                                                              
Current Number of Nodes Scheduled: 0                                                                                                                                                                               
Number of Nodes Scheduled with Up-to-date Pods: 0   
```