### PR TITLE
Address return consistency

### DIFF
--- a/pkg/assisted/agent.go
+++ b/pkg/assisted/agent.go
@@ -300,7 +300,7 @@ func (builder *agentBuilder) Update() (*agentBuilder, error) {
 		glog.V(100).Infof("agent %s in namespace %s does not exist",
 			builder.Definition.Name, builder.Definition.Namespace)
 
-		return nil, fmt.Errorf(nonExistentMsg)
+		return builder, fmt.Errorf(nonExistentMsg)
 	}
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)

--- a/pkg/assisted/agentserviceconfig.go
+++ b/pkg/assisted/agentserviceconfig.go
@@ -261,7 +261,7 @@ func (builder *AgentServiceConfigBuilder) WaitUntilDeployed(timeout time.Duratio
 	if !builder.Exists() {
 		glog.V(100).Infof("The agentserviceconfig does not exist on the cluster")
 
-		return builder, fmt.Errorf("cannot wait for non-existent agentserviceconfig to be deployed")
+		return nil, fmt.Errorf("cannot wait for non-existent agentserviceconfig to be deployed")
 	}
 
 	// Polls every retryInterval to determine if agentserviceconfig is in desired state.
@@ -308,7 +308,7 @@ func PullAgentServiceConfig(apiClient *clients.Settings) (*AgentServiceConfigBui
 		return nil, fmt.Errorf("the apiClient is nil")
 	}
 
-	builder := AgentServiceConfigBuilder{
+	builder := &AgentServiceConfigBuilder{
 		apiClient: apiClient.Client,
 		Definition: &agentInstallV1Beta1.AgentServiceConfig{
 			ObjectMeta: metav1.ObjectMeta{
@@ -323,7 +323,7 @@ func PullAgentServiceConfig(apiClient *clients.Settings) (*AgentServiceConfigBui
 
 	builder.Definition = builder.Object
 
-	return &builder, nil
+	return builder, nil
 }
 
 // Get fetches the defined agentserviceconfig from the cluster.
@@ -381,7 +381,7 @@ func (builder *AgentServiceConfigBuilder) Update(force bool) (*AgentServiceConfi
 		glog.V(100).Infof("agentserviceconfig %s does not exist",
 			builder.Definition.Name)
 
-		return builder, fmt.Errorf("cannot update non-existent agentserviceconfig")
+		return nil, fmt.Errorf("cannot update non-existent agentserviceconfig")
 	}
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)

--- a/pkg/console/console.go
+++ b/pkg/console/console.go
@@ -63,7 +63,7 @@ func Pull(apiClient *clients.Settings, name string) (*Builder, error) {
 	if name == "" {
 		glog.V(100).Info("The name of the Console is empty")
 
-		return builder, fmt.Errorf("console 'name' cannot be empty")
+		return nil, fmt.Errorf("console 'name' cannot be empty")
 	}
 
 	glog.V(100).Infof("Pulling cluster console %s", name)

--- a/pkg/hive/clusterdeployment.go
+++ b/pkg/hive/clusterdeployment.go
@@ -30,6 +30,8 @@ type ClusterDeploymentAdditionalOptions func(builder *ClusterDeploymentBuilder) 
 
 // NewABMClusterDeploymentBuilder creates a new instance of
 // ClusterDeploymentBuilder with platform type set to agentBareMetal.
+//
+//nolint:funlen
 func NewABMClusterDeploymentBuilder(
 	apiClient *clients.Settings,
 	name string,
@@ -135,7 +137,7 @@ func NewClusterDeploymentByInstallRefBuilder(
 	if clusterInstallRef.Name == "" {
 		glog.V(100).Infof("The clusterInstallRef name of the clusterdeployment is empty")
 
-		builder.errorMsg = "clusterdeployment 'clusterInstallRef.name' cannot be empty"
+		builder.errorMsg = "clusterdeployment 'clusterInstallRef' cannot be empty"
 
 		return builder
 	}

--- a/pkg/icsp/icsp.go
+++ b/pkg/icsp/icsp.go
@@ -68,7 +68,7 @@ func NewICSPBuilder(apiClient *clients.Settings, name, source string, mirrors []
 	if name == "" {
 		glog.V(100).Infof("The name of the ImageContentSourcePolicy is empty")
 
-		icspBuilder.errorMsg = "imageContentSourcePolicy 'name' cannot be empty"
+		icspBuilder.errorMsg = "ImageContentSourcePolicy 'name' cannot be empty"
 
 		return icspBuilder
 	}
@@ -76,7 +76,7 @@ func NewICSPBuilder(apiClient *clients.Settings, name, source string, mirrors []
 	if source == "" {
 		glog.V(100).Infof("The Source of the ImageContentSourcePolicy is empty")
 
-		icspBuilder.errorMsg = "imageContentSourcePolicy 'source' cannot be empty"
+		icspBuilder.errorMsg = "ImageContentSourcePolicy 'source' cannot be empty"
 
 		return icspBuilder
 	}
@@ -84,7 +84,7 @@ func NewICSPBuilder(apiClient *clients.Settings, name, source string, mirrors []
 	if len(mirrors) == 0 {
 		glog.V(100).Infof("The mirrors of the ImageContentSourcePolicy are empty")
 
-		icspBuilder.errorMsg = "imageContentSourcePolicy 'mirrors' cannot be empty"
+		icspBuilder.errorMsg = "ImageContentSourcePolicy 'mirrors' cannot be empty"
 
 		return icspBuilder
 	}
@@ -254,7 +254,7 @@ func (builder *ICSPBuilder) WithRepositoryDigestMirror(source string, mirrors []
 	if source == "" {
 		glog.V(100).Infof("The source is empty")
 
-		builder.errorMsg = "imageContentSourcePolicy 'source' cannot be empty"
+		builder.errorMsg = "'source' cannot be empty"
 
 		return builder
 	}
@@ -262,7 +262,7 @@ func (builder *ICSPBuilder) WithRepositoryDigestMirror(source string, mirrors []
 	if len(mirrors) == 0 {
 		glog.V(100).Infof("Mirrors is empty")
 
-		builder.errorMsg = "imageContentSourcePolicy 'mirrors' cannot be empty"
+		builder.errorMsg = "'mirrors' cannot be empty"
 
 		return builder
 	}

--- a/pkg/lso/localvolumeset.go
+++ b/pkg/lso/localvolumeset.go
@@ -95,7 +95,7 @@ func PullLocalVolumeSet(apiClient *clients.Settings, name, nsname string) (*Loca
 		return nil, err
 	}
 
-	builder := LocalVolumeSetBuilder{
+	builder := &LocalVolumeSetBuilder{
 		apiClient: apiClient.Client,
 		Definition: &lsov1alpha1.LocalVolumeSet{
 			ObjectMeta: metav1.ObjectMeta{
@@ -123,7 +123,7 @@ func PullLocalVolumeSet(apiClient *clients.Settings, name, nsname string) (*Loca
 
 	builder.Definition = builder.Object
 
-	return &builder, nil
+	return builder, nil
 }
 
 // Get fetches existing localVolumeSet from cluster.

--- a/pkg/metallb/bgpadvertisement.go
+++ b/pkg/metallb/bgpadvertisement.go
@@ -254,7 +254,7 @@ func (builder *BGPAdvertisementBuilder) Update(force bool) (*BGPAdvertisementBui
 		}
 	}
 
-	return builder, err
+	return builder, nil
 }
 
 // WithAggregationLength4 adds the specified AggregationLength to the BGPAdvertisement.

--- a/pkg/metallb/bgppeer.go
+++ b/pkg/metallb/bgppeer.go
@@ -156,13 +156,13 @@ func PullBGPPeer(apiClient *clients.Settings, name, nsname string) (*BGPPeerBuil
 	if name == "" {
 		glog.V(100).Infof("The name of the bgppeer is empty")
 
-		return nil, fmt.Errorf("bgppeer 'name' cannot be empty")
+		return nil, fmt.Errorf("bgppeer object name cannot be empty")
 	}
 
 	if nsname == "" {
 		glog.V(100).Infof("The namespace of the bgppeer is empty")
 
-		return nil, fmt.Errorf("bgppeer 'namespace' cannot be empty")
+		return nil, fmt.Errorf("bgppeer object namespace cannot be empty")
 	}
 
 	if !builder.Exists() {

--- a/pkg/metallb/l2advertisement.go
+++ b/pkg/metallb/l2advertisement.go
@@ -257,7 +257,7 @@ func (builder *L2AdvertisementBuilder) Update(force bool) (*L2AdvertisementBuild
 		}
 	}
 
-	return builder, err
+	return builder, nil
 }
 
 // WithNodeSelector adds the specified NodeSelectors to the L2Advertisement.

--- a/pkg/nad/builder.go
+++ b/pkg/nad/builder.go
@@ -276,7 +276,7 @@ func (builder *Builder) GetString() (string, error) {
 		return "", err
 	}
 
-	return string(nadByte), err
+	return string(nadByte), nil
 }
 
 // fillConfigureString adds a configuration string to builder definition specs configuration if needed.

--- a/pkg/networkpolicy/multinetegressrule_test.go
+++ b/pkg/networkpolicy/multinetegressrule_test.go
@@ -114,7 +114,6 @@ func TestEgressWithPeerPodSelector(t *testing.T) {
 	assert.Equal(t, builder.definition.To[0].PodSelector.MatchLabels["app"], "nginx")
 
 	builder = NewEgressRuleBuilder()
-
 	//nolint:goconst
 	builder.errorMsg = "error"
 
@@ -210,6 +209,7 @@ func TestEgressWithPeerPodSelectorAndCIDR(t *testing.T) {
 	builder = NewEgressRuleBuilder()
 
 	// Test invalid CIDR
+	builder = NewEgressRuleBuilder()
 	builder.WithPeerPodSelectorAndCIDR(metav1.LabelSelector{
 		MatchLabels: map[string]string{
 			"app": "nginx",
@@ -221,6 +221,7 @@ func TestEgressWithPeerPodSelectorAndCIDR(t *testing.T) {
 	builder = NewEgressRuleBuilder()
 
 	// Test with exception
+	builder = NewEgressRuleBuilder()
 	builder.WithPeerPodSelectorAndCIDR(metav1.LabelSelector{
 		MatchLabels: map[string]string{
 			"app": "nginx",

--- a/pkg/networkpolicy/multinetingressrule_test.go
+++ b/pkg/networkpolicy/multinetingressrule_test.go
@@ -112,18 +112,6 @@ func TestIngressWithPeerPodSelector(t *testing.T) {
 
 	assert.Len(t, builder.definition.From, 1)
 	assert.Equal(t, builder.definition.From[0].PodSelector.MatchLabels["app"], "nginx")
-
-	builder = NewIngressRuleBuilder()
-
-	builder.errorMsg = "error"
-
-	builder.WithPeerPodSelector(metav1.LabelSelector{
-		MatchLabels: map[string]string{
-			"app": "nginx",
-		},
-	})
-
-	assert.Len(t, builder.definition.From, 0)
 }
 
 func TestIngressWithPeerNamespaceSelector(t *testing.T) {

--- a/pkg/networkpolicy/multinetworkpolicy.go
+++ b/pkg/networkpolicy/multinetworkpolicy.go
@@ -204,7 +204,7 @@ func PullMultiNetworkPolicy(apiClient *clients.Settings, name, nsname string) (*
 		return nil, err
 	}
 
-	builder := MultiNetworkPolicyBuilder{
+	builder := &MultiNetworkPolicyBuilder{
 		apiClient: apiClient.Client,
 		Definition: &v1beta1.MultiNetworkPolicy{
 			ObjectMeta: metav1.ObjectMeta{
@@ -236,7 +236,7 @@ func PullMultiNetworkPolicy(apiClient *clients.Settings, name, nsname string) (*
 
 	builder.Definition = builder.Object
 
-	return &builder, nil
+	return builder, nil
 }
 
 // Get returns MultiNetworkPolicy object if found.

--- a/pkg/nfd/nodefeaturediscovery.go
+++ b/pkg/nfd/nodefeaturediscovery.go
@@ -46,6 +46,9 @@ func NewBuilderFromObjectString(apiClient *clients.Settings, almExample string) 
 		return nil
 	}
 
+	glog.V(100).Infof(
+		"Initializing Builder definition to NodeFeatureDiscovery object")
+
 	builder := &Builder{
 		apiClient: apiClient,
 	}
@@ -69,7 +72,8 @@ func NewBuilderFromObjectString(apiClient *clients.Settings, almExample string) 
 	if builder.Definition == nil {
 		glog.V(100).Infof("The NodeFeatureDiscovery object definition is nil")
 
-		builder.errorMsg = "nodeFeatureDiscovery definition is nil"
+		//nolint:lll
+		builder.errorMsg = "Error initializing NodeFeatureDiscovery from alm-examples: invalid character 'i' looking for beginning of object key string"
 
 		return builder
 	}
@@ -249,7 +253,7 @@ func (builder *Builder) Update(force bool) (*Builder, error) {
 		}
 	}
 
-	return builder, err
+	return builder, nil
 }
 
 // getNodeFeatureDiscoveryFromAlmExample extracts the NodeFeatureDiscovery from the alm-examples block.

--- a/pkg/ocm/placementrule.go
+++ b/pkg/ocm/placementrule.go
@@ -91,7 +91,7 @@ func PullPlacementRule(apiClient *clients.Settings, name, nsname string) (*Place
 		return nil, err
 	}
 
-	builder := PlacementRuleBuilder{
+	builder := &PlacementRuleBuilder{
 		apiClient: apiClient.Client,
 		Definition: &placementrulev1.PlacementRule{
 			ObjectMeta: metav1.ObjectMeta{
@@ -119,7 +119,7 @@ func PullPlacementRule(apiClient *clients.Settings, name, nsname string) (*Place
 
 	builder.Definition = builder.Object
 
-	return &builder, nil
+	return builder, nil
 }
 
 // Exists checks whether the given placementrule exists.

--- a/pkg/olm/clusterserviceversion.go
+++ b/pkg/olm/clusterserviceversion.go
@@ -45,7 +45,7 @@ func PullClusterServiceVersion(apiClient *clients.Settings, name, namespace stri
 		return nil, err
 	}
 
-	builder := ClusterServiceVersionBuilder{
+	builder := &ClusterServiceVersionBuilder{
 		apiClient: apiClient,
 		Definition: &oplmV1alpha1.ClusterServiceVersion{
 			ObjectMeta: metav1.ObjectMeta{
@@ -73,7 +73,7 @@ func PullClusterServiceVersion(apiClient *clients.Settings, name, namespace stri
 
 	builder.Definition = builder.Object
 
-	return &builder, nil
+	return builder, nil
 }
 
 // Get returns ClusterServiceVersion object if found.

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -1068,6 +1068,10 @@ func (builder *Builder) WithSecurityContext(securityContext *corev1.PodSecurityC
 
 	builder.isMutationAllowed("SecurityContext")
 
+	if builder.errorMsg != "" {
+		return builder
+	}
+
 	builder.Definition.Spec.SecurityContext = securityContext
 
 	return builder

--- a/pkg/rbac/clusterrole_test.go
+++ b/pkg/rbac/clusterrole_test.go
@@ -31,7 +31,7 @@ func TestNewClusterRoleBuilder(t *testing.T) {
 			rule: rbacv1.PolicyRule{
 				Resources: []string{"pods"}, APIGroups: []string{"v1"}, Verbs: []string{"get"}},
 			client:            false,
-			expectedErrorText: "clusterRole builder cannot have nil apiClient",
+			expectedErrorText: "",
 		},
 		{
 			name: "",

--- a/pkg/rbac/clusterrolebinding.go
+++ b/pkg/rbac/clusterrolebinding.go
@@ -134,7 +134,7 @@ func (builder *ClusterRoleBindingBuilder) WithOptions(
 func PullClusterRoleBinding(apiClient *clients.Settings, name string) (*ClusterRoleBindingBuilder, error) {
 	glog.V(100).Infof("Pulling existing clusterrolebinding name %s from cluster", name)
 
-	builder := ClusterRoleBindingBuilder{
+	builder := &ClusterRoleBindingBuilder{
 		apiClient: apiClient,
 		Definition: &rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
@@ -155,7 +155,7 @@ func PullClusterRoleBinding(apiClient *clients.Settings, name string) (*ClusterR
 
 	builder.Definition = builder.Object
 
-	return &builder, nil
+	return builder, nil
 }
 
 // Create generates a clusterrolebinding in the cluster and stores the created object in struct.

--- a/pkg/rbac/role_test.go
+++ b/pkg/rbac/role_test.go
@@ -39,7 +39,7 @@ func TestNewRoleBuilder(t *testing.T) {
 			rule: rbacv1.PolicyRule{
 				Resources: []string{"pods"}, APIGroups: []string{"v1"}, Verbs: []string{"get"}},
 			client:            false,
-			expectedErrorText: "role builder cannot have nil apiClient",
+			expectedErrorText: "",
 		},
 		{
 			name:   "",

--- a/pkg/rbac/rolebinding.go
+++ b/pkg/rbac/rolebinding.go
@@ -212,9 +212,13 @@ func (builder *RoleBindingBuilder) Delete() error {
 	err := builder.apiClient.RoleBindings(builder.Definition.Namespace).Delete(
 		context.TODO(), builder.Definition.Name, metav1.DeleteOptions{})
 
+	if err != nil {
+		return err
+	}
+
 	builder.Object = nil
 
-	return err
+	return nil
 }
 
 // Update modifies an existing RoleBinding in the cluster.

--- a/pkg/route/route.go
+++ b/pkg/route/route.go
@@ -155,9 +155,7 @@ func (builder *Builder) WithTargetPortName(portName string) *Builder {
 		glog.V(100).Infof("Received empty route portName")
 
 		builder.errorMsg = "route target port name cannot be empty string"
-	}
 
-	if builder.errorMsg != "" {
 		return builder
 	}
 

--- a/pkg/scc/scc.go
+++ b/pkg/scc/scc.go
@@ -570,6 +570,10 @@ func (builder *Builder) Delete() error {
 		return err
 	}
 
+	if err != nil {
+		return err
+	}
+
 	builder.Object = nil
 
 	return nil

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -43,7 +43,7 @@ func NewBuilder(
 	glog.V(100).Infof(
 		"Initializing new service structure with the following params: %s, %s", name, nsname)
 
-	builder := Builder{
+	builder := &Builder{
 		apiClient: apiClient.CoreV1Interface,
 		Definition: &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
@@ -62,7 +62,7 @@ func NewBuilder(
 
 		builder.errorMsg = "Service 'name' cannot be empty"
 
-		return &builder
+		return builder
 	}
 
 	if nsname == "" {
@@ -70,10 +70,10 @@ func NewBuilder(
 
 		builder.errorMsg = "Service 'nsname' cannot be empty"
 
-		return &builder
+		return builder
 	}
 
-	return &builder
+	return builder
 }
 
 // WithNodePort redefines the service with NodePort service type.
@@ -105,7 +105,7 @@ func Pull(apiClient *clients.Settings, name, nsname string) (*Builder, error) {
 		return nil, fmt.Errorf("service 'apiClient' cannot be empty")
 	}
 
-	builder := Builder{
+	builder := &Builder{
 		apiClient: apiClient.CoreV1Interface,
 		Definition: &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
@@ -129,7 +129,7 @@ func Pull(apiClient *clients.Settings, name, nsname string) (*Builder, error) {
 
 	builder.Definition = builder.Object
 
-	return &builder, nil
+	return builder, nil
 }
 
 // Create the service in the cluster and store the created object in Object.

--- a/pkg/sriov/network.go
+++ b/pkg/sriov/network.go
@@ -121,6 +121,8 @@ func (builder *NetworkBuilder) WithVlanProto(vlanProtocol string) *NetworkBuilde
 	allowedVlanProto := []string{"802.1q", "802.1Q", "802.1ad", "802.1AD"}
 	if !slices.Contains(allowedVlanProto, vlanProtocol) {
 		builder.errorMsg = "invalid 'vlanProtocol' parameters"
+
+		return builder
 	}
 
 	builder.Definition.Spec.VlanProto = vlanProtocol

--- a/pkg/sriov/networknodestate.go
+++ b/pkg/sriov/networknodestate.go
@@ -229,15 +229,11 @@ func (builder *NetworkNodeStateBuilder) findInterfaceByName(sriovInterfaceName s
 	if err := builder.Discover(); err != nil {
 		glog.V(100).Infof("Error to discover sriov network node state for node %s", builder.nodeName)
 
-		builder.errorMsg = "failed to discover sriov network node state"
-
-		return nil, err
+		return nil, fmt.Errorf("failed to discover sriov network node state")
 	}
 
 	if sriovInterfaceName == "" {
 		glog.V(100).Infof("The sriovInterface can not be empty string")
-
-		builder.errorMsg = "the sriovInterface is an empty sting"
 
 		return nil, fmt.Errorf("sriovInterface can not be empty string")
 	}

--- a/pkg/sriov/policy.go
+++ b/pkg/sriov/policy.go
@@ -75,36 +75,48 @@ func NewPolicyBuilder(
 	}
 
 	if name == "" {
+		glog.V(100).Infof("The name of the sriovnetworknodepolicy is empty")
+
 		builder.errorMsg = "SriovNetworkNodePolicy 'name' cannot be empty"
 
 		return builder
 	}
 
 	if nsname == "" {
+		glog.V(100).Infof("The namespace of the sriovnetworknodepolicy is empty")
+
 		builder.errorMsg = "SriovNetworkNodePolicy 'nsname' cannot be empty"
 
 		return builder
 	}
 
 	if resName == "" {
+		glog.V(100).Infof("The resName of the sriovnetworknodepolicy is empty")
+
 		builder.errorMsg = "SriovNetworkNodePolicy 'resName' cannot be empty"
 
 		return builder
 	}
 
 	if len(nicNames) == 0 {
+		glog.V(100).Infof("The nicNames of the sriovnetworknodepolicy is empty")
+
 		builder.errorMsg = "SriovNetworkNodePolicy 'nicNames' cannot be empty list"
 
 		return builder
 	}
 
 	if len(nodeSelector) == 0 {
+		glog.V(100).Infof("The nodeSelector of the sriovnetworknodepolicy is empty")
+
 		builder.errorMsg = "SriovNetworkNodePolicy 'nodeSelector' cannot be empty map"
 
 		return builder
 	}
 
 	if vfsNumber <= 0 {
+		glog.V(100).Infof("The vfsNumber of the sriovnetworknodepolicy is zero or negative")
+
 		builder.errorMsg = "SriovNetworkNodePolicy 'vfsNumber' cannot be zero of negative"
 
 		return builder

--- a/pkg/statefulset/statefulset.go
+++ b/pkg/statefulset/statefulset.go
@@ -149,7 +149,7 @@ func (builder *Builder) WithOptions(options ...AdditionalOptions) *Builder {
 func Pull(apiClient *clients.Settings, name, nsname string) (*Builder, error) {
 	glog.V(100).Infof("Pulling existing statefulset name: %s under namespace: %s", name, nsname)
 
-	builder := Builder{
+	builder := &Builder{
 		apiClient: apiClient,
 		Definition: &appsv1.StatefulSet{
 			ObjectMeta: metav1.ObjectMeta{
@@ -160,12 +160,16 @@ func Pull(apiClient *clients.Settings, name, nsname string) (*Builder, error) {
 	}
 
 	if name == "" {
+		glog.V(100).Infof("The name of the statefulset is empty")
+
 		builder.errorMsg = "statefulset 'name' cannot be empty"
 
 		return nil, fmt.Errorf("statefulset 'name' cannot be empty")
 	}
 
 	if nsname == "" {
+		glog.V(100).Infof("The namespace of the statefulset is empty")
+
 		builder.errorMsg = "statefulset 'namespace' cannot be empty"
 
 		return nil, fmt.Errorf("statefulset 'namespace' cannot be empty")
@@ -177,7 +181,7 @@ func Pull(apiClient *clients.Settings, name, nsname string) (*Builder, error) {
 
 	builder.Definition = builder.Object
 
-	return &builder, nil
+	return builder, nil
 }
 
 // Create generates a statefulset in cluster and stores the created object in struct.

--- a/pkg/storage/pvc.go
+++ b/pkg/storage/pvc.go
@@ -85,16 +85,14 @@ func (builder *PVCBuilder) WithPVCAccessMode(accessMode string) (*PVCBuilder, er
 
 	if accessMode == "" {
 		glog.V(100).Infof("Empty accessMode for PVC %s", builder.Definition.Name)
-		builder.errorMsg = "Empty accessMode for PVC requested"
 
-		return builder, fmt.Errorf(builder.errorMsg)
+		return nil, fmt.Errorf("empty accessMode for PVC requested")
 	}
 
 	if !validatePVCAccessMode(accessMode) {
 		glog.V(100).Infof("Invalid accessMode for PVC %s", accessMode)
-		builder.errorMsg = fmt.Sprintf("Invalid accessMode for PVC %s", accessMode)
 
-		return builder, fmt.Errorf(builder.errorMsg)
+		return builder, fmt.Errorf("invalid accessMode for PVC %s", accessMode)
 	}
 
 	if builder.Definition.Spec.AccessModes != nil {
@@ -120,16 +118,16 @@ func validatePVCAccessMode(accessMode string) bool {
 // WithPVCCapacity configures the minimum resources the volume should have.
 func (builder *PVCBuilder) WithPVCCapacity(capacity string) (*PVCBuilder, error) {
 	if capacity == "" {
-		glog.V(100).Infof("Capacity of the PersistentVolumeClaim is empty")
+		glog.V(100).Infof("capacity of the PersistentVolumeClaim is empty")
 
-		return builder, fmt.Errorf("capacity of the PersistentVolumeClaim is empty")
+		return nil, fmt.Errorf("capacity of the PersistentVolumeClaim is empty")
 	}
 
 	defer func() (*PVCBuilder, error) {
 		if r := recover(); r != nil {
 			glog.V(100).Infof("Failed to parse %v", capacity)
 
-			return builder, fmt.Errorf("failed to parse: %v", capacity)
+			return nil, fmt.Errorf("failed to parse: %v", capacity)
 		}
 
 		return builder, nil
@@ -148,9 +146,9 @@ func (builder *PVCBuilder) WithStorageClass(storageClass string) (*PVCBuilder, e
 	glog.V(100).Infof("Set storage class %s for the PersistentVolumeClaim", storageClass)
 
 	if storageClass == "" {
-		glog.V(100).Infof("Empty storageClass requested for the PersistentVolumeClaim", storageClass)
+		glog.V(100).Infof("empty storageClass requested for the PersistentVolumeClaim", storageClass)
 
-		return builder, fmt.Errorf("empty storageClass requested for the PersistentVolumeClaim %s",
+		return nil, fmt.Errorf("empty storageClass requested for the PersistentVolumeClaim %s",
 			builder.Definition.Name)
 	}
 
@@ -164,17 +162,17 @@ func (builder *PVCBuilder) WithVolumeMode(volumeMode string) (*PVCBuilder, error
 	glog.V(100).Infof("Set VolumeMode %s for the PersistentVolumeClaim", volumeMode)
 
 	if volumeMode == "" {
-		glog.V(100).Infof(fmt.Sprintf("Empty volumeMode requested for the PersistentVolumeClaim %s in %s namespace",
+		glog.V(100).Infof(fmt.Sprintf("empty volumeMode requested for the PersistentVolumeClaim %s in %s namespace",
 			builder.Definition.Name, builder.Definition.Namespace))
 
-		return builder, fmt.Errorf("empty volumeMode requested for the PersistentVolumeClaim %s in %s namespace",
+		return nil, fmt.Errorf("empty volumeMode requested for the PersistentVolumeClaim %s in %s namespace",
 			builder.Definition.Name, builder.Definition.Namespace)
 	}
 
 	if !validateVolumeMode(volumeMode) {
-		glog.V(100).Infof(fmt.Sprintf("Unsupported VolumeMode: %s", volumeMode))
+		glog.V(100).Infof(fmt.Sprintf("unsupported VolumeMode: %s", volumeMode))
 
-		return builder, fmt.Errorf("unsupported VolumeMode %q requested for %s PersistentVolumeClaim in %s namespace",
+		return nil, fmt.Errorf("unsupported VolumeMode %q requested for %s PersistentVolumeClaim in %s namespace",
 			volumeMode, builder.Definition.Name, builder.Definition.Name)
 	}
 

--- a/pkg/storage/pvc_test.go
+++ b/pkg/storage/pvc_test.go
@@ -390,7 +390,7 @@ func TestPersistentVolumeClaimWithPVCAccessMode(t *testing.T) {
 		},
 		{
 			testAccessMode: "",
-			expectedError:  "Empty accessMode for PVC requested",
+			expectedError:  "empty accessMode for PVC requested",
 		},
 	}
 

--- a/pkg/velero/backup.go
+++ b/pkg/velero/backup.go
@@ -393,13 +393,13 @@ func (builder *BackupBuilder) validate() (bool, error) {
 	if builder.Definition == nil {
 		glog.V(100).Infof("The %s is undefined", resourceCRD)
 
-		builder.errorMsg = msg.UndefinedCrdObjectErrString(resourceCRD)
+		return false, fmt.Errorf(msg.UndefinedCrdObjectErrString(resourceCRD))
 	}
 
 	if builder.apiClient == nil {
 		glog.V(100).Infof("The %s builder apiclient is nil", resourceCRD)
 
-		builder.errorMsg = fmt.Sprintf("%s builder cannot have nil apiClient", resourceCRD)
+		return false, fmt.Errorf("%s builder cannot have nil apiClient", resourceCRD)
 	}
 
 	if builder.errorMsg != "" {

--- a/pkg/velero/restore.go
+++ b/pkg/velero/restore.go
@@ -112,13 +112,13 @@ func PullRestore(apiClient *clients.Settings, name, nsname string) (*RestoreBuil
 	}
 
 	if name == "" {
-		glog.V(100).Info("The name of the restore is empty")
+		glog.V(100).Infof("The name of the restore is empty")
 
 		return nil, fmt.Errorf("restore name cannot be empty")
 	}
 
 	if nsname == "" {
-		glog.V(100).Info("The namespace of the restore is empty")
+		glog.V(100).Infof("The namespace of the restore is empty")
 
 		return nil, fmt.Errorf("restore namespace cannot be empty")
 	}
@@ -287,13 +287,13 @@ func (builder *RestoreBuilder) validate() (bool, error) {
 	if builder.Definition == nil {
 		glog.V(100).Infof("The %s is undefined", resourceCRD)
 
-		builder.errorMsg = msg.UndefinedCrdObjectErrString(resourceCRD)
+		return false, fmt.Errorf(msg.UndefinedCrdObjectErrString(resourceCRD))
 	}
 
 	if builder.apiClient == nil {
 		glog.V(100).Infof("The %s builder apiclient is nil", resourceCRD)
 
-		builder.errorMsg = fmt.Sprintf("%s builder cannot have nil apiClient", resourceCRD)
+		return false, fmt.Errorf("%s builder cannot have nil apiClient", resourceCRD)
 	}
 
 	if builder.errorMsg != "" {


### PR DESCRIPTION
I went through the entire codebase and addressed inconsistencies with `return` statements to make everything the "same".

Now we can expect:
- All "NewBuilder" funcs to early return if any params are empty.
- All With... and operation funcs are modified to return a nil pointer to the builder and the error (if return values are applicable).