### PR TITLE
BMC: added redfish api to get and change system's boot order.

### DIFF
--- a/pkg/bmc/testdata/redfish_v1_system.json
+++ b/pkg/bmc/testdata/redfish_v1_system.json
@@ -44,9 +44,7 @@
       },
       "BootOrder": [
         "Boot0003",
-        "Boot0000",
-        "Boot0001",
-        "Boot0002"
+        "Boot0000"
       ],
       "BootOrder@odata.count": 4,
       "BootSourceOverrideEnabled": "Disabled",

--- a/pkg/bmc/testdata/redfish_v1_system_boot_option_Boot0000.json
+++ b/pkg/bmc/testdata/redfish_v1_system_boot_option_Boot0000.json
@@ -1,0 +1,17 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#BootOption.BootOption",
+  "@odata.id": "/redfish/v1/Systems/System.Embedded.1/BootOptions/Boot0000",
+  "@odata.type": "#BootOption.v1_0_4.BootOption",
+  "BootOptionEnabled": true,
+  "BootOptionReference": "Boot0000",
+  "Description": "Current settings of the UEFI Boot option",
+  "DisplayName": "PXE Device 1: Embedded NIC 1 Port 1 Partition 1",
+  "Id": "Boot0000",
+  "Name": "Uefi Boot Option",
+  "UefiDevicePath": "VenHw(3A191845-5F86-4E78-8FCE-C4CFF59F9DAA)",
+  "RelatedItem": [
+    {
+      "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/NetworkAdapters/NIC.Embedded.1/NetworkDeviceFunctions/NIC.Embedded.1-1-1"
+    }
+  ]
+}

--- a/pkg/bmc/testdata/redfish_v1_system_boot_option_Boot0003.json
+++ b/pkg/bmc/testdata/redfish_v1_system_boot_option_Boot0003.json
@@ -1,0 +1,17 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#BootOption.BootOption",
+  "@odata.id": "/redfish/v1/Systems/System.Embedded.1/BootOptions/Boot0003",
+  "@odata.type": "#BootOption.v1_0_4.BootOption",
+  "BootOptionEnabled": true,
+  "BootOptionReference": "Boot0003",
+  "Description": "Current settings of the UEFI Boot option",
+  "DisplayName": "RAID Controller in SL 3: Red Hat Enterprise Linux",
+  "Id": "Boot0003",
+  "Name": "Uefi Boot Option",
+  "UefiDevicePath": "HD(1,GPT,3C849C22-2F6C-425F-8072-B3B822F5BEA2,0x800,0x12C000)/\\EFI\\redhat\\shimx64.efi",
+  "RelatedItem": [
+    {
+      "@odata.id": "/redfish/v1/Chassis/Enclosure.Internal.0-1:RAID.SL.3-1"
+    }
+  ]
+}

--- a/pkg/bmc/testdata/redfish_v1_system_boot_options.json
+++ b/pkg/bmc/testdata/redfish_v1_system_boot_options.json
@@ -1,0 +1,16 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#BootOptionCollection.BootOptionCollection",
+    "@odata.type": "#BootOptionCollection.BootOptionCollection",
+    "@odata.id": "/redfish/v1/Systems/System.Embedded.1/BootOptions",
+    "Description": "Collection of BootOptions",
+    "Members": [
+      {
+        "@odata.id": "/redfish/v1/Systems/System.Embedded.1/BootOptions/Boot0003"
+      },
+      {
+        "@odata.id": "/redfish/v1/Systems/System.Embedded.1/BootOptions/Boot0000"
+      }
+    ],
+    "Members@odata.count": 2,
+    "Name": "Boot Options Collection"
+  }


### PR DESCRIPTION
- SystemBootOptions: helper function that reads the current available boot options and creates a map so the user can see the display name of each of boot option reference.
- SystemBootOrderReferences: returns a slice with the current boot order references.
- SetSystemBootOrderReferences: updates the system's boot order references. Needs a system reset so changes take effect.