### PR TITLE
Update Go to v1.22.5

### DIFF
--- a/.github/workflows/eco-gotests-integration.yml
+++ b/.github/workflows/eco-gotests-integration.yml
@@ -20,7 +20,7 @@ jobs:
         if: ${{ !contains(github.event.*.labels.*.name, 'ignore-dep-check') }}
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.4
+          go-version: 1.22.5
 
       - name: Check out the eco-goinfra code
         if: ${{ !contains(github.event.*.labels.*.name, 'ignore-dep-check') }}

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go 1.22
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.4
+          go-version: 1.22.5
 
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
https://groups.google.com/g/golang-announce/c/gyb7aM1C9H4

Related to: https://github.com/test-network-function/cnf-certification-test/pull/2229