### PR TITLE
Add eco-gotests 'make vet' to PR checks

### DIFF
--- a/.github/workflows/eco-gotests-integration.yml
+++ b/.github/workflows/eco-gotests-integration.yml
@@ -17,14 +17,17 @@ jobs:
 
     steps:
       - name: Set up Go 1.22
+        if: ${{ !contains(github.event.*.labels.*.name, 'ignore-dep-check') }}
         uses: actions/setup-go@v5
         with:
           go-version: 1.22.3
 
       - name: Check out the eco-goinfra code
+        if: ${{ !contains(github.event.*.labels.*.name, 'ignore-dep-check') }}
         uses: actions/checkout@v4
 
       - name: Check out the eco-gotests code
+        if: ${{ !contains(github.event.*.labels.*.name, 'ignore-dep-check') }}
         uses: actions/checkout@v4
         with:
           repository: ${{ env.ECO_GOTESTS_REPO }}
@@ -34,11 +37,13 @@ jobs:
 
       # Update the go.mod file in eco-gotests to include the current eco-goinfra code
       - name: Update go.mod in eco-gotests
+        if: ${{ !contains(github.event.*.labels.*.name, 'ignore-dep-check') }}
         run: |
           go mod edit -replace github.com/openshift-kni/eco-goinfra=${{ github.workspace }}
           go mod vendor
         working-directory: ${{ env.ECO_GOTESTS_PATH }}
 
       - name: eco-gotests go vet
+        if: ${{ !contains(github.event.*.labels.*.name, 'ignore-dep-check') }}
         run: make vet
         working-directory: ${{ env.ECO_GOTESTS_PATH }}

--- a/.github/workflows/eco-gotests-integration.yml
+++ b/.github/workflows/eco-gotests-integration.yml
@@ -1,0 +1,43 @@
+name: eco-gotests integration
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    env:
+      SHELL: /bin/bash
+      ECO_GOTESTS_PATH: gotests
+      ECO_GOTESTS_REPO: openshift-kni/eco-gotests
+      ECO_GOTESTS_BRANCH: main
+
+    steps:
+      - name: Set up Go 1.22
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.22.3
+
+      - name: Check out the eco-goinfra code
+        uses: actions/checkout@v4
+
+      - name: Check out the eco-gotests code
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.ECO_GOTESTS_REPO }}
+          ref: ${{ env.ECO_GOTESTS_BRANCH }}
+          path: ${{ env.ECO_GOTESTS_PATH }}
+
+      # Update the go.mod file in eco-gotests to include the current eco-goinfra code
+      - name: Update go.mod in eco-gotests
+        run: |
+          go mod edit -replace github.com/openshift-kni/eco-goinfra=${{ github.workspace }}
+          go mod vendor
+        working-directory: ${{ env.ECO_GOTESTS_PATH }}
+
+      - name: eco-gotests go vet
+        run: make vet
+        working-directory: ${{ env.ECO_GOTESTS_PATH }}

--- a/.github/workflows/eco-gotests-integration.yml
+++ b/.github/workflows/eco-gotests-integration.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches:
       - main
+      - 'release-\d.\d\d'
 
 jobs:
   build:
@@ -13,7 +14,6 @@ jobs:
       SHELL: /bin/bash
       ECO_GOTESTS_PATH: gotests
       ECO_GOTESTS_REPO: openshift-kni/eco-gotests
-      ECO_GOTESTS_BRANCH: main
 
     steps:
       - name: Set up Go 1.22
@@ -28,7 +28,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ${{ env.ECO_GOTESTS_REPO }}
-          ref: ${{ env.ECO_GOTESTS_BRANCH }}
+          # check out the branch name that is targeted by the PR
+          ref:  ${{ github.base_ref }}
           path: ${{ env.ECO_GOTESTS_PATH }}
 
       # Update the go.mod file in eco-gotests to include the current eco-goinfra code


### PR DESCRIPTION
Upon new PRs, clone both repos down (eco-gotests and eco-goinfra) and then replace the eco-goinfra with the local copy in the eco-gotests go.mod.  Once the replacement is done, run the `make vet` path in the eco-gotests folder to see if everything compiles correctly.

This was previously not possible to test because `eco-gotests` was private.

![image](https://github.com/openshift-kni/eco-goinfra/assets/4563082/c70a70ad-97af-4d9c-9e3d-522c3972f80c)
