### PR TITLE
ocm: increased coverage for kac and mcl 

### DIFF
--- a/pkg/ocm/kac.go
+++ b/pkg/ocm/kac.go
@@ -180,6 +180,8 @@ func (builder *KACBuilder) Update(force bool) (*KACBuilder, error) {
 			glog.V(100).Infof(msg.FailToUpdateNotification("klusterletAddonConfig", builder.Definition.Name))
 
 			err := builder.Delete()
+			builder.Definition.ResourceVersion = ""
+
 			if err != nil {
 				glog.V(100).Infof(msg.FailToUpdateError("klusterletAddonConfig", builder.Definition.Name))
 

--- a/pkg/ocm/kac_test.go
+++ b/pkg/ocm/kac_test.go
@@ -238,6 +238,11 @@ func TestKACUpdate(t *testing.T) {
 			assert.True(t, kacBuilder.Exists())
 		}
 
+		// This causes an error while updating and allows us to test the code path for force updates.
+		if testCase.force {
+			kacBuilder.Definition.ResourceVersion = kacBuilder.Definition.Name
+		}
+
 		assert.NotNil(t, kacBuilder.Definition)
 		assert.False(t, kacBuilder.Definition.Spec.SearchCollectorConfig.Enabled)
 


### PR DESCRIPTION
Closes #544 by adding unit tests for the list and validate functions in the OCM package and modifying a few existing test cases to improve coverage a bit. This PR also resets the resourceversion during force updates to preemptively address situations like in #483.