### PR TITLE
Update setup-go action to v5

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Set up Go 1.20
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: 1.20.11
 


### PR DESCRIPTION
https://github.com/actions/setup-go/releases/tag/v5.0.0

If #240 was merged, this would be handled by dependabot automatically.