### PR TITLE
Fix PullKubeAPIServerBuilder func name

### DIFF
--- a/pkg/apiservers/kubeapiserver.go
+++ b/pkg/apiservers/kubeapiserver.go
@@ -31,8 +31,8 @@ type KubeAPIServerBuilder struct {
 
 var kubeAPIServerObjName = "cluster"
 
-// PullKubeAPIServer pulls existing kubeApiServer from the cluster.
-func PullKubeAPIServer(apiClient *clients.Settings) (*KubeAPIServerBuilder, error) {
+// PullKubeAPIServerBuilder pulls existing kubeApiServer from the cluster.
+func PullKubeAPIServerBuilder(apiClient *clients.Settings) (*KubeAPIServerBuilder, error) {
 	glog.V(100).Infof("Pulling existing kubeApiServer from cluster")
 
 	if apiClient == nil {

--- a/pkg/apiservers/kubeapiserver_test.go
+++ b/pkg/apiservers/kubeapiserver_test.go
@@ -60,7 +60,7 @@ func TestPullKubeAPIServer(t *testing.T) {
 			testSettings = clients.GetTestClients(clients.TestClientParams{K8sMockObjects: runtimeObjects})
 		}
 
-		builderResult, err := PullKubeAPIServer(testSettings)
+		builderResult, err := PullKubeAPIServerBuilder(testSettings)
 
 		assert.Equal(t, testCase.expectedError, err)
 


### PR DESCRIPTION
Follow up to: #381 

Seems that this changed the public function that is used by `eco-gotests`.