### PR TITLE
bmh: fix test for delete and wait

### DIFF
--- a/pkg/bmh/baremetalhost_test.go
+++ b/pkg/bmh/baremetalhost_test.go
@@ -952,7 +952,7 @@ func TestBareMetalHostDeleteAndWaitUntilDeleted(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		builder, err := testCase.testBmHost.DeleteAndWaitUntilDeleted(1 * time.Second)
+		builder, err := testCase.testBmHost.DeleteAndWaitUntilDeleted(2 * time.Second)
 		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {


### PR DESCRIPTION
Same issue as in #420, the `DeleteAndWaitUntilDeleted` test will occasionally fail. Didn't notice this function needed to be changed during that PR.