### PR TITLE
context consistency: switch Background() to TODO()

### DIFF
--- a/pkg/assisted/nmstateconfig.go
+++ b/pkg/assisted/nmstateconfig.go
@@ -139,7 +139,7 @@ func (builder *NmStateConfigBuilder) Delete() error {
 func ListNmStateConfigsInAllNamespaces(apiClient *clients.Settings) ([]*NmStateConfigBuilder, error) {
 	nmStateConfigList := &assistedv1beta1.NMStateConfigList{}
 
-	err := apiClient.List(context.Background(), nmStateConfigList, &goclient.ListOptions{})
+	err := apiClient.List(context.TODO(), nmStateConfigList, &goclient.ListOptions{})
 
 	if err != nil {
 		glog.V(100).Infof("Failed to list nmStateConfigs across all namespaces due to %s", err.Error())
@@ -171,7 +171,7 @@ func ListNmStateConfigs(apiClient *clients.Settings, namespace string) ([]*NmSta
 		return nil, fmt.Errorf("namespace to list nmstateconfigs cannot be empty")
 	}
 
-	err := apiClient.List(context.Background(), nmStateConfigList, &goclient.ListOptions{Namespace: namespace})
+	err := apiClient.List(context.TODO(), nmStateConfigList, &goclient.ListOptions{Namespace: namespace})
 
 	if err != nil {
 		glog.V(100).Infof("Failed to list nmStateConfigs in namespace: %s due to %s",

--- a/pkg/bmh/list.go
+++ b/pkg/bmh/list.go
@@ -45,7 +45,7 @@ func List(apiClient *clients.Settings, nsname string, options ...goclient.ListOp
 	glog.V(100).Infof(logMessage)
 
 	var bmhList bmhv1alpha1.BareMetalHostList
-	err := apiClient.List(context.Background(), &bmhList, &passedOptions)
+	err := apiClient.List(context.TODO(), &bmhList, &passedOptions)
 
 	if err != nil {
 		glog.V(100).Infof("Failed to list bareMetalHosts in the nsname %s due to %s", nsname, err.Error())

--- a/pkg/cgu/cgu.go
+++ b/pkg/cgu/cgu.go
@@ -185,7 +185,7 @@ func (builder *CguBuilder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.RanV1alpha1().ClusterGroupUpgrades(builder.Definition.Namespace).Get(
-		context.Background(), builder.Definition.Name, metav1.GetOptions{})
+		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }
@@ -321,7 +321,7 @@ func (builder *CguBuilder) WaitUntilComplete(timeout time.Duration) (*CguBuilder
 	err = wait.PollUntilContextTimeout(
 		context.TODO(), time.Second*3, timeout, true, func(ctx context.Context) (bool, error) {
 			builder.Object, err = builder.apiClient.RanV1alpha1().ClusterGroupUpgrades(builder.Definition.Namespace).Get(
-				context.Background(), builder.Definition.Name, metav1.GetOptions{})
+				context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
 			if err != nil {
 				return false, nil

--- a/pkg/cgu/cgulist.go
+++ b/pkg/cgu/cgulist.go
@@ -30,7 +30,7 @@ func ListInAllNamespaces(apiClient *clients.Settings, options ...runtimeclient.L
 
 	glog.V(100).Infof(logMessage)
 
-	err := apiClient.Client.List(context.Background(), cguList, &passedOptions)
+	err := apiClient.Client.List(context.TODO(), cguList, &passedOptions)
 
 	if err != nil {
 		glog.V(100).Infof("Failed to list all CGUs in all namespaces due to %s", err.Error())

--- a/pkg/clusterlogging/clusterlogforwarder.go
+++ b/pkg/clusterlogging/clusterlogforwarder.go
@@ -156,7 +156,7 @@ func (builder *ClusterLogForwarderBuilder) Get() (*clov1.ClusterLogForwarder, er
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	clusterLogForwarder := &clov1.ClusterLogForwarder{}
-	err := builder.apiClient.Get(context.Background(), goclient.ObjectKey{
+	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, clusterLogForwarder)
@@ -201,7 +201,7 @@ func (builder *ClusterLogForwarderBuilder) Delete() error {
 		return fmt.Errorf("clusterlogforwarder cannot be deleted because it does not exist")
 	}
 
-	err := builder.apiClient.Delete(context.Background(), builder.Definition)
+	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
 
 	if err != nil {
 		return fmt.Errorf("can not delete clusterlogforwarder: %w", err)

--- a/pkg/clusterlogging/clusterlogging.go
+++ b/pkg/clusterlogging/clusterlogging.go
@@ -102,7 +102,7 @@ func (builder *Builder) Get() (*clov1.ClusterLogging, error) {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	clusterLogging := &clov1.ClusterLogging{}
-	err := builder.apiClient.Get(context.Background(), goclient.ObjectKey{
+	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, clusterLogging)
@@ -147,7 +147,7 @@ func (builder *Builder) Delete() error {
 		return fmt.Errorf("clusterLogging cannot be deleted because it does not exist")
 	}
 
-	err := builder.apiClient.Delete(context.Background(), builder.Definition)
+	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
 
 	if err != nil {
 		return fmt.Errorf("can not delete clusterLogging: %w", err)

--- a/pkg/clusteroperator/clusteroperator.go
+++ b/pkg/clusteroperator/clusteroperator.go
@@ -44,7 +44,7 @@ func (builder *Builder) Exists() bool {
 	glog.V(100).Infof("Checking if clusterOperator %s exists", builder.Definition.Name)
 
 	_, err := builder.apiClient.ClusterOperators().Get(
-		context.Background(),
+		context.TODO(),
 		builder.Definition.Name,
 		metav1.GetOptions{})
 
@@ -127,7 +127,7 @@ func (builder *Builder) WaitUntilConditionTrue(
 		context.TODO(), time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 			var err error
 			builder.Object, err = builder.apiClient.ClusterOperators().Get(
-				context.Background(),
+				context.TODO(),
 				builder.Definition.Name,
 				metav1.GetOptions{})
 

--- a/pkg/clusteroperator/list.go
+++ b/pkg/clusteroperator/list.go
@@ -29,7 +29,7 @@ func List(apiClient *clients.Settings, options ...metav1.ListOptions) ([]*Builde
 
 	glog.V(100).Infof(logMessage)
 
-	coList, err := apiClient.ClusterOperators().List(context.Background(), passedOptions)
+	coList, err := apiClient.ClusterOperators().List(context.TODO(), passedOptions)
 
 	if err != nil {
 		glog.V(100).Infof("Failed to list clusterOperators due to %s", err.Error())

--- a/pkg/clusterversion/clusterversion.go
+++ b/pkg/clusterversion/clusterversion.go
@@ -60,7 +60,7 @@ func (builder *Builder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.ConfigV1Interface.ClusterVersions().Get(
-		context.Background(), builder.Definition.Name, metav1.GetOptions{})
+		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }

--- a/pkg/configmap/configmap.go
+++ b/pkg/configmap/configmap.go
@@ -152,7 +152,7 @@ func (builder *Builder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.ConfigMaps(builder.Definition.Namespace).Get(
-		context.Background(), builder.Definition.Name, metav1.GetOptions{})
+		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }

--- a/pkg/console/console.go
+++ b/pkg/console/console.go
@@ -86,7 +86,7 @@ func (builder *Builder) Create() (*Builder, error) {
 	var err error
 	if !builder.Exists() {
 		builder.Object, err = builder.apiClient.Consoles().Create(
-			context.Background(), builder.Definition, metav1.CreateOptions{})
+			context.TODO(), builder.Definition, metav1.CreateOptions{})
 	}
 
 	return builder, err
@@ -102,7 +102,7 @@ func (builder *Builder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.Consoles().Get(
-		context.Background(), builder.Definition.Name, metav1.GetOptions{})
+		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }
@@ -119,7 +119,7 @@ func (builder *Builder) Delete() error {
 		return fmt.Errorf("console cannot be deleted because it does not exist")
 	}
 
-	err := builder.apiClient.Consoles().Delete(context.Background(), builder.Definition.Name, metav1.DeleteOptions{})
+	err := builder.apiClient.Consoles().Delete(context.TODO(), builder.Definition.Name, metav1.DeleteOptions{})
 
 	if err != nil {
 		return fmt.Errorf("cannot delete console: %w", err)
@@ -139,7 +139,7 @@ func (builder *Builder) Update() (*Builder, error) {
 	glog.V(100).Info("Updating cluster console %s", builder.Definition.Name)
 
 	var err error
-	builder.Object, err = builder.apiClient.Consoles().Update(context.Background(), builder.Definition,
+	builder.Object, err = builder.apiClient.Consoles().Update(context.TODO(), builder.Definition,
 		metav1.UpdateOptions{})
 
 	return builder, err

--- a/pkg/daemonset/daemonset.go
+++ b/pkg/daemonset/daemonset.go
@@ -304,7 +304,7 @@ func (builder *Builder) CreateAndWaitUntilReady(timeout time.Duration) (*Builder
 	err = wait.PollUntilContextTimeout(
 		context.TODO(), retryInterval, timeout, true, func(ctx context.Context) (bool, error) {
 			builder.Object, err = builder.apiClient.DaemonSets(builder.Definition.Namespace).Get(
-				context.Background(), builder.Definition.Name, metav1.GetOptions{})
+				context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
 			if err != nil {
 				return false, nil
@@ -343,7 +343,7 @@ func (builder *Builder) DeleteAndWait(timeout time.Duration) error {
 	return wait.PollUntilContextTimeout(
 		context.TODO(), retryInterval, timeout, true, func(ctx context.Context) (bool, error) {
 			_, err := builder.apiClient.DaemonSets(builder.Definition.Namespace).Get(
-				context.Background(), builder.Definition.Name, metav1.GetOptions{})
+				context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 			if k8serrors.IsNotFound(err) {
 				return true, nil
 			}
@@ -363,7 +363,7 @@ func (builder *Builder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.DaemonSets(builder.Definition.Namespace).Get(
-		context.Background(), builder.Definition.Name, metav1.GetOptions{})
+		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }
@@ -386,7 +386,7 @@ func (builder *Builder) IsReady(timeout time.Duration) bool {
 
 			var err error
 			builder.Object, err = builder.apiClient.DaemonSets(builder.Definition.Namespace).Get(
-				context.Background(), builder.Definition.Name, metav1.GetOptions{})
+				context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
 			if err != nil {
 				return false, nil

--- a/pkg/deployment/deployment.go
+++ b/pkg/deployment/deployment.go
@@ -472,7 +472,7 @@ func (builder *Builder) IsReady(timeout time.Duration) bool {
 		context.TODO(), time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 			var err error
 			builder.Object, err = builder.apiClient.Deployments(builder.Definition.Namespace).Get(
-				context.Background(), builder.Definition.Name, metav1.GetOptions{})
+				context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
 			if err != nil {
 				return false, err
@@ -505,7 +505,7 @@ func (builder *Builder) DeleteAndWait(timeout time.Duration) error {
 	return wait.PollUntilContextTimeout(
 		context.TODO(), time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 			_, err := builder.apiClient.Deployments(builder.Definition.Namespace).Get(
-				context.Background(), builder.Definition.Name, metav1.GetOptions{})
+				context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 			if k8serrors.IsNotFound(err) {
 				return true, nil
 			}
@@ -525,7 +525,7 @@ func (builder *Builder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.Deployments(builder.Definition.Namespace).Get(
-		context.Background(), builder.Definition.Name, metav1.GetOptions{})
+		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }
@@ -547,7 +547,7 @@ func (builder *Builder) WaitUntilCondition(condition appsv1.DeploymentConditionT
 	return wait.PollUntilContextTimeout(
 		context.TODO(), time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 			updateDeployment, err := builder.apiClient.Deployments(builder.Definition.Namespace).Get(
-				context.Background(), builder.Definition.Name, metav1.GetOptions{})
+				context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 			if err != nil {
 				return false, nil
 			}

--- a/pkg/deployment/list.go
+++ b/pkg/deployment/list.go
@@ -33,7 +33,7 @@ func List(apiClient *clients.Settings, nsname string, options ...metav1.ListOpti
 
 	glog.V(100).Infof(logMessage)
 
-	deploymentList, err := apiClient.Deployments(nsname).List(context.Background(), passedOptions)
+	deploymentList, err := apiClient.Deployments(nsname).List(context.TODO(), passedOptions)
 
 	if err != nil {
 		glog.V(100).Infof("Failed to list deployments in the namespace %s due to %s", nsname, err.Error())
@@ -75,7 +75,7 @@ func ListInAllNamespaces(apiClient *clients.Settings, options ...metav1.ListOpti
 
 	glog.V(100).Infof(logMessage)
 
-	deploymentList, err := apiClient.Deployments("").List(context.Background(), passedOptions)
+	deploymentList, err := apiClient.Deployments("").List(context.TODO(), passedOptions)
 
 	if err != nil {
 		glog.V(100).Infof("Failed to list deployments in all namespaces due to %s", err.Error())

--- a/pkg/events/list.go
+++ b/pkg/events/list.go
@@ -34,7 +34,7 @@ func List(
 
 	glog.V(100).Infof(logMessage)
 
-	eventList, err := apiClient.Events(nsname).List(context.Background(), passedOptions)
+	eventList, err := apiClient.Events(nsname).List(context.TODO(), passedOptions)
 
 	if err != nil {
 		glog.V(100).Infof("Failed to list Events in the namespace %s due to %s", nsname, err.Error())

--- a/pkg/infrastructure/infrastructure.go
+++ b/pkg/infrastructure/infrastructure.go
@@ -58,7 +58,7 @@ func (builder *Builder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.ConfigV1Interface.Infrastructures().Get(
-		context.Background(), builder.Definition.Name, metav1.GetOptions{})
+		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }

--- a/pkg/lso/localvolumediscovery.go
+++ b/pkg/lso/localvolumediscovery.go
@@ -173,7 +173,7 @@ func (builder *LocalVolumeDiscoveryBuilder) Delete() error {
 		return fmt.Errorf("localVolumeDiscovery cannot be deleted because it does not exist")
 	}
 
-	err := builder.apiClient.Delete(context.Background(), builder.Definition)
+	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
 
 	if err != nil {
 		return fmt.Errorf("can not delete localVolumeDiscovery: %w", err)

--- a/pkg/lso/localvolumeset.go
+++ b/pkg/lso/localvolumeset.go
@@ -142,7 +142,7 @@ func (builder *LocalVolumeSetBuilder) Delete() error {
 		return fmt.Errorf("localVolumeSet cannot be deleted because it does not exist")
 	}
 
-	err := builder.apiClient.Delete(context.Background(), builder.Definition)
+	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
 
 	if err != nil {
 		return fmt.Errorf("can not delete localVolumeSet: %w", err)

--- a/pkg/mco/kubeletconfig.go
+++ b/pkg/mco/kubeletconfig.go
@@ -93,7 +93,7 @@ func (builder *KubeletConfigBuilder) Create() (*KubeletConfigBuilder, error) {
 	var err error
 	if !builder.Exists() {
 		builder.Object, err = builder.apiClient.KubeletConfigs().Create(
-			context.Background(), builder.Definition, metav1.CreateOptions{})
+			context.TODO(), builder.Definition, metav1.CreateOptions{})
 	}
 
 	return builder, err
@@ -133,7 +133,7 @@ func (builder *KubeletConfigBuilder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.KubeletConfigs().Get(
-		context.Background(), builder.Definition.Name, metav1.GetOptions{})
+		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }

--- a/pkg/mco/machineconfig.go
+++ b/pkg/mco/machineconfig.go
@@ -145,7 +145,7 @@ func (builder *MCBuilder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.MachineConfigs().Get(
-		context.Background(), builder.Definition.Name, metav1.GetOptions{})
+		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }

--- a/pkg/mco/mcp.go
+++ b/pkg/mco/mcp.go
@@ -141,7 +141,7 @@ func (builder *MCPBuilder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.MachineConfigPools().Get(
-		context.Background(), builder.Definition.Name, metav1.GetOptions{})
+		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }
@@ -184,7 +184,7 @@ func (builder *MCPBuilder) WaitToBeInCondition(
 
 	return wait.PollUntilContextTimeout(
 		context.TODO(), fiveScds, timeout, true, func(ctx context.Context) (bool, error) {
-			mcp, err := builder.apiClient.MachineConfigPools().Get(context.Background(),
+			mcp, err := builder.apiClient.MachineConfigPools().Get(context.TODO(),
 				builder.Object.Name, metav1.GetOptions{})
 
 			if err != nil {
@@ -210,7 +210,7 @@ func (builder *MCPBuilder) WaitForUpdate(timeout time.Duration) error {
 	glog.V(100).Infof("WaitForUpdate waits up to specified time %v until updating"+
 		" machineConfigPool object is updated", timeout)
 
-	mcpUpdating, err := builder.apiClient.MachineConfigPools().Get(context.Background(),
+	mcpUpdating, err := builder.apiClient.MachineConfigPools().Get(context.TODO(),
 		builder.Object.Name, metav1.GetOptions{})
 
 	if err != nil {
@@ -221,7 +221,7 @@ func (builder *MCPBuilder) WaitForUpdate(timeout time.Duration) error {
 		if condition.Type == "Updating" && condition.Status == isTrue {
 			err := wait.PollUntilContextTimeout(
 				context.TODO(), fiveScds, timeout, true, func(ctx context.Context) (bool, error) {
-					mcpUpdated, err := builder.apiClient.MachineConfigPools().Get(context.Background(),
+					mcpUpdated, err := builder.apiClient.MachineConfigPools().Get(context.TODO(),
 						builder.Object.Name, metav1.GetOptions{})
 
 					if err != nil {

--- a/pkg/mco/mcplist.go
+++ b/pkg/mco/mcplist.go
@@ -30,7 +30,7 @@ func ListMCP(apiClient *clients.Settings, options ...metav1.ListOptions) ([]*MCP
 
 	glog.V(100).Infof(logMessage)
 
-	mcpList, err := apiClient.MachineConfigPools().List(context.Background(), passedOptions)
+	mcpList, err := apiClient.MachineConfigPools().List(context.TODO(), passedOptions)
 
 	if err != nil {
 		glog.V(100).Infof("Failed to list MCP objects due to %s", err.Error())

--- a/pkg/nad/builder.go
+++ b/pkg/nad/builder.go
@@ -119,7 +119,7 @@ func (builder *Builder) Create() (*Builder, error) {
 
 	if !builder.Exists() {
 		builder.Object, err = builder.apiClient.NetworkAttachmentDefinitions(builder.Definition.Namespace).
-			Create(context.Background(), builder.Definition, metav1.CreateOptions{})
+			Create(context.TODO(), builder.Definition, metav1.CreateOptions{})
 		if err != nil {
 			return builder, fmt.Errorf("fail to create NAD object due to: " + err.Error())
 		}
@@ -144,7 +144,7 @@ func (builder *Builder) Delete() error {
 	}
 
 	err := builder.apiClient.NetworkAttachmentDefinitions(builder.Definition.Namespace).Delete(
-		context.Background(), builder.Definition.Namespace, metav1.DeleteOptions{})
+		context.TODO(), builder.Definition.Namespace, metav1.DeleteOptions{})
 
 	if err != nil {
 		return fmt.Errorf("fail to delete NAD object due to: %w", err)
@@ -187,7 +187,7 @@ func (builder *Builder) Exists() bool {
 	glog.V(100).Infof("Checking if NetworkAttachmentDefinition %s exists in namespace %s",
 		builder.Definition.Name, builder.Definition.Namespace)
 
-	_, err := builder.apiClient.NetworkAttachmentDefinitions(builder.Definition.Namespace).Get(context.Background(),
+	_, err := builder.apiClient.NetworkAttachmentDefinitions(builder.Definition.Namespace).Get(context.TODO(),
 		builder.Definition.Name, metav1.GetOptions{})
 
 	return nil == err || !k8serrors.IsNotFound(err)

--- a/pkg/namespace/list.go
+++ b/pkg/namespace/list.go
@@ -27,7 +27,7 @@ func List(apiClient *clients.Settings, options ...v1.ListOptions) ([]*Builder, e
 
 	glog.V(100).Infof(logMessage)
 
-	namespacesList, err := apiClient.CoreV1Interface.Namespaces().List(context.Background(), passedOptions)
+	namespacesList, err := apiClient.CoreV1Interface.Namespaces().List(context.TODO(), passedOptions)
 	if err != nil {
 		glog.V(100).Infof("Failed to list namespaces due to %s", err.Error())
 

--- a/pkg/namespace/namespace.go
+++ b/pkg/namespace/namespace.go
@@ -184,7 +184,7 @@ func (builder *Builder) DeleteAndWait(timeout time.Duration) error {
 
 	return wait.PollUntilContextTimeout(
 		context.TODO(), time.Second, timeout, true, func(ctx context.Context) (bool, error) {
-			_, err := builder.apiClient.Namespaces().Get(context.Background(), builder.Definition.Name, metav1.GetOptions{})
+			_, err := builder.apiClient.Namespaces().Get(context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 			if k8serrors.IsNotFound(err) {
 				return true, nil
 			}
@@ -203,7 +203,7 @@ func (builder *Builder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.Namespaces().Get(
-		context.Background(), builder.Definition.Name, metav1.GetOptions{})
+		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }
@@ -257,7 +257,7 @@ func (builder *Builder) CleanObjects(cleanTimeout time.Duration, objects ...sche
 			resource.Resource, builder.Definition.Name)
 
 		err := builder.apiClient.Resource(resource).Namespace(builder.Definition.Name).DeleteCollection(
-			context.Background(), metav1.DeleteOptions{
+			context.TODO(), metav1.DeleteOptions{
 				GracePeriodSeconds: ptr.To(int64(0)),
 			}, metav1.ListOptions{})
 
@@ -271,7 +271,7 @@ func (builder *Builder) CleanObjects(cleanTimeout time.Duration, objects ...sche
 		err = wait.PollUntilContextTimeout(
 			context.TODO(), 3*time.Second, cleanTimeout, true, func(ctx context.Context) (bool, error) {
 				objList, err := builder.apiClient.Resource(resource).Namespace(builder.Definition.Name).List(
-					context.Background(), metav1.ListOptions{})
+					context.TODO(), metav1.ListOptions{})
 
 				if err != nil || len(objList.Items) > 1 {
 					// avoid timeout due to default automatically created openshift

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -60,7 +60,7 @@ func (builder *ConfigBuilder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.ConfigV1Interface.Networks().Get(
-		context.Background(), builder.Definition.Name, metav1.GetOptions{})
+		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }

--- a/pkg/networkpolicy/multinetworkpolicy.go
+++ b/pkg/networkpolicy/multinetworkpolicy.go
@@ -250,7 +250,7 @@ func (builder *MultiNetworkPolicyBuilder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.MultiNetworkPolicies(builder.Definition.Namespace).Get(
-		context.Background(), builder.Definition.Name, metav1.GetOptions{})
+		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }

--- a/pkg/networkpolicy/networkpolicy.go
+++ b/pkg/networkpolicy/networkpolicy.go
@@ -239,7 +239,7 @@ func (builder *NetworkPolicyBuilder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.NetworkPolicies(builder.Definition.Namespace).Get(
-		context.Background(), builder.Definition.Name, metav1.GetOptions{})
+		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }

--- a/pkg/nmstate/policylist.go
+++ b/pkg/nmstate/policylist.go
@@ -29,7 +29,7 @@ func ListPolicy(apiClient *clients.Settings, options ...goclient.ListOptions) ([
 	glog.V(100).Infof(logMessage)
 
 	policyList := &nmstateV1.NodeNetworkConfigurationPolicyList{}
-	err := apiClient.Client.List(context.Background(), policyList, &passedOptions)
+	err := apiClient.Client.List(context.TODO(), policyList, &passedOptions)
 
 	if err != nil {
 		glog.V(100).Infof("Failed to list NodeNetworkConfigurationPolicy due to %s", err.Error())

--- a/pkg/nodes/list.go
+++ b/pkg/nodes/list.go
@@ -34,7 +34,7 @@ func List(apiClient *clients.Settings, options ...v1.ListOptions) ([]*Builder, e
 
 	glog.V(100).Infof(logMessage)
 
-	nodeList, err := apiClient.CoreV1Interface.Nodes().List(context.Background(), passedOptions)
+	nodeList, err := apiClient.CoreV1Interface.Nodes().List(context.TODO(), passedOptions)
 	if err != nil {
 		glog.V(100).Infof("Failed to list nodes due to %s", err.Error())
 

--- a/pkg/nodes/node.go
+++ b/pkg/nodes/node.go
@@ -167,7 +167,7 @@ func (builder *Builder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.CoreV1().Nodes().Get(
-		context.Background(), builder.Definition.Name, metav1.GetOptions{})
+		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }
@@ -185,7 +185,7 @@ func (builder *Builder) Delete() error {
 	}
 
 	err := builder.apiClient.CoreV1().Nodes().Delete(
-		context.Background(),
+		context.TODO(),
 		builder.Definition.Name,
 		metav1.DeleteOptions{})
 

--- a/pkg/ocm/placementbindingList.go
+++ b/pkg/ocm/placementbindingList.go
@@ -32,7 +32,7 @@ func ListPlacementBindingsInAllNamespaces(apiClient *clients.Settings,
 
 	placementBindingList := &policiesv1.PlacementBindingList{}
 
-	err := apiClient.Client.List(context.Background(), placementBindingList, &passedOptions)
+	err := apiClient.Client.List(context.TODO(), placementBindingList, &passedOptions)
 
 	if err != nil {
 		glog.V(100).Infof("Failed to list all placementBindings in all namespaces due to %s", err.Error())

--- a/pkg/ocm/placementrulelist.go
+++ b/pkg/ocm/placementrulelist.go
@@ -32,7 +32,7 @@ func ListPlacementrulesInAllNamespaces(apiClient *clients.Settings,
 
 	placementRuleList := &placementrulev1.PlacementRuleList{}
 
-	err := apiClient.Client.List(context.Background(), placementRuleList, &passedOptions)
+	err := apiClient.Client.List(context.TODO(), placementRuleList, &passedOptions)
 
 	if err != nil {
 		glog.V(100).Infof("Failed to list all placementrules in all namespaces due to %s", err.Error())

--- a/pkg/ocm/policylist.go
+++ b/pkg/ocm/policylist.go
@@ -32,7 +32,7 @@ func ListPoliciesInAllNamespaces(apiClient *clients.Settings,
 
 	policyList := &policiesv1.PolicyList{}
 
-	err := apiClient.Client.List(context.Background(), policyList, &passedOptions)
+	err := apiClient.Client.List(context.TODO(), policyList, &passedOptions)
 
 	if err != nil {
 		glog.V(100).Infof("Failed to list all policies in all namespaces due to %s", err.Error())

--- a/pkg/ocm/policyset.go
+++ b/pkg/ocm/policyset.go
@@ -87,7 +87,7 @@ func (builder *PolicySetBuilder) Get() (*policiesv1beta1.PolicySet, error) {
 
 	policySet := &policiesv1beta1.PolicySet{}
 
-	err := builder.apiClient.Get(context.Background(), runtimeclient.ObjectKey{
+	err := builder.apiClient.Get(context.TODO(), runtimeclient.ObjectKey{
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, policySet)

--- a/pkg/ocm/policysetlist.go
+++ b/pkg/ocm/policysetlist.go
@@ -32,7 +32,7 @@ func ListPolicieSetsInAllNamespaces(apiClient *clients.Settings,
 
 	policySetList := &policiesv1beta1.PolicySetList{}
 
-	err := apiClient.Client.List(context.Background(), policySetList, &passedOptions)
+	err := apiClient.Client.List(context.TODO(), policySetList, &passedOptions)
 
 	if err != nil {
 		glog.V(100).Infof("Failed to list all policySets in all namespaces due to %s", err.Error())

--- a/pkg/olm/catalogsource.go
+++ b/pkg/olm/catalogsource.go
@@ -98,7 +98,7 @@ func (builder *CatalogSourceBuilder) Create() (*CatalogSourceBuilder, error) {
 
 	var err error
 	if !builder.Exists() {
-		builder.Object, err = builder.apiClient.CatalogSources(builder.Definition.Namespace).Create(context.Background(),
+		builder.Object, err = builder.apiClient.CatalogSources(builder.Definition.Namespace).Create(context.TODO(),
 			builder.Definition, metav1.CreateOptions{})
 	}
 
@@ -118,7 +118,7 @@ func (builder *CatalogSourceBuilder) Exists() bool {
 	var err error
 	builder.Object, err = builder.apiClient.OperatorsV1alpha1Interface.CatalogSources(
 		builder.Definition.Namespace).Get(
-		context.Background(), builder.Definition.Name, metav1.GetOptions{})
+		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }

--- a/pkg/olm/catalogsourcelist.go
+++ b/pkg/olm/catalogsourcelist.go
@@ -37,7 +37,7 @@ func ListCatalogSources(
 	glog.V(100).Infof(logMessage)
 
 	catalogSourceList, err := apiClient.OperatorsV1alpha1Interface.CatalogSources(nsname).List(
-		context.Background(), passedOptions)
+		context.TODO(), passedOptions)
 
 	if err != nil {
 		glog.V(100).Infof("Failed to list catalogsources in the namespace %s due to %s", nsname, err.Error())

--- a/pkg/olm/clusterserviceversion.go
+++ b/pkg/olm/clusterserviceversion.go
@@ -72,7 +72,7 @@ func (builder *ClusterServiceVersionBuilder) Exists() bool {
 	var err error
 	builder.Object, err = builder.apiClient.OperatorsV1alpha1Interface.ClusterServiceVersions(
 		builder.Definition.Namespace).Get(
-		context.Background(), builder.Definition.Name, metav1.GetOptions{})
+		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }

--- a/pkg/olm/clusterserviceversionlist.go
+++ b/pkg/olm/clusterserviceversionlist.go
@@ -38,7 +38,7 @@ func ListClusterServiceVersion(
 	glog.V(100).Infof(logMessage)
 
 	csvList, err := apiClient.OperatorsV1alpha1Interface.ClusterServiceVersions(nsname).List(
-		context.Background(), passedOptions)
+		context.TODO(), passedOptions)
 
 	if err != nil {
 		glog.V(100).Infof("Failed to list clusterserviceversion in the nsname %s due to %s", nsname, err.Error())
@@ -120,7 +120,7 @@ func ListClusterServiceVersionInAllNamespaces(
 
 	glog.V(100).Infof(logMessage)
 
-	csvList, err := apiClient.ClusterServiceVersions("").List(context.Background(), passedOptions)
+	csvList, err := apiClient.ClusterServiceVersions("").List(context.TODO(), passedOptions)
 
 	if err != nil {
 		glog.V(100).Infof("Failed to list CSVs in all namespaces due to %s", err.Error())

--- a/pkg/olm/installplan.go
+++ b/pkg/olm/installplan.go
@@ -66,7 +66,7 @@ func (builder *InstallPlanBuilder) Create() (*InstallPlanBuilder, error) {
 
 	var err error
 	if !builder.Exists() {
-		builder.Object, err = builder.apiClient.InstallPlans(builder.Definition.Namespace).Create(context.Background(),
+		builder.Object, err = builder.apiClient.InstallPlans(builder.Definition.Namespace).Create(context.TODO(),
 			builder.Definition, metav1.CreateOptions{})
 	}
 
@@ -84,7 +84,7 @@ func (builder *InstallPlanBuilder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.InstallPlans(builder.Definition.Namespace).Get(
-		context.Background(), builder.Definition.Name, metav1.GetOptions{})
+		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }

--- a/pkg/olm/installplanlist.go
+++ b/pkg/olm/installplanlist.go
@@ -34,7 +34,7 @@ func ListInstallPlan(
 
 	glog.V(100).Infof(logMessage)
 
-	installPlanList, err := apiClient.InstallPlans(nsname).List(context.Background(), passedOptions)
+	installPlanList, err := apiClient.InstallPlans(nsname).List(context.TODO(), passedOptions)
 
 	if err != nil {
 		glog.V(100).Infof("Failed to list all installplan in namespace %s due to %s",

--- a/pkg/olm/packagemanifest.go
+++ b/pkg/olm/packagemanifest.go
@@ -105,7 +105,7 @@ func (builder *PackageManifestBuilder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.PackageManifestInterface.PackageManifests(
-		builder.Definition.Namespace).Get(context.Background(), builder.Definition.Name, metav1.GetOptions{})
+		builder.Definition.Namespace).Get(context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }

--- a/pkg/olm/packagemanifestlist.go
+++ b/pkg/olm/packagemanifestlist.go
@@ -36,7 +36,7 @@ func ListPackageManifest(
 
 	glog.V(100).Infof(logMessage)
 
-	pkgManifestList, err := apiClient.PackageManifestInterface.PackageManifests(nsname).List(context.Background(),
+	pkgManifestList, err := apiClient.PackageManifestInterface.PackageManifests(nsname).List(context.TODO(),
 		passedOptions)
 
 	if err != nil {

--- a/pkg/pod/list.go
+++ b/pkg/pod/list.go
@@ -33,7 +33,7 @@ func List(apiClient *clients.Settings, nsname string, options ...v1.ListOptions)
 
 	glog.V(100).Infof(logMessage)
 
-	podList, err := apiClient.Pods(nsname).List(context.Background(), passedOptions)
+	podList, err := apiClient.Pods(nsname).List(context.TODO(), passedOptions)
 
 	if err != nil {
 		glog.V(100).Infof("Failed to list pods in the nsname %s due to %s", nsname, err.Error())
@@ -75,7 +75,7 @@ func ListInAllNamespaces(apiClient *clients.Settings, options ...v1.ListOptions)
 
 	glog.V(100).Infof(logMessage)
 
-	podList, err := apiClient.Pods("").List(context.Background(), passedOptions)
+	podList, err := apiClient.Pods("").List(context.TODO(), passedOptions)
 
 	if err != nil {
 		glog.V(100).Infof("Failed to list all pods due to %s", err.Error())
@@ -109,7 +109,7 @@ func ListByNamePattern(apiClient *clients.Settings, namePattern, nsname string) 
 		return nil, fmt.Errorf("failed to list pods, 'nsname' parameter is empty")
 	}
 
-	podList, err := apiClient.Pods(nsname).List(context.Background(), v1.ListOptions{})
+	podList, err := apiClient.Pods(nsname).List(context.TODO(), v1.ListOptions{})
 
 	if err != nil {
 		glog.V(100).Infof("Failed to list pods filtered by the name pattern %s in the nsname %s due to %s",

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -270,7 +270,7 @@ func (builder *Builder) WaitUntilInStatus(status corev1.PodPhase, timeout time.D
 	return wait.PollUntilContextTimeout(
 		context.TODO(), time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 			updatePod, err := builder.apiClient.Pods(builder.Object.Namespace).Get(
-				context.Background(), builder.Object.Name, metav1.GetOptions{})
+				context.TODO(), builder.Object.Name, metav1.GetOptions{})
 			if err != nil {
 				return false, nil
 			}
@@ -291,7 +291,7 @@ func (builder *Builder) WaitUntilDeleted(timeout time.Duration) error {
 	err := wait.PollUntilContextTimeout(
 		context.TODO(), time.Second, timeout, false, func(ctx context.Context) (bool, error) {
 			_, err := builder.apiClient.Pods(builder.Definition.Namespace).Get(
-				context.Background(), builder.Definition.Name, metav1.GetOptions{})
+				context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 			if err == nil {
 				glog.V(100).Infof("pod %s/%s still present", builder.Definition.Namespace, builder.Definition.Name)
 
@@ -336,7 +336,7 @@ func (builder *Builder) WaitUntilCondition(condition corev1.PodConditionType, ti
 	return wait.PollUntilContextTimeout(
 		context.TODO(), time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 			updatePod, err := builder.apiClient.Pods(builder.Object.Namespace).Get(
-				context.Background(), builder.Object.Name, metav1.GetOptions{})
+				context.TODO(), builder.Object.Name, metav1.GetOptions{})
 			if err != nil {
 				return false, nil
 			}
@@ -503,7 +503,7 @@ func (builder *Builder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.Pods(builder.Definition.Namespace).Get(
-		context.Background(), builder.Definition.Name, metav1.GetOptions{})
+		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }
@@ -1079,7 +1079,7 @@ func (builder *Builder) GetLog(logStartTime time.Duration, containerName string)
 	logStart := int64(logStartTime.Seconds())
 	req := builder.apiClient.Pods(builder.Definition.Namespace).GetLogs(builder.Definition.Name, &corev1.PodLogOptions{
 		SinceSeconds: &logStart, Container: containerName})
-	log, err := req.Stream(context.Background())
+	log, err := req.Stream(context.TODO())
 
 	if err != nil {
 		return "", err
@@ -1106,7 +1106,7 @@ func (builder *Builder) GetFullLog(containerName string) (string, error) {
 	}
 
 	logStream, err := builder.apiClient.Pods(builder.Definition.Namespace).GetLogs(builder.Definition.Name,
-		&corev1.PodLogOptions{Container: containerName}).Stream(context.Background())
+		&corev1.PodLogOptions{Container: containerName}).Stream(context.TODO())
 
 	if err != nil {
 		return "", err

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -60,7 +60,7 @@ func (builder *Builder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.ConfigV1Interface.Proxies().Get(
-		context.Background(), builder.Definition.Name, metav1.GetOptions{})
+		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }

--- a/pkg/rbac/clusterrole.go
+++ b/pkg/rbac/clusterrole.go
@@ -224,7 +224,7 @@ func (builder *ClusterRoleBuilder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.ClusterRoles().Get(
-		context.Background(), builder.Definition.Name, metav1.GetOptions{})
+		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }

--- a/pkg/rbac/clusterrolebinding.go
+++ b/pkg/rbac/clusterrolebinding.go
@@ -228,7 +228,7 @@ func (builder *ClusterRoleBindingBuilder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.ClusterRoleBindings().Get(
-		context.Background(), builder.Definition.Name, metav1.GetOptions{})
+		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }

--- a/pkg/rbac/role.go
+++ b/pkg/rbac/role.go
@@ -244,7 +244,7 @@ func (builder *RoleBuilder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.Roles(builder.Definition.Namespace).Get(
-		context.Background(), builder.Definition.Name, metav1.GetOptions{})
+		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }

--- a/pkg/rbac/rolebinding.go
+++ b/pkg/rbac/rolebinding.go
@@ -237,7 +237,7 @@ func (builder *RoleBindingBuilder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.RoleBindings(builder.Definition.Namespace).Get(
-		context.Background(), builder.Definition.Name, metav1.GetOptions{})
+		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }

--- a/pkg/route/route.go
+++ b/pkg/route/route.go
@@ -205,7 +205,7 @@ func (builder *Builder) Get() (*routev1.Route, error) {
 
 	route := &routev1.Route{}
 
-	err := builder.apiClient.Get(context.Background(), client.ObjectKey{
+	err := builder.apiClient.Get(context.TODO(), client.ObjectKey{
 		Name:      builder.Definition.Name,
 		Namespace: builder.Definition.Namespace,
 	}, route)

--- a/pkg/scc/scc.go
+++ b/pkg/scc/scc.go
@@ -554,7 +554,7 @@ func (builder *Builder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.SecurityContextConstraints().Get(
-		context.Background(), builder.Definition.Name, metav1.GetOptions{})
+		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }

--- a/pkg/secret/secret.go
+++ b/pkg/secret/secret.go
@@ -143,7 +143,7 @@ func (builder *Builder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.Secrets(builder.Definition.Namespace).Get(
-		context.Background(), builder.Definition.Name, metav1.GetOptions{})
+		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -150,7 +150,7 @@ func (builder *Builder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.Services(builder.Definition.Namespace).Get(
-		context.Background(), builder.Definition.Name, metav1.GetOptions{})
+		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }

--- a/pkg/serviceaccount/serviceaccount.go
+++ b/pkg/serviceaccount/serviceaccount.go
@@ -145,7 +145,7 @@ func (builder *Builder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.ServiceAccounts(builder.Definition.Namespace).Get(
-		context.Background(), builder.Definition.Name, metav1.GetOptions{})
+		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }

--- a/pkg/servicemesh/control-plane.go
+++ b/pkg/servicemesh/control-plane.go
@@ -407,7 +407,7 @@ func (builder *ControlPlaneBuilder) Delete() error {
 			builder.Definition.Name, builder.Definition.Namespace)
 	}
 
-	err := builder.apiClient.Delete(context.Background(), builder.Definition)
+	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
 
 	if err != nil {
 		return fmt.Errorf("can not delete serviceMeshControlPlane %s in namespace %s due to %w",

--- a/pkg/servicemesh/member-roll.go
+++ b/pkg/servicemesh/member-roll.go
@@ -150,7 +150,7 @@ func (builder *MemberRollBuilder) Delete() error {
 			builder.Definition.Name, builder.Definition.Namespace)
 	}
 
-	err := builder.apiClient.Delete(context.Background(), builder.Definition)
+	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
 
 	if err != nil {
 		return fmt.Errorf("can not delete serviceMeshMemberRoll %s in namespace %s due to %w",

--- a/pkg/sriov/network.go
+++ b/pkg/sriov/network.go
@@ -333,7 +333,7 @@ func (builder *NetworkBuilder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.SriovnetworkV1().SriovNetworks(builder.Definition.Namespace).Get(
-		context.Background(), builder.Definition.Name, metav1.GetOptions{})
+		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }

--- a/pkg/sriov/networklist.go
+++ b/pkg/sriov/networklist.go
@@ -40,7 +40,7 @@ func List(apiClient *clients.Settings, nsname string, options ...metav1.ListOpti
 	glog.V(100).Infof(logMessage)
 
 	networkList, err := apiClient.ClientSrIov.SriovnetworkV1().
-		SriovNetworks(nsname).List(context.Background(), passedOptions)
+		SriovNetworks(nsname).List(context.TODO(), passedOptions)
 
 	if err != nil {
 		glog.V(100).Infof("Failed to list sriov networks in the namespace %s due to %s", nsname, err.Error())

--- a/pkg/sriov/networknodestatelist.go
+++ b/pkg/sriov/networknodestatelist.go
@@ -41,7 +41,7 @@ func ListNetworkNodeState(
 	glog.V(100).Infof(logMessage)
 
 	networkNodeStateList, err := apiClient.ClientSrIov.SriovnetworkV1().
-		SriovNetworkNodeStates(nsname).List(context.Background(), passedOptions)
+		SriovNetworkNodeStates(nsname).List(context.TODO(), passedOptions)
 
 	if err != nil {
 		glog.V(100).Infof("Failed to list SriovNetworkNodeStates in the namespace %s due to %s", nsname, err.Error())

--- a/pkg/sriov/policy.go
+++ b/pkg/sriov/policy.go
@@ -312,7 +312,7 @@ func (builder *PolicyBuilder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.SriovnetworkV1().SriovNetworkNodePolicies(builder.Definition.Namespace).Get(
-		context.Background(), builder.Definition.Name, metav1.GetOptions{})
+		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }

--- a/pkg/sriov/policylist.go
+++ b/pkg/sriov/policylist.go
@@ -40,7 +40,7 @@ func ListPolicy(apiClient *clients.Settings, nsname string, options ...metav1.Li
 	glog.V(100).Infof(logMessage)
 
 	networkNodePoliciesList, err := apiClient.ClientSrIov.SriovnetworkV1().
-		SriovNetworkNodePolicies(nsname).List(context.Background(), passedOptions)
+		SriovNetworkNodePolicies(nsname).List(context.TODO(), passedOptions)
 
 	if err != nil {
 		glog.V(100).Infof("Failed to list SriovNetworkNodePolicies in the namespace %s due to %s",

--- a/pkg/sriov/poolconfiglist.go
+++ b/pkg/sriov/poolconfiglist.go
@@ -20,7 +20,7 @@ func ListPoolConfigs(apiClient *clients.Settings, namespace string) ([]*PoolConf
 		return nil, fmt.Errorf("failed to list sriovNetworkPoolConfigs, 'namespace' parameter is empty")
 	}
 
-	err := apiClient.List(context.Background(), sriovNetworkPoolConfigList, &client.ListOptions{Namespace: namespace})
+	err := apiClient.List(context.TODO(), sriovNetworkPoolConfigList, &client.ListOptions{Namespace: namespace})
 
 	if err != nil {
 		glog.V(100).Infof("Failed to list SriovNetworkPoolConfigs in namespace: %s due to %s",

--- a/pkg/statefulset/list.go
+++ b/pkg/statefulset/list.go
@@ -33,7 +33,7 @@ func List(apiClient *clients.Settings, nsname string, options ...metav1.ListOpti
 
 	glog.V(100).Infof(logMessage)
 
-	statefulsetList, err := apiClient.StatefulSets(nsname).List(context.Background(), passedOptions)
+	statefulsetList, err := apiClient.StatefulSets(nsname).List(context.TODO(), passedOptions)
 
 	if err != nil {
 		glog.V(100).Infof("Failed to list statefulsets in the namespace %s due to %s", nsname, err.Error())

--- a/pkg/statefulset/statefulset.go
+++ b/pkg/statefulset/statefulset.go
@@ -200,7 +200,7 @@ func (builder *Builder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.StatefulSets(builder.Definition.Namespace).Get(
-		context.Background(), builder.Definition.Name, metav1.GetOptions{})
+		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }
@@ -222,7 +222,7 @@ func (builder *Builder) IsReady(timeout time.Duration) bool {
 		context.TODO(), time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 			var err error
 			builder.Object, err = builder.apiClient.StatefulSets(builder.Definition.Namespace).Get(
-				context.Background(), builder.Definition.Name, metav1.GetOptions{})
+				context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
 			if err != nil {
 				return false, err

--- a/pkg/storage/pv.go
+++ b/pkg/storage/pv.go
@@ -55,7 +55,7 @@ func (builder *PVBuilder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.PersistentVolumes().Get(
-		context.Background(), builder.Definition.Name, metav1.GetOptions{})
+		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }

--- a/pkg/storage/pvc.go
+++ b/pkg/storage/pvc.go
@@ -271,7 +271,7 @@ func (builder *PVCBuilder) DeleteAndWait(timeout time.Duration) error {
 	return wait.PollUntilContextTimeout(
 		context.TODO(), time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 			_, err := builder.apiClient.PersistentVolumeClaims(builder.Definition.Namespace).Get(
-				context.Background(), builder.Definition.Name, metav1.GetOptions{})
+				context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 			if k8serrors.IsNotFound(err) {
 				return true, nil
 			}
@@ -319,7 +319,7 @@ func (builder *PVCBuilder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.PersistentVolumeClaims(builder.Definition.Namespace).Get(
-		context.Background(), builder.Definition.Name, metav1.GetOptions{})
+		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }

--- a/pkg/velero/backup.go
+++ b/pkg/velero/backup.go
@@ -257,7 +257,7 @@ func (builder *BackupBuilder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.VeleroV1().Backups(builder.Definition.Namespace).Get(
-		context.Background(), builder.Definition.Name, metav1.GetOptions{})
+		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }

--- a/pkg/velero/restore.go
+++ b/pkg/velero/restore.go
@@ -136,7 +136,7 @@ func (builder *RestoreBuilder) Exists() bool {
 
 	var err error
 	builder.Object, err = builder.apiClient.VeleroV1().Restores(builder.Definition.Namespace).Get(
-		context.Background(), builder.Definition.Name, metav1.GetOptions{})
+		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }


### PR DESCRIPTION
Make the usage of `context.Background()` and `context.TODO()` the same throughout the repo.

There were more references of TODO than Background.

Similar to: 
- https://github.com/test-network-function/cnf-certification-test/pull/1216
- https://github.com/test-network-function/cnfcert-tests-verification/pull/398