### PR TITLE
ocm: added unit tests and increased policy set coverage

### DIFF
--- a/pkg/clients/clients.go
+++ b/pkg/clients/clients.go
@@ -116,7 +116,6 @@ import (
 	veleroFakeClient "github.com/vmware-tanzu/velero/pkg/generated/clientset/versioned/fake"
 	veleroV1Client "github.com/vmware-tanzu/velero/pkg/generated/clientset/versioned/typed/velero/v1"
 	dynamicFake "k8s.io/client-go/dynamic/fake"
-	policiesv1beta1 "open-cluster-management.io/governance-policy-propagator/api/v1beta1"
 )
 
 // Settings provides the struct to talk with relevant API.
@@ -355,10 +354,6 @@ func SetScheme(crScheme *runtime.Scheme) error {
 		return err
 	}
 
-	if err := policiesv1beta1.AddToScheme(crScheme); err != nil {
-		return err
-	}
-
 	if err := routev1.AddToScheme(crScheme); err != nil {
 		return err
 	}
@@ -522,8 +517,6 @@ func GetTestClients(tcp TestClientParams) *Settings {
 		case *operatorv1.OpenShiftAPIServer:
 			genericClientObjects = append(genericClientObjects, v)
 		case *routev1.Route:
-			genericClientObjects = append(genericClientObjects, v)
-		case *policiesv1beta1.PolicySet:
 			genericClientObjects = append(genericClientObjects, v)
 		case *configV1.Node:
 			genericClientObjects = append(genericClientObjects, v)

--- a/pkg/ocm/policysetlist.go
+++ b/pkg/ocm/policysetlist.go
@@ -14,6 +14,19 @@ import (
 func ListPolicieSetsInAllNamespaces(apiClient *clients.Settings,
 	options ...runtimeclient.ListOptions) (
 	[]*PolicySetBuilder, error) {
+	if apiClient == nil {
+		glog.V(100).Info("PolicySets 'apiClient' parameter cannot be nil")
+
+		return nil, fmt.Errorf("failed to list policySets, 'apiClient' parameter is nil")
+	}
+
+	err := apiClient.AttachScheme(policiesv1beta1.AddToScheme)
+	if err != nil {
+		glog.V(100).Info("Failed to add PolicySet scheme to client schemes")
+
+		return nil, err
+	}
+
 	logMessage := string("Listing all policySets in all namespaces")
 	passedOptions := runtimeclient.ListOptions{}
 
@@ -30,9 +43,8 @@ func ListPolicieSetsInAllNamespaces(apiClient *clients.Settings,
 
 	glog.V(100).Infof(logMessage)
 
-	policySetList := &policiesv1beta1.PolicySetList{}
-
-	err := apiClient.Client.List(context.TODO(), policySetList, &passedOptions)
+	policySetList := new(policiesv1beta1.PolicySetList)
+	err = apiClient.Client.List(context.TODO(), policySetList, &passedOptions)
 
 	if err != nil {
 		glog.V(100).Infof("Failed to list all policySets in all namespaces due to %s", err.Error())
@@ -45,7 +57,7 @@ func ListPolicieSetsInAllNamespaces(apiClient *clients.Settings,
 	for _, policy := range policySetList.Items {
 		copiedPolicySet := policy
 		policySetBuilder := &PolicySetBuilder{
-			apiClient:  apiClient,
+			apiClient:  apiClient.Client,
 			Object:     &copiedPolicySet,
 			Definition: &copiedPolicySet,
 		}

--- a/pkg/ocm/policysetlist_test.go
+++ b/pkg/ocm/policysetlist_test.go
@@ -1,0 +1,71 @@
+package ocm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/openshift-kni/eco-goinfra/pkg/clients"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/labels"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestListPolicieSetsInAllNamespaces(t *testing.T) {
+	testCases := []struct {
+		policySets    []*PolicySetBuilder
+		listOptions   []runtimeclient.ListOptions
+		expectedError error
+		client        bool
+	}{
+		{
+			policySets: []*PolicySetBuilder{
+				buildValidPolicySetTestBuilder(buildTestClientWithDummyPolicySet()),
+			},
+			listOptions:   nil,
+			expectedError: nil,
+			client:        true,
+		},
+		{
+			policySets: []*PolicySetBuilder{
+				buildValidPolicySetTestBuilder(buildTestClientWithDummyPolicySet()),
+			},
+			listOptions:   []runtimeclient.ListOptions{{LabelSelector: labels.NewSelector()}},
+			expectedError: nil,
+			client:        true,
+		},
+		{
+			policySets: []*PolicySetBuilder{
+				buildValidPolicySetTestBuilder(buildTestClientWithDummyPolicySet()),
+			},
+			listOptions: []runtimeclient.ListOptions{
+				{LabelSelector: labels.NewSelector()},
+				{LabelSelector: labels.NewSelector()},
+			},
+			expectedError: fmt.Errorf("error: more than one ListOptions was passed"),
+			client:        true,
+		},
+		{
+			policySets: []*PolicySetBuilder{
+				buildValidPolicySetTestBuilder(buildTestClientWithDummyPolicySet()),
+			},
+			listOptions:   []runtimeclient.ListOptions{{LabelSelector: labels.NewSelector()}},
+			expectedError: fmt.Errorf("failed to list policySets, 'apiClient' parameter is nil"),
+			client:        false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		var testSettings *clients.Settings
+
+		if testCase.client {
+			testSettings = buildTestClientWithDummyPolicySet()
+		}
+
+		builders, err := ListPolicieSetsInAllNamespaces(testSettings, testCase.listOptions...)
+		assert.Equal(t, err, testCase.expectedError)
+
+		if testCase.expectedError == nil && len(testCase.listOptions) == 0 {
+			assert.Equal(t, len(testCase.policySets), len(builders))
+		}
+	}
+}


### PR DESCRIPTION
This PR adds unit tests for list and validate for the policy set resource in the OCM package.