### PR TITLE
argocd: reset application resource version on update

### DIFF
--- a/pkg/argocd/applications.go
+++ b/pkg/argocd/applications.go
@@ -140,6 +140,7 @@ func (builder *ApplicationBuilder) Update(force bool) (*ApplicationBuilder, erro
 				msg.FailToUpdateNotification("Application", builder.Definition.Name, builder.Definition.Namespace))
 
 			builder, err := builder.Delete()
+			builder.Definition.ResourceVersion = ""
 
 			if err != nil {
 				glog.V(100).Infof(


### PR DESCRIPTION
When using force updates on an Argo CD application that has already been pulled from the cluster, there is a risk that the ResourceVersion is newer on the server but is also set in the Definition, resulting in the delete succeeding but not the creation during a force update.