### PR TITLE
Fix extraneous fmt.Sprintf calls

### DIFF
--- a/pkg/configmap/configmap.go
+++ b/pkg/configmap/configmap.go
@@ -230,7 +230,7 @@ func (builder *Builder) validate() (bool, error) {
 	if builder.apiClient == nil {
 		glog.V(100).Infof("The %s builder apiclient is nil", resourceCRD)
 
-		return false, fmt.Errorf(fmt.Sprintf("%s builder cannot have nil apiClient", resourceCRD))
+		return false, fmt.Errorf("%s builder cannot have nil apiClient", resourceCRD)
 	}
 
 	if builder.errorMsg != "" {

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -85,7 +85,7 @@ func (builder *ConfigBuilder) validate() (bool, error) {
 	if builder.apiClient == nil {
 		glog.V(100).Infof("The %s builder apiclient is nil", resourceCRD)
 
-		return false, fmt.Errorf(fmt.Sprintf("%s builder cannot have nil apiClient", resourceCRD))
+		return false, fmt.Errorf("%s builder cannot have nil apiClient", resourceCRD)
 	}
 
 	return true, nil

--- a/pkg/nfd/nodefeaturediscovery.go
+++ b/pkg/nfd/nodefeaturediscovery.go
@@ -258,7 +258,7 @@ func (builder *Builder) validate() (bool, error) {
 	if builder.apiClient == nil {
 		glog.V(100).Infof("The %s builder apiclient is nil", resourceCRD)
 
-		return false, fmt.Errorf(fmt.Sprintf("%s builder cannot have nil apiClient", resourceCRD))
+		return false, fmt.Errorf("%s builder cannot have nil apiClient", resourceCRD)
 	}
 
 	return true, nil

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -85,7 +85,7 @@ func (builder *Builder) validate() (bool, error) {
 	if builder.apiClient == nil {
 		glog.V(100).Infof("The %s builder apiclient is nil", resourceCRD)
 
-		return false, fmt.Errorf(fmt.Sprintf("%s builder cannot have nil apiClient", resourceCRD))
+		return false, fmt.Errorf("%s builder cannot have nil apiClient", resourceCRD)
 	}
 
 	return true, nil

--- a/pkg/sriov/operatorconfig.go
+++ b/pkg/sriov/operatorconfig.go
@@ -222,7 +222,7 @@ func (builder *OperatorConfigBuilder) validate() (bool, error) {
 	if builder.apiClient == nil {
 		glog.V(100).Infof("The %s builder apiclient is nil", resourceCRD)
 
-		return false, fmt.Errorf(fmt.Sprintf("%s builder cannot have nil apiClient", resourceCRD))
+		return false, fmt.Errorf("%s builder cannot have nil apiClient", resourceCRD)
 	}
 
 	if builder.errorMsg != "" {

--- a/pkg/storage/pvc.go
+++ b/pkg/storage/pvc.go
@@ -121,7 +121,7 @@ func (builder *PVCBuilder) WithPVCCapacity(capacity string) (*PVCBuilder, error)
 			glog.V(100).Infof("Failed to parse %v", capacity)
 			builder.errorMsg = fmt.Sprintf("Failed to parse: %v", capacity)
 
-			return builder, fmt.Errorf(fmt.Sprintf("Failed to parse: %v", capacity))
+			return builder, fmt.Errorf("failed to parse: %v", capacity)
 		}
 
 		return builder, nil


### PR DESCRIPTION
I'm surprised the linter didn't catch these already.