### PR TITLE
bmh: fixed occasional failed unit test

### DIFF
--- a/pkg/bmh/baremetalhost_test.go
+++ b/pkg/bmh/baremetalhost_test.go
@@ -982,7 +982,7 @@ func TestBareMetalHostWaitUntilDeleted(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		err := testCase.testBmHost.WaitUntilDeleted(1 * time.Second)
+		err := testCase.testBmHost.WaitUntilDeleted(2 * time.Second)
 		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {


### PR DESCRIPTION
In `baremetalhost_test.go` the `TestBareMetalHostWaitUntilDeleted` unit test waits only 1 second for deletion, which causes tests to fail sometimes since the actual WaitUntilDeleted function polls every 1 second and does not immediately execute. This fix just increases the wait time in the test to 2 seconds which should always be sufficient.