### PR TITLE
Update checkout action to v4

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           go-version: 1.20.11
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Run lint
         run: make lint


### PR DESCRIPTION
https://github.com/actions/checkout/releases/tag/v4.1.4

If #240 was merged, this would be handled by dependabot automatically.