### PR TITLE
Add 'make coverage-html' make path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,3 +19,7 @@ install: deps-update
 test:
 	go test ./...
 
+coverage-html:
+	go test -coverprofile=coverage.out ./...
+	go tool cover -html=coverage.out
+


### PR DESCRIPTION
`make coverage-html` generates a coverage output website.  `*.out` is already covered in the gitignore.