### PR TITLE
Adjust deployment pkg returns and logs

### DIFF
--- a/pkg/deployment/deployment.go
+++ b/pkg/deployment/deployment.go
@@ -90,6 +90,8 @@ func NewBuilder(
 func Pull(apiClient *clients.Settings, name, nsname string) (*Builder, error) {
 	// Safeguard against nil apiClient interfaces.
 	if apiClient == nil {
+		glog.V(100).Infof("The apiClient is nil")
+
 		return nil, fmt.Errorf("apiClient cannot be nil")
 	}
 
@@ -106,10 +108,14 @@ func Pull(apiClient *clients.Settings, name, nsname string) (*Builder, error) {
 	}
 
 	if name == "" {
+		glog.V(100).Infof("The name of the deployment is empty")
+
 		return nil, fmt.Errorf("deployment 'name' cannot be empty")
 	}
 
 	if nsname == "" {
+		glog.V(100).Infof("The namespace of the deployment is empty")
+
 		return nil, fmt.Errorf("deployment 'namespace' cannot be empty")
 	}
 
@@ -581,13 +587,13 @@ func (builder *Builder) validate() (bool, error) {
 	if builder.Definition == nil {
 		glog.V(100).Infof("The %s is undefined", resourceCRD)
 
-		builder.errorMsg = msg.UndefinedCrdObjectErrString(resourceCRD)
+		return false, fmt.Errorf(msg.UndefinedCrdObjectErrString(resourceCRD))
 	}
 
 	if builder.apiClient == nil {
 		glog.V(100).Infof("The %s builder apiclient is nil", resourceCRD)
 
-		builder.errorMsg = fmt.Sprintf("%s builder cannot have nil apiClient", resourceCRD)
+		return false, fmt.Errorf("%s builder cannot have nil apiClient", resourceCRD)
 	}
 
 	if builder.errorMsg != "" {


### PR DESCRIPTION
Follow up to: #314 

- Adds back in the `glog` calls for a few functions.
- Adjust the returned error in `validate`.