### PR TITLE
Use client params struct

### DIFF
--- a/pkg/cgu/cgu_test.go
+++ b/pkg/cgu/cgu_test.go
@@ -90,7 +90,9 @@ func TestPullCgu(t *testing.T) {
 		}
 
 		if testCase.client {
-			testSettings = clients.GetTestClients(runtimeObjects)
+			testSettings = clients.GetTestClients(clients.TestClientParams{
+				K8sMockObjects: runtimeObjects,
+			})
 		}
 
 		// Test the Pull method
@@ -148,7 +150,7 @@ func TestNewCguBuilder(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		testSettings := clients.GetTestClients([]runtime.Object{})
+		testSettings := clients.GetTestClients(clients.TestClientParams{})
 		testCguStructure := generateCguBuilder(
 			testSettings,
 			testCase.cguName,
@@ -309,7 +311,9 @@ func TestCguExist(t *testing.T) {
 }
 
 func buildTestClientWithDummyCguObject() *clients.Settings {
-	return clients.GetTestClients(buildDummyCguObject())
+	return clients.GetTestClients(clients.TestClientParams{
+		K8sMockObjects: buildDummyCguObject(),
+	})
 }
 
 func buildDummyCguObject() []runtime.Object {

--- a/pkg/clients/clients.go
+++ b/pkg/clients/clients.go
@@ -339,16 +339,24 @@ func (settings *Settings) GetAPIClient() (*Settings, error) {
 	return settings, nil
 }
 
+// TestClientParams provides the struct to store the parameters for the test client.
+type TestClientParams struct {
+	K8sMockObjects []runtime.Object
+	GVK            []schema.GroupVersionKind
+
+	// Note: Add more fields below if/when needed.
+}
+
 // GetTestClients returns a fake clientset for testing.
 //
 //nolint:funlen,gocyclo
-func GetTestClients(k8sMockObjects []runtime.Object, gvk ...schema.GroupVersionKind) *Settings {
+func GetTestClients(tcp TestClientParams) *Settings {
 	clientSet := &Settings{}
 
 	var k8sClientObjects, genericClientObjects, srIovObjects, veleroClientObjects, cguObjects []runtime.Object
 
 	//nolint:varnamelen
-	for _, v := range k8sMockObjects {
+	for _, v := range tcp.K8sMockObjects {
 		// Based on what type of object is, populate certain object slices
 		// with what is supported by a certain client.
 		// Add more items below if/when needed.
@@ -434,9 +442,9 @@ func GetTestClients(k8sMockObjects []runtime.Object, gvk ...schema.GroupVersionK
 		return nil
 	}
 
-	if len(gvk) > 0 && len(genericClientObjects) > 0 {
+	if len(tcp.GVK) > 0 && len(genericClientObjects) > 0 {
 		fakeClientScheme.AddKnownTypeWithName(
-			gvk[0], genericClientObjects[0])
+			tcp.GVK[0], genericClientObjects[0])
 	}
 
 	clientSet.Interface = dynamicFake.NewSimpleDynamicClient(fakeClientScheme, genericClientObjects...)

--- a/pkg/configmap/configmap_test.go
+++ b/pkg/configmap/configmap_test.go
@@ -45,7 +45,7 @@ func TestNewBuilder(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testSettings := clients.GetTestClients([]runtime.Object{})
+		testSettings := clients.GetTestClients(clients.TestClientParams{})
 
 		testBuilder := NewBuilder(testSettings, testCase.name, testCase.nsname)
 
@@ -108,7 +108,9 @@ func TestPull(t *testing.T) {
 			runtimeObjects = append(runtimeObjects, testCM)
 		}
 
-		testSettings = clients.GetTestClients(runtimeObjects)
+		testSettings = clients.GetTestClients(clients.TestClientParams{
+			K8sMockObjects: runtimeObjects,
+		})
 
 		// Test the Pull function
 		builderResult, err := Pull(testSettings, testCase.name, testCase.nsname)

--- a/pkg/deployment/deployment_test.go
+++ b/pkg/deployment/deployment_test.go
@@ -97,7 +97,9 @@ func TestPull(t *testing.T) {
 			runtimeObjects = append(runtimeObjects, testDeployment)
 		}
 
-		testSettings = clients.GetTestClients(runtimeObjects)
+		testSettings = clients.GetTestClients(clients.TestClientParams{
+			K8sMockObjects: runtimeObjects,
+		})
 
 		// Test the Pull method
 		builderResult, err := Pull(testSettings, testDeployment.Name, testDeployment.Namespace)

--- a/pkg/metallb/adresspool_test.go
+++ b/pkg/metallb/adresspool_test.go
@@ -86,7 +86,10 @@ func TestPullAddressPool(t *testing.T) {
 		}
 
 		if testCase.client {
-			testSettings = clients.GetTestClients(runtimeObjects, addressPoolGvk)
+			testSettings = clients.GetTestClients(clients.TestClientParams{
+				K8sMockObjects: runtimeObjects,
+				GVK:            []schema.GroupVersionKind{addressPoolGvk},
+			})
 		}
 
 		builderResult, err := PullAddressPool(testSettings, testCase.name, testCase.namespace)
@@ -135,7 +138,9 @@ func TestNewIPAddressPoolBuilder(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testSettings := clients.GetTestClients([]runtime.Object{}, addressPoolGvk)
+		testSettings := clients.GetTestClients(clients.TestClientParams{
+			GVK: []schema.GroupVersionKind{addressPoolGvk},
+		})
 		testIPAddressPoolBuilder := generateIPAddressPoolBuilder(
 			testSettings, testCase.name, testCase.namespace, testCase.addrPool)
 		assert.Equal(t, testCase.expectedError, testIPAddressPoolBuilder.errorMsg)
@@ -350,7 +355,10 @@ func buildInValidIPAddressPoolBuilder(apiClient *clients.Settings) *IPAddressPoo
 }
 
 func buildTestClientWithDummyObject() *clients.Settings {
-	return clients.GetTestClients(buildDummyIPAddressPool(), addressPoolGvk)
+	return clients.GetTestClients(clients.TestClientParams{
+		K8sMockObjects: buildDummyIPAddressPool(),
+		GVK:            []schema.GroupVersionKind{addressPoolGvk},
+	})
 }
 
 func buildDummyIPAddressPool() []runtime.Object {

--- a/pkg/route/route_test.go
+++ b/pkg/route/route_test.go
@@ -114,7 +114,9 @@ func TestPull(t *testing.T) {
 
 		if testCase.addToRuntimeObjects {
 			runtimeObjects = append(runtimeObjects, testRoute)
-			testSettings = clients.GetTestClients(runtimeObjects)
+			testSettings = clients.GetTestClients(clients.TestClientParams{
+				K8sMockObjects: runtimeObjects,
+			})
 		}
 
 		// Test the Pull method

--- a/pkg/sriov/list_test.go
+++ b/pkg/sriov/list_test.go
@@ -55,7 +55,9 @@ func TestNetworkList(t *testing.T) {
 		var testSettings *clients.Settings
 
 		if testCase.client {
-			testSettings = clients.GetTestClients(buildDummySrIovNetworkObject())
+			testSettings = clients.GetTestClients(clients.TestClientParams{
+				K8sMockObjects: buildDummySrIovNetworkObject(),
+			})
 		}
 
 		netBuilders, err := List(testSettings, testCase.nsName, testCase.listOptions...)
@@ -123,7 +125,9 @@ func TestNetworkCleanAllNetworksByTargetNamespace(t *testing.T) {
 		var testSettings *clients.Settings
 
 		if testCase.client {
-			testSettings = clients.GetTestClients(buildDummySrIovNetworkObject())
+			testSettings = clients.GetTestClients(clients.TestClientParams{
+				K8sMockObjects: buildDummySrIovNetworkObject(),
+			})
 		}
 
 		err := CleanAllNetworksByTargetNamespace(
@@ -194,7 +198,9 @@ func TestListNetworkNodeState(t *testing.T) {
 		}
 
 		if testCase.client {
-			testSettings = clients.GetTestClients(runtimeObjects)
+			testSettings = clients.GetTestClients(clients.TestClientParams{
+				K8sMockObjects: runtimeObjects,
+			})
 		}
 
 		builders, err := ListNetworkNodeState(testSettings, testCase.nsName, testCase.listOptions...)
@@ -267,7 +273,9 @@ func TestListPolicy(t *testing.T) {
 		}
 
 		if testCase.client {
-			testSettings = clients.GetTestClients(runtimeObjects)
+			testSettings = clients.GetTestClients(clients.TestClientParams{
+				K8sMockObjects: runtimeObjects,
+			})
 		}
 
 		builders, err := ListPolicy(testSettings, testCase.nsName, testCase.listOptions...)
@@ -339,7 +347,9 @@ func TestCleanAllNetworkNodePolicies(t *testing.T) {
 		}
 
 		if testCase.client {
-			testSettings = clients.GetTestClients(runtimeObjects)
+			testSettings = clients.GetTestClients(clients.TestClientParams{
+				K8sMockObjects: runtimeObjects,
+			})
 		}
 
 		err := CleanAllNetworkNodePolicies(testSettings, testCase.nsName, testCase.listOptions...)

--- a/pkg/sriov/network_test.go
+++ b/pkg/sriov/network_test.go
@@ -94,7 +94,9 @@ func TestPullNetwork(t *testing.T) {
 		}
 
 		if testCase.client {
-			testSettings = clients.GetTestClients(runtimeObjects)
+			testSettings = clients.GetTestClients(clients.TestClientParams{
+				K8sMockObjects: runtimeObjects,
+			})
 		}
 
 		// Test the Pull method
@@ -168,7 +170,7 @@ func TestNewNetworkBuilder(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		testSettings := clients.GetTestClients([]runtime.Object{})
+		testSettings := clients.GetTestClients(clients.TestClientParams{})
 		testNetworkStructure := generateNetworkBuilder(
 			testSettings, testCase.networkName, testCase.networkNamespace, testCase.targetNs, testCase.resName)
 		assert.NotNil(t, testNetworkStructure)
@@ -519,7 +521,9 @@ func buildInvalidSrIovNetworkTestBuilder(apiClient *clients.Settings) *NetworkBu
 }
 
 func buildTestClientWithDummyObject() *clients.Settings {
-	return clients.GetTestClients(buildDummySrIovNetworkObject())
+	return clients.GetTestClients(clients.TestClientParams{
+		K8sMockObjects: buildDummySrIovNetworkObject(),
+	})
 }
 
 func buildDummySrIovNetworkObject() []runtime.Object {

--- a/pkg/sriov/networknodestate_test.go
+++ b/pkg/sriov/networknodestate_test.go
@@ -46,7 +46,7 @@ func TestNewNetworkNodeStateBuilder(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		testSettings := clients.GetTestClients([]runtime.Object{})
+		testSettings := clients.GetTestClients(clients.TestClientParams{})
 		testNetworkStructure := generateNetworkBuilder(
 			testSettings, testCase.nodeName, testCase.nsName)
 		assert.NotNil(t, testNetworkStructure)
@@ -109,7 +109,9 @@ func TestNetworkNodeStateDiscovery(t *testing.T) {
 			runtimeObjects = append(runtimeObjects, networkNodeState)
 		}
 
-		testSettings = clients.GetTestClients(runtimeObjects)
+		testSettings = clients.GetTestClients(clients.TestClientParams{
+			K8sMockObjects: runtimeObjects,
+		})
 
 		networkNodeStateBuilder := NewNetworkNodeStateBuilder(testSettings, testCase.nodeName, testCase.nsName)
 		err := networkNodeStateBuilder.Discover()
@@ -161,7 +163,9 @@ func TestNetworkNodeStateGetNICs(t *testing.T) {
 		networkNodeState := buildNodeNetworkStateWithNics(testCase.netInterface)
 		runtimeObjects = append(runtimeObjects, networkNodeState)
 
-		testSettings = clients.GetTestClients(runtimeObjects)
+		testSettings = clients.GetTestClients(clients.TestClientParams{
+			K8sMockObjects: runtimeObjects,
+		})
 
 		networkNodeStateBuilder := NewNetworkNodeStateBuilder(testSettings, testCase.nodeName, defaultNodeNsName)
 		nics, err := networkNodeStateBuilder.GetNICs()
@@ -236,7 +240,9 @@ func TestNetworkNodeStateGetUpNICs(t *testing.T) {
 
 	for _, testCase := range testCases {
 		networkNodeState := buildNodeNetworkStateWithNics(testCase.netInterface)
-		testSettings := clients.GetTestClients(append([]runtime.Object{}, networkNodeState))
+		testSettings := clients.GetTestClients(clients.TestClientParams{
+			K8sMockObjects: []runtime.Object{networkNodeState},
+		})
 		networkNodeStateBuilder := NewNetworkNodeStateBuilder(testSettings, testCase.nodeName, defaultNodeNsName)
 		nics, err := networkNodeStateBuilder.GetUpNICs()
 
@@ -271,7 +277,9 @@ func TestNetworkNodeStateWaitUntilSyncStatus(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		networkNodeState := buildNodeNetworkStateSyncStatus(defaultNodeName, defaultNodeNsName, testCase.syncStatus)
-		testSettings := clients.GetTestClients(append([]runtime.Object{}, networkNodeState))
+		testSettings := clients.GetTestClients(clients.TestClientParams{
+			K8sMockObjects: []runtime.Object{networkNodeState},
+		})
 		networkNodeStateBuilder := NewNetworkNodeStateBuilder(testSettings, defaultNodeName, defaultNodeNsName)
 		err := networkNodeStateBuilder.Discover()
 		assert.Nil(t, err)
@@ -300,7 +308,9 @@ func TestNetworkNodeStateGetNumVFs(t *testing.T) {
 
 	for _, testCase := range testCases {
 		networkNodeState := buildNodeNetworkStateWithNics(testCase.netInterface)
-		testSettings := clients.GetTestClients(append([]runtime.Object{}, networkNodeState))
+		testSettings := clients.GetTestClients(clients.TestClientParams{
+			K8sMockObjects: []runtime.Object{networkNodeState},
+		})
 		networkNodeStateBuilder := NewNetworkNodeStateBuilder(testSettings, defaultNodeName, defaultNodeNsName)
 		err := networkNodeStateBuilder.Discover()
 		assert.Nil(t, err)
@@ -333,7 +343,9 @@ func TestNetworkNodeStateGetDriverName(t *testing.T) {
 
 	for _, testCase := range testCases {
 		networkNodeState := buildNodeNetworkStateWithNics(testCase.netInterface)
-		testSettings := clients.GetTestClients(append([]runtime.Object{}, networkNodeState))
+		testSettings := clients.GetTestClients(clients.TestClientParams{
+			K8sMockObjects: []runtime.Object{networkNodeState},
+		})
 		networkNodeStateBuilder := NewNetworkNodeStateBuilder(testSettings, defaultNodeName, defaultNetNsName)
 		err := networkNodeStateBuilder.Discover()
 		assert.Nil(t, err)
@@ -366,7 +378,9 @@ func TestNetworkNodeStateGetPciAddress(t *testing.T) {
 
 	for _, testCase := range testCases {
 		networkNodeState := buildNodeNetworkStateWithNics(testCase.netInterface)
-		testSettings := clients.GetTestClients(append([]runtime.Object{}, networkNodeState))
+		testSettings := clients.GetTestClients(clients.TestClientParams{
+			K8sMockObjects: []runtime.Object{networkNodeState},
+		})
 		networkNodeStateBuilder := NewNetworkNodeStateBuilder(testSettings, defaultNodeName, defaultNodeNsName)
 		err := networkNodeStateBuilder.Discover()
 		assert.Nil(t, err)

--- a/pkg/sriov/operatorconfig_test.go
+++ b/pkg/sriov/operatorconfig_test.go
@@ -75,7 +75,9 @@ func TestPullOperatorConfig(t *testing.T) {
 		}
 
 		if testCase.client {
-			testSettings = clients.GetTestClients(runtimeObjects)
+			testSettings = clients.GetTestClients(clients.TestClientParams{
+				K8sMockObjects: runtimeObjects,
+			})
 		}
 
 		// Test the Pull method
@@ -114,7 +116,7 @@ func TestNewOperatorConfigBuilder(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		testSettings := clients.GetTestClients([]runtime.Object{})
+		testSettings := clients.GetTestClients(clients.TestClientParams{})
 		testPolicyStructure := generatePolicyBuilder(testSettings, testCase.operatorConfigNamespace)
 		assert.NotNil(t, testPolicyStructure)
 		assert.Equal(t, testPolicyStructure.errorMsg, testCase.expectedErrorText)
@@ -281,7 +283,9 @@ func TestOperatorConfigDelete(t *testing.T) {
 }
 
 func buildTestClientWithDummyOperatorConfigObject() *clients.Settings {
-	return clients.GetTestClients(buildDummySrIovOperatorConfigObject())
+	return clients.GetTestClients(clients.TestClientParams{
+		K8sMockObjects: buildDummySrIovOperatorConfigObject(),
+	})
 }
 
 func buildDummySrIovOperatorConfigObject() []runtime.Object {

--- a/pkg/sriov/policy_test.go
+++ b/pkg/sriov/policy_test.go
@@ -94,7 +94,9 @@ func TestPullPolicy(t *testing.T) {
 		}
 
 		if testCase.client {
-			testSettings = clients.GetTestClients(runtimeObjects)
+			testSettings = clients.GetTestClients(clients.TestClientParams{
+				K8sMockObjects: runtimeObjects,
+			})
 		}
 
 		// Test the Pull method
@@ -194,7 +196,7 @@ func TestNewPolicyBuilder(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		testSettings := clients.GetTestClients([]runtime.Object{})
+		testSettings := clients.GetTestClients(clients.TestClientParams{})
 		testPolicyStructure := generatePolicyBuilder(
 			testSettings,
 			testCase.policyName,
@@ -490,7 +492,9 @@ func buildInvalidSriovPolicyTestBuilder(apiClient *clients.Settings) *PolicyBuil
 }
 
 func buildTestClientWithDummyPolicyObject() *clients.Settings {
-	return clients.GetTestClients(buildDummySrIovPolicyObject())
+	return clients.GetTestClients(clients.TestClientParams{
+		K8sMockObjects: buildDummySrIovPolicyObject(),
+	})
 }
 
 func buildDummySrIovPolicyObject() []runtime.Object {

--- a/pkg/velero/backup_test.go
+++ b/pkg/velero/backup_test.go
@@ -100,7 +100,9 @@ func TestPullBackup(t *testing.T) {
 			runtimeObjects = append(runtimeObjects, testBackup)
 		}
 
-		testSettings = clients.GetTestClients(runtimeObjects)
+		testSettings = clients.GetTestClients(clients.TestClientParams{
+			K8sMockObjects: runtimeObjects,
+		})
 
 		// Test the Pull method
 		builderResult, err := PullBackup(testSettings, testCase.name, testCase.namespace)

--- a/pkg/velero/restore_test.go
+++ b/pkg/velero/restore_test.go
@@ -110,7 +110,9 @@ func TestPullRestore(t *testing.T) {
 			runtimeObjects = append(runtimeObjects, testRestore)
 		}
 
-		testSettings = clients.GetTestClients(runtimeObjects)
+		testSettings = clients.GetTestClients(clients.TestClientParams{
+			K8sMockObjects: runtimeObjects,
+		})
 
 		// Test the Pull method
 		builderResult, err := PullRestore(testSettings, testCase.name, testCase.namespace)


### PR DESCRIPTION
Created a `TestClientParams` struct to house parameters that are needed inside of the `GetTestClients()` func.  This allows for flexibility whenever we need to add new types to our test client.