### PR TITLE
BMC: added method to get system's power state.

### DIFF
--- a/pkg/bmc/bmc.go
+++ b/pkg/bmc/bmc.go
@@ -472,6 +472,40 @@ func (bmc *BMC) SystemPowerCycle() error {
 	return bmc.SystemResetAction(redfish.PowerCycleResetType)
 }
 
+// SystemPowerState returns the system's current power state using the Redfish API.
+// Returned string can be one of On/Off/Paused/PoweringOn/PoweringOff.
+func (bmc *BMC) SystemPowerState() (string, error) {
+	if valid, err := bmc.validateRedfish(); !valid {
+		return "", err
+	}
+
+	glog.V(100).Info("Collecting current power state from bmc's redfish endpoint")
+
+	redfishClient, cancel, err := redfishConnect(
+		bmc.host,
+		bmc.redfishUser.Name, bmc.redfishUser.Password,
+		bmc.timeOuts.Redfish)
+	if err != nil {
+		glog.V(100).Infof("Redfish connection error: %v", err)
+
+		return "", fmt.Errorf("redfish connection error: %w", err)
+	}
+
+	defer func() {
+		redfishClient.Logout()
+		cancel()
+	}()
+
+	system, err := redfishGetSystem(redfishClient, bmc.systemIndex)
+	if err != nil {
+		glog.V(100).Infof("Failed to get redfish system: %v", err)
+
+		return "", fmt.Errorf("failed to get redfish system: %w", err)
+	}
+
+	return string(system.PowerState), nil
+}
+
 // PowerUsage returns the current power usage of the chassis in watts using the Redfish API. This method uses the first
 // chassis with a power link and the power control index for the BMC client.
 func (bmc *BMC) PowerUsage() (float32, error) {

--- a/pkg/bmc/bmc.go
+++ b/pkg/bmc/bmc.go
@@ -267,7 +267,8 @@ func (bmc *BMC) SystemManufacturer() (string, error) {
 
 	redfishClient, cancel, err := redfishConnect(
 		bmc.host,
-		bmc.redfishUser.Name, bmc.redfishUser.Password,
+		bmc.redfishUser.Name,
+		bmc.redfishUser.Password,
 		bmc.timeOuts.Redfish)
 	if err != nil {
 		glog.V(100).Infof("Redfish connection error: %v", err)
@@ -300,7 +301,8 @@ func (bmc *BMC) IsSecureBootEnabled() (bool, error) {
 
 	redfishClient, cancel, err := redfishConnect(
 		bmc.host,
-		bmc.redfishUser.Name, bmc.redfishUser.Password,
+		bmc.redfishUser.Name,
+		bmc.redfishUser.Password,
 		bmc.timeOuts.Redfish)
 	if err != nil {
 		glog.V(100).Infof("Redfish connection error: %v", err)
@@ -333,7 +335,8 @@ func (bmc *BMC) SecureBootEnable() error {
 
 	redfishClient, cancel, err := redfishConnect(
 		bmc.host,
-		bmc.redfishUser.Name, bmc.redfishUser.Password,
+		bmc.redfishUser.Name,
+		bmc.redfishUser.Password,
 		bmc.timeOuts.Redfish)
 	if err != nil {
 		glog.V(100).Infof("Redfish connection error: %v", err)
@@ -381,7 +384,8 @@ func (bmc *BMC) SecureBootDisable() error {
 
 	redfishClient, cancel, err := redfishConnect(
 		bmc.host,
-		bmc.redfishUser.Name, bmc.redfishUser.Password,
+		bmc.redfishUser.Name,
+		bmc.redfishUser.Password,
 		bmc.timeOuts.Redfish)
 	if err != nil {
 		glog.V(100).Infof("Redfish connection error: %v", err)
@@ -429,7 +433,8 @@ func (bmc *BMC) SystemResetAction(action redfish.ResetType) error {
 
 	redfishClient, cancel, err := redfishConnect(
 		bmc.host,
-		bmc.redfishUser.Name, bmc.redfishUser.Password,
+		bmc.redfishUser.Name,
+		bmc.redfishUser.Password,
 		bmc.timeOuts.Redfish)
 	if err != nil {
 		glog.V(100).Infof("Redfish connection error: %v", err)
@@ -483,7 +488,8 @@ func (bmc *BMC) SystemPowerState() (string, error) {
 
 	redfishClient, cancel, err := redfishConnect(
 		bmc.host,
-		bmc.redfishUser.Name, bmc.redfishUser.Password,
+		bmc.redfishUser.Name,
+		bmc.redfishUser.Password,
 		bmc.timeOuts.Redfish)
 	if err != nil {
 		glog.V(100).Infof("Redfish connection error: %v", err)
@@ -517,7 +523,8 @@ func (bmc *BMC) PowerUsage() (float32, error) {
 
 	redfishClient, cancel, err := redfishConnect(
 		bmc.host,
-		bmc.redfishUser.Name, bmc.redfishUser.Password,
+		bmc.redfishUser.Name,
+		bmc.redfishUser.Password,
 		bmc.timeOuts.Redfish)
 	if err != nil {
 		glog.V(100).Infof("Redfish connection error: %v", err)

--- a/pkg/bmc/bmc_test.go
+++ b/pkg/bmc/bmc_test.go
@@ -564,6 +564,21 @@ func TestBMCSystemPowerCycle(t *testing.T) {
 	})
 }
 
+func TestBMCSystemPowerState(t *testing.T) {
+	// Create fake redfish endpoint.
+	redfishServer := createFakeRedfishLocalServer(false, redfishAPIResponseCallbacks{})
+	defer redfishServer.Close()
+
+	host := strings.Split(redfishServer.URL, "//")[1]
+	bmc := New(host).WithRedfishUser(defaultUsername, defaultPassword)
+
+	const expectedPowerState = "On"
+
+	powerState, err := bmc.SystemPowerState()
+	assert.NoError(t, err)
+	assert.Equal(t, expectedPowerState, powerState)
+}
+
 func TestBMCPowerUsage(t *testing.T) {
 	// Create a fake redfish api endpoint with secureBoot "disabled"
 	redfishServer := createFakeRedfishLocalServer(false, redfishAPIResponseCallbacks{})

--- a/usage/bmc/bmc.go
+++ b/usage/bmc/bmc.go
@@ -123,8 +123,14 @@ func main() {
 		fmt.Printf("Failed to get secure boot status on %v: %v\n", *hostFlag, err)
 	}
 
+	powerState, err := bmcClient.SystemPowerState()
+	if err != nil {
+		fmt.Printf("Failed to get system's power state: %v\n", err)
+	}
+
 	fmt.Printf("System %d Manufacturer       : %v\n", *systemIndexFlag, manufacturer)
 	fmt.Printf("System %d SecureBoot enabled : %v\n", *systemIndexFlag, sbEnabled)
+	fmt.Printf("System %d PowerState         : %v\n", *systemIndexFlag, powerState)
 
 	// Run the help command. We should see all the available CLI commands.
 	runCLICommand(bmcClient, "help", true, 10*time.Second)


### PR DESCRIPTION
bmc.SystemPowerState() returns the PowerState (string) field from the bmc's configured ComputerSystem.