### PR TITLE
Delete() funcs should return nil if not exists

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -83,6 +83,8 @@ linters-settings:
     checks:
       - all
       - ST1001
+      - "-SA1006"
+    
 
 linters:
   enable:
@@ -122,7 +124,6 @@ linters:
     - predeclared
     - promlinter
     - revive
-    - staticcheck
     - stylecheck
     - tenv
     - thelper

--- a/pkg/bmh/baremetalhost_test.go
+++ b/pkg/bmh/baremetalhost_test.go
@@ -957,7 +957,7 @@ func TestBareMetalHostDeleteAndWaitUntilDeleted(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		builder, err := testCase.testBmHost.DeleteAndWaitUntilDeleted(2 * time.Second)
+		builder, err := testCase.testBmHost.DeleteAndWaitUntilDeleted(5 * time.Second)
 		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {

--- a/pkg/clusterlogging/clusterlogging.go
+++ b/pkg/clusterlogging/clusterlogging.go
@@ -348,13 +348,13 @@ func (builder *Builder) validate() (bool, error) {
 	if builder.Definition == nil {
 		glog.V(100).Infof("The %s is undefined", resourceCRD)
 
-		builder.errorMsg = msg.UndefinedCrdObjectErrString(resourceCRD)
+		return false, fmt.Errorf(msg.UndefinedCrdObjectErrString(resourceCRD))
 	}
 
 	if builder.apiClient == nil {
 		glog.V(100).Infof("The %s builder apiclient is nil", resourceCRD)
 
-		builder.errorMsg = fmt.Sprintf("%s builder cannot have nil apiClient", resourceCRD)
+		return false, fmt.Errorf("%s builder cannot have nil apiClient", resourceCRD)
 	}
 
 	if builder.errorMsg != "" {

--- a/pkg/hive/clusterdeployment.go
+++ b/pkg/hive/clusterdeployment.go
@@ -364,6 +364,8 @@ func (builder *ClusterDeploymentBuilder) Delete() error {
 
 		builder.Object = nil
 
+		builder.Object = nil
+
 		return nil
 	}
 

--- a/pkg/hive/clusterimageset.go
+++ b/pkg/hive/clusterimageset.go
@@ -293,13 +293,13 @@ func (builder *ClusterImageSetBuilder) validate() (bool, error) {
 	if builder.Definition == nil {
 		glog.V(100).Infof("The %s is undefined", resourceCRD)
 
-		builder.errorMsg = msg.UndefinedCrdObjectErrString(resourceCRD)
+		return false, fmt.Errorf(msg.UndefinedCrdObjectErrString(resourceCRD))
 	}
 
 	if builder.apiClient == nil {
 		glog.V(100).Infof("The %s builder apiclient is nil", resourceCRD)
 
-		builder.errorMsg = fmt.Sprintf("%s builder cannot have nil apiClient", resourceCRD)
+		return false, fmt.Errorf("%s builder cannot have nil apiClient", resourceCRD)
 	}
 
 	if builder.errorMsg != "" {

--- a/pkg/hive/config.go
+++ b/pkg/hive/config.go
@@ -219,13 +219,13 @@ func (builder *ConfigBuilder) validate() (bool, error) {
 	if builder.Definition == nil {
 		glog.V(100).Infof("The %s is undefined", resourceCRD)
 
-		builder.errorMsg = msg.UndefinedCrdObjectErrString(resourceCRD)
+		return false, fmt.Errorf(msg.UndefinedCrdObjectErrString(resourceCRD))
 	}
 
 	if builder.apiClient == nil {
 		glog.V(100).Infof("The %s builder apiclient is nil", resourceCRD)
 
-		builder.errorMsg = fmt.Sprintf("%s builder cannot have nil apiClient", resourceCRD)
+		return false, fmt.Errorf("%s builder cannot have nil apiClient", resourceCRD)
 	}
 
 	if builder.errorMsg != "" {

--- a/pkg/ibi/imageclusterinstall.go
+++ b/pkg/ibi/imageclusterinstall.go
@@ -454,13 +454,13 @@ func (builder *ImageClusterInstallBuilder) validate() (bool, error) {
 	if builder.Definition == nil {
 		glog.V(100).Infof("The %s is undefined", resourceCRD)
 
-		builder.errorMsg = msg.UndefinedCrdObjectErrString(resourceCRD)
+		return false, fmt.Errorf(msg.UndefinedCrdObjectErrString(resourceCRD))
 	}
 
 	if builder.apiClient == nil {
 		glog.V(100).Infof("The %s builder apiclient is nil", resourceCRD)
 
-		builder.errorMsg = fmt.Sprintf("%s builder cannot have nil apiClient", resourceCRD)
+		return false, fmt.Errorf("%s builder cannot have nil apiClient", resourceCRD)
 	}
 
 	if builder.errorMsg != "" {

--- a/pkg/network/operator.go
+++ b/pkg/network/operator.go
@@ -238,13 +238,13 @@ func (builder *OperatorBuilder) validate() (bool, error) {
 	if builder.Definition == nil {
 		glog.V(100).Infof("The %s is undefined", resourceCRD)
 
-		builder.errorMsg = msg.UndefinedCrdObjectErrString(resourceCRD)
+		return false, fmt.Errorf(msg.UndefinedCrdObjectErrString(resourceCRD))
 	}
 
 	if builder.apiClient == nil {
 		glog.V(100).Infof("The %s builder apiclient is nil", resourceCRD)
 
-		builder.errorMsg = fmt.Sprintf("%s builder cannot have nil apiClient", resourceCRD)
+		return false, fmt.Errorf("%s builder cannot have nil apiClient", resourceCRD)
 	}
 
 	if builder.errorMsg != "" {

--- a/pkg/nfd/nodefeaturediscovery.go
+++ b/pkg/nfd/nodefeaturediscovery.go
@@ -181,6 +181,8 @@ func (builder *Builder) Delete() (*Builder, error) {
 
 		builder.Object = nil
 
+		builder.Object = nil
+
 		return builder, nil
 	}
 

--- a/pkg/nto/performanceprofile.go
+++ b/pkg/nto/performanceprofile.go
@@ -467,9 +467,6 @@ func (builder *Builder) Delete() (*Builder, error) {
 	glog.V(100).Infof("Deleting PerformanceProfile %s", builder.Definition.Name)
 
 	if !builder.Exists() {
-		glog.V(100).Infof("performanceprofile %s cannot be deleted because it does not exist",
-			builder.Definition.Name)
-
 		builder.Object = nil
 
 		return builder, nil

--- a/pkg/ocm/placementbinding_test.go
+++ b/pkg/ocm/placementbinding_test.go
@@ -300,13 +300,11 @@ func TestPlacementBindingUpdate(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testBuilder := buildValidPlacementBindingTestBuilder(buildTestClientWithPlacementBindingScheme())
-
 		// Create the builder rather than just adding it to the client so that the proper metadata is added and
 		// the update will not fail.
 		var err error
 
-		testBuilder = buildValidPlacementBindingTestBuilder(buildTestClientWithPlacementBindingScheme())
+		testBuilder := buildValidPlacementBindingTestBuilder(buildTestClientWithPlacementBindingScheme())
 		testBuilder, err = testBuilder.Create()
 		assert.Nil(t, err)
 

--- a/pkg/ocm/placementbinding_test.go
+++ b/pkg/ocm/placementbinding_test.go
@@ -289,24 +289,13 @@ func TestPlacementBindingDelete(t *testing.T) {
 
 func TestPlacementBindingUpdate(t *testing.T) {
 	testCases := []struct {
-		alreadyExists bool
-		force         bool
+		force bool
 	}{
 		{
-			alreadyExists: false,
-			force:         false,
+			force: false,
 		},
 		{
-			alreadyExists: true,
-			force:         false,
-		},
-		{
-			alreadyExists: false,
-			force:         true,
-		},
-		{
-			alreadyExists: true,
-			force:         true,
+			force: true,
 		},
 	}
 
@@ -315,13 +304,11 @@ func TestPlacementBindingUpdate(t *testing.T) {
 
 		// Create the builder rather than just adding it to the client so that the proper metadata is added and
 		// the update will not fail.
-		if testCase.alreadyExists {
-			var err error
+		var err error
 
-			testBuilder = buildValidPlacementBindingTestBuilder(buildTestClientWithPlacementBindingScheme())
-			testBuilder, err = testBuilder.Create()
-			assert.Nil(t, err)
-		}
+		testBuilder = buildValidPlacementBindingTestBuilder(buildTestClientWithPlacementBindingScheme())
+		testBuilder, err = testBuilder.Create()
+		assert.Nil(t, err)
 
 		assert.NotNil(t, testBuilder.Definition)
 		assert.Empty(t, testBuilder.Definition.SubFilter)
@@ -331,13 +318,9 @@ func TestPlacementBindingUpdate(t *testing.T) {
 		placementBindingBuilder, err := testBuilder.Update(testCase.force)
 		assert.NotNil(t, testBuilder.Definition)
 
-		if testCase.alreadyExists {
-			assert.Nil(t, err)
-			assert.Equal(t, testBuilder.Definition.Name, placementBindingBuilder.Definition.Name)
-			assert.Equal(t, testBuilder.Definition.SubFilter, placementBindingBuilder.Definition.SubFilter)
-		} else {
-			assert.NotNil(t, err)
-		}
+		assert.Nil(t, err)
+		assert.Equal(t, testBuilder.Definition.Name, placementBindingBuilder.Definition.Name)
+		assert.Equal(t, testBuilder.Definition.SubFilter, placementBindingBuilder.Definition.SubFilter)
 	}
 }
 

--- a/pkg/ocm/placementrule_test.go
+++ b/pkg/ocm/placementrule_test.go
@@ -257,24 +257,13 @@ func TestPlacementRuleDelete(t *testing.T) {
 
 func TestPlacementRuleUpdate(t *testing.T) {
 	testCases := []struct {
-		alreadyExists bool
-		force         bool
+		force bool
 	}{
 		{
-			alreadyExists: false,
-			force:         false,
+			force: false,
 		},
 		{
-			alreadyExists: true,
-			force:         false,
-		},
-		{
-			alreadyExists: false,
-			force:         true,
-		},
-		{
-			alreadyExists: true,
-			force:         true,
+			force: true,
 		},
 	}
 
@@ -283,13 +272,11 @@ func TestPlacementRuleUpdate(t *testing.T) {
 
 		// Create the builder rather than just adding it to the client so that the proper metadata is added and
 		// the update will not fail.
-		if testCase.alreadyExists {
-			var err error
+		var err error
 
-			testBuilder = buildValidPlacementRuleTestBuilder(buildTestClientWithPlacementRuleScheme())
-			testBuilder, err = testBuilder.Create()
-			assert.Nil(t, err)
-		}
+		testBuilder = buildValidPlacementRuleTestBuilder(buildTestClientWithPlacementRuleScheme())
+		testBuilder, err = testBuilder.Create()
+		assert.Nil(t, err)
 
 		assert.NotNil(t, testBuilder.Definition)
 		assert.Empty(t, testBuilder.Definition.Spec.SchedulerName)
@@ -299,13 +286,9 @@ func TestPlacementRuleUpdate(t *testing.T) {
 		placementRuleBuilder, err := testBuilder.Update(testCase.force)
 		assert.NotNil(t, testBuilder.Definition)
 
-		if testCase.alreadyExists {
-			assert.Nil(t, err)
-			assert.Equal(t, testBuilder.Definition.Name, placementRuleBuilder.Definition.Name)
-			assert.Equal(t, testBuilder.Definition.Spec.SchedulerName, placementRuleBuilder.Definition.Spec.SchedulerName)
-		} else {
-			assert.NotNil(t, err)
-		}
+		assert.Nil(t, err)
+		assert.Equal(t, testBuilder.Definition.Name, placementRuleBuilder.Definition.Name)
+		assert.Equal(t, testBuilder.Definition.Spec.SchedulerName, placementRuleBuilder.Definition.Spec.SchedulerName)
 	}
 }
 

--- a/pkg/ocm/placementrule_test.go
+++ b/pkg/ocm/placementrule_test.go
@@ -268,13 +268,11 @@ func TestPlacementRuleUpdate(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testBuilder := buildValidPlacementRuleTestBuilder(buildTestClientWithPlacementRuleScheme())
-
 		// Create the builder rather than just adding it to the client so that the proper metadata is added and
 		// the update will not fail.
 		var err error
 
-		testBuilder = buildValidPlacementRuleTestBuilder(buildTestClientWithPlacementRuleScheme())
+		testBuilder := buildValidPlacementRuleTestBuilder(buildTestClientWithPlacementRuleScheme())
 		testBuilder, err = testBuilder.Create()
 		assert.Nil(t, err)
 

--- a/pkg/ocm/policy_test.go
+++ b/pkg/ocm/policy_test.go
@@ -2,6 +2,7 @@ package ocm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -258,7 +259,7 @@ func TestPolicyDelete(t *testing.T) {
 		},
 		{
 			testBuilder:   buildInvalidPolicyTestBuilder(buildTestClientWithDummyPolicy()),
-			expectedError: fmt.Errorf("policy 'nsname' cannot be empty"),
+			expectedError: errors.New("policy 'nsname' cannot be empty"),
 		},
 	}
 
@@ -274,39 +275,24 @@ func TestPolicyDelete(t *testing.T) {
 
 func TestPolicyUpdate(t *testing.T) {
 	testCases := []struct {
-		alreadyExists bool
-		force         bool
+		force bool
 	}{
 		{
-			alreadyExists: false,
-			force:         false,
+			force: false,
 		},
 		{
-			alreadyExists: true,
-			force:         false,
-		},
-		{
-			alreadyExists: false,
-			force:         true,
-		},
-		{
-			alreadyExists: true,
-			force:         true,
+			force: true,
 		},
 	}
 
 	for _, testCase := range testCases {
 		testBuilder := buildValidPolicyTestBuilder(buildTestClientWithPolicyScheme())
 
-		// Create the builder rather than just adding it to the client so that the proper metadata is added and
-		// the update will not fail.
-		if testCase.alreadyExists {
-			var err error
+		var err error
 
-			testBuilder = buildValidPolicyTestBuilder(buildTestClientWithPolicyScheme())
-			testBuilder, err = testBuilder.Create()
-			assert.Nil(t, err)
-		}
+		testBuilder = buildValidPolicyTestBuilder(buildTestClientWithPolicyScheme())
+		testBuilder, err = testBuilder.Create()
+		assert.Nil(t, err)
 
 		assert.NotNil(t, testBuilder.Definition)
 		assert.False(t, testBuilder.Definition.Spec.Disabled)
@@ -316,13 +302,9 @@ func TestPolicyUpdate(t *testing.T) {
 		policyBuilder, err := testBuilder.Update(testCase.force)
 		assert.NotNil(t, testBuilder.Definition)
 
-		if testCase.alreadyExists {
-			assert.Nil(t, err)
-			assert.Equal(t, testBuilder.Definition.Name, policyBuilder.Definition.Name)
-			assert.Equal(t, testBuilder.Definition.Spec.Disabled, policyBuilder.Definition.Spec.Disabled)
-		} else {
-			assert.NotNil(t, err)
-		}
+		assert.Nil(t, err)
+		assert.Equal(t, testBuilder.Definition.Name, policyBuilder.Definition.Name)
+		assert.Equal(t, testBuilder.Definition.Spec.Disabled, policyBuilder.Definition.Spec.Disabled)
 	}
 }
 

--- a/pkg/ocm/policy_test.go
+++ b/pkg/ocm/policy_test.go
@@ -286,11 +286,9 @@ func TestPolicyUpdate(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testBuilder := buildValidPolicyTestBuilder(buildTestClientWithPolicyScheme())
-
 		var err error
 
-		testBuilder = buildValidPolicyTestBuilder(buildTestClientWithPolicyScheme())
+		testBuilder := buildValidPolicyTestBuilder(buildTestClientWithPolicyScheme())
 		testBuilder, err = testBuilder.Create()
 		assert.Nil(t, err)
 

--- a/pkg/ocm/policyset_test.go
+++ b/pkg/ocm/policyset_test.go
@@ -274,39 +274,21 @@ func TestPolicySetDelete(t *testing.T) {
 
 func TestPolicySetUpdate(t *testing.T) {
 	testCases := []struct {
-		alreadyExists bool
-		force         bool
+		force bool
 	}{
 		{
-			alreadyExists: false,
-			force:         false,
+			force: false,
 		},
 		{
-			alreadyExists: true,
-			force:         false,
-		},
-		{
-			alreadyExists: false,
-			force:         true,
-		},
-		{
-			alreadyExists: true,
-			force:         true,
+			force: true,
 		},
 	}
 
 	for _, testCase := range testCases {
+		var err error
 		testBuilder := buildValidPolicySetTestBuilder(buildTestClientWithPolicySetScheme())
-
-		// Create the builder rather than just adding it to the client so that the proper metadata is added and
-		// the update will not fail.
-		if testCase.alreadyExists {
-			var err error
-
-			testBuilder = buildValidPolicySetTestBuilder(buildTestClientWithPolicySetScheme())
-			testBuilder, err = testBuilder.Create()
-			assert.Nil(t, err)
-		}
+		testBuilder, err = testBuilder.Create()
+		assert.Nil(t, err)
 
 		assert.NotNil(t, testBuilder.Definition)
 		assert.Empty(t, testBuilder.Definition.Spec.Description)
@@ -316,13 +298,9 @@ func TestPolicySetUpdate(t *testing.T) {
 		policySetBuilder, err := testBuilder.Update(testCase.force)
 		assert.NotNil(t, testBuilder.Definition)
 
-		if testCase.alreadyExists {
-			assert.Nil(t, err)
-			assert.Equal(t, testBuilder.Definition.Name, policySetBuilder.Definition.Name)
-			assert.Equal(t, testBuilder.Definition.Spec.Description, policySetBuilder.Definition.Spec.Description)
-		} else {
-			assert.NotNil(t, err)
-		}
+		assert.Nil(t, err)
+		assert.Equal(t, testBuilder.Definition.Name, policySetBuilder.Definition.Name)
+		assert.Equal(t, testBuilder.Definition.Spec.Description, policySetBuilder.Definition.Spec.Description)
 	}
 }
 

--- a/pkg/ocm/policyset_test.go
+++ b/pkg/ocm/policyset_test.go
@@ -286,6 +286,7 @@ func TestPolicySetUpdate(t *testing.T) {
 
 	for _, testCase := range testCases {
 		var err error
+
 		testBuilder := buildValidPolicySetTestBuilder(buildTestClientWithPolicySetScheme())
 		testBuilder, err = testBuilder.Create()
 		assert.Nil(t, err)

--- a/pkg/olm/catalogsource.go
+++ b/pkg/olm/catalogsource.go
@@ -265,13 +265,13 @@ func (builder *CatalogSourceBuilder) validate() (bool, error) {
 	if builder.Definition == nil {
 		glog.V(100).Infof("The %s is undefined", resourceCRD)
 
-		builder.errorMsg = msg.UndefinedCrdObjectErrString(resourceCRD)
+		return false, fmt.Errorf(msg.UndefinedCrdObjectErrString(resourceCRD))
 	}
 
 	if builder.apiClient == nil {
 		glog.V(100).Infof("The %s builder apiclient is nil", resourceCRD)
 
-		builder.errorMsg = fmt.Sprintf("%s builder cannot have nil apiClient", resourceCRD)
+		return false, fmt.Errorf("%s builder cannot have nil apiClient", resourceCRD)
 	}
 
 	if builder.errorMsg != "" {

--- a/pkg/olm/clusterserviceversion.go
+++ b/pkg/olm/clusterserviceversion.go
@@ -133,6 +133,8 @@ func (builder *ClusterServiceVersionBuilder) Delete() error {
 
 		builder.Object = nil
 
+		builder.Object = nil
+
 		return nil
 	}
 

--- a/pkg/schemes/argocd/argocdtypes/v1alpha1/types.go
+++ b/pkg/schemes/argocd/argocdtypes/v1alpha1/types.go
@@ -970,7 +970,6 @@ type ApplicationDestination struct {
 	// Name is an alternate way of specifying the target cluster by its symbolic name. This must be set if Server is not set.
 	Name string `json:"name,omitempty" protobuf:"bytes,3,opt,name=name"`
 
-	// nolint:govet
 	isServerInferred bool `json:"-"`
 }
 
@@ -1080,7 +1079,6 @@ type SyncOperationResource struct {
 	Kind      string `json:"kind" protobuf:"bytes,2,opt,name=kind"`
 	Name      string `json:"name" protobuf:"bytes,3,opt,name=name"`
 	Namespace string `json:"namespace,omitempty" protobuf:"bytes,4,opt,name=namespace"`
-	// nolint:govet
 	Exclude bool `json:"-"`
 }
 

--- a/pkg/servicemesh/controlplane.go
+++ b/pkg/servicemesh/controlplane.go
@@ -514,13 +514,13 @@ func (builder *ControlPlaneBuilder) validate() (bool, error) {
 	if builder.Definition == nil {
 		glog.V(100).Infof("The %s is undefined", resourceCRD)
 
-		builder.errorMsg = msg.UndefinedCrdObjectErrString(resourceCRD)
+		return false, fmt.Errorf(msg.UndefinedCrdObjectErrString(resourceCRD))
 	}
 
 	if builder.apiClient == nil {
 		glog.V(100).Infof("The %s builder apiclient is nil", resourceCRD)
 
-		builder.errorMsg = fmt.Sprintf("%s builder cannot have nil apiClient", resourceCRD)
+		return false, fmt.Errorf("%s builder cannot have nil apiClient", resourceCRD)
 	}
 
 	if builder.errorMsg != "" {

--- a/pkg/sriov/networknodestate.go
+++ b/pkg/sriov/networknodestate.go
@@ -225,17 +225,13 @@ func (builder *NetworkNodeStateBuilder) findInterfaceByName(sriovInterfaceName s
 	if err := builder.Discover(); err != nil {
 		glog.V(100).Infof("Error to discover sriov network node state for node %s", builder.nodeName)
 
-		builder.errorMsg = "failed to discover sriov network node state"
+		return nil, fmt.Errorf("error to discover sriov network node state for node %s", builder.nodeName)
 	}
 
 	if sriovInterfaceName == "" {
 		glog.V(100).Infof("The sriovInterface can not be empty string")
 
-		builder.errorMsg = "the sriovInterface is an empty sting"
-	}
-
-	if builder.errorMsg != "" {
-		return nil, fmt.Errorf(builder.errorMsg)
+		return nil, fmt.Errorf("sriovInterfaceName cannot be empty")
 	}
 
 	for _, interf := range builder.Objects.Status.Interfaces {
@@ -261,7 +257,7 @@ func (builder *NetworkNodeStateBuilder) validate() (bool, error) {
 	if builder.apiClient == nil {
 		glog.V(100).Infof("The %s builder apiclient is nil", resourceCRD)
 
-		builder.errorMsg = fmt.Sprintf("%s builder cannot have nil apiClient", resourceCRD)
+		return false, fmt.Errorf("%s builder cannot have nil apiClient", resourceCRD)
 	}
 
 	if builder.errorMsg != "" {

--- a/pkg/storage/pvc.go
+++ b/pkg/storage/pvc.go
@@ -222,8 +222,7 @@ func (builder *PVCBuilder) Delete() error {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	if !builder.Exists() {
-		glog.V(100).Infof("PersistentVolumeClaim %s not found in %s namespace",
-			builder.Definition.Name, builder.Definition.Namespace)
+		builder.Object = nil
 
 		builder.Object = nil
 


### PR DESCRIPTION
There seems to be a mismatch of how we expect `Delete()` funcs throughout the repo.

The general consensus from most of the `Delete()` functions is that we should return nil because the object doesn't exist.  There are a few outliers that I changed in this PR that were returning an error because an item didn't exist.

I have adjusted all of the Delete() funcs to set the `builder.Object` to nil and then return `nil`