### PR TITLE
bmc: refactor New and add methods for setting timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,17 +97,16 @@ exit status 1
 Please refer to the [secret pkg](./pkg/secret/secret.go)'s use of the validate method for more information.
 
 ### BMC Package
-The BMC package can be used to access the BMC's Redfish API, run BMC's CLI commands or getting the systems' serial console. Credentials for both Redfish and SSH user, the SSH port and timeouts need to be passed as parameters of the New() method. E.g.
+The BMC package can be used to access the BMC's Redfish API, run BMC's CLI commands, or get the systems' serial console. Only the host must be provided in `New()` while Redfish and SSH credentials, along with other options, can be configured using separate methods.
 
+```go
+bmc := bmc.New("1.2.3.4").
+    WithRedfishUser("redfishuser1", "redfishpass1").
+    WithSSHUser("sshuser1", "sshpass1").
+    WithSSHPort(1234)
 ```
-redfishUser := bmc.User{Name: "redfishuser1", Password: "redfishpass1"}
-sshUser := bmc.User{Name: "sshuser1", Password: "sshpass1"}
-timeOuts := bmc.TimeOuts{Redfish: 10*time.Second, SSH: 10*time.Second}
 
-bmc, err := bmc.New("1.2.3.4", redfishUser, sshUser, 22, timeOuts)
-```
-
-You can check an example program for the BMC package [here](usage/bmc/bmc.go).
+You can check an example program for the BMC package in [usage](usage/bmc/bmc.go).
 
 #### BMC's Redfish API
 The access to BMC's Redfish API is done by methods that encapsulate the underlaying HTTP calls made by the external gofish library. The redfish system index is defaulted to 0, but it can be changed with `SetSystemIndex()`:


### PR DESCRIPTION
This commit brings the creation and configuration for the BMC client more in line with the rest of the packages and allows for Redfish and SSH access to be configured separately.

Depending on the use case, the Redfish user or the SSH user must be provided, with a few other options available for configuration. A summary of these configuration methods is provided:

```
func New(host string) *BMC

Redfish access only:
  Mandatory:
    func (bmc *BMC) WithRedfishUser(user, pass string) *BMC
  Optional:
    func (bmc *BMC) WithRedfishTimeout(timeout time.Duration) *BMC
    func (bmc *BMC) WithRedfishSystemIndex(index int) *BMC
    func (bmc *BMC) WithRedfishPowerControlIndex(index int) *BMC

SSH Access (cli commands) only:
  Mandatory:
    func (bmc *BMC) WithSSHUser(user, pass string) *BMC
  Optional:
    func (bmc *BMC) WithSSHPort(port uint16) *BMC
    func (bmc *BMC) WithSSHTimeout(timeout time.Duratin) *BMC
```

Additionally, the unit tests have been updated to match these new public methods and all use assert.