### PR TITLE
ocm: removed kac and mcl types from clients

### DIFF
--- a/pkg/clients/clients.go
+++ b/pkg/clients/clients.go
@@ -85,7 +85,6 @@ import (
 	clusterClient "open-cluster-management.io/api/client/cluster/clientset/versioned"
 	clusterClientFake "open-cluster-management.io/api/client/cluster/clientset/versioned/fake"
 	clusterV1Client "open-cluster-management.io/api/client/cluster/clientset/versioned/typed/cluster/v1"
-	clusterv1 "open-cluster-management.io/api/cluster/v1"
 
 	appsv1 "k8s.io/api/apps/v1"
 	scalingv1 "k8s.io/api/autoscaling/v1"
@@ -113,7 +112,6 @@ import (
 	ocsoperatorv1 "github.com/red-hat-storage/ocs-operator/api/v1"
 	odfoperatorv1alpha1 "github.com/red-hat-storage/odf-operator/api/v1alpha1"
 	mcmV1Beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api-hub/v1beta1"
-	kacv1 "github.com/stolostron/klusterlet-addon-controller/pkg/apis/agent/v1"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	veleroClient "github.com/vmware-tanzu/velero/pkg/generated/clientset/versioned"
 	veleroFakeClient "github.com/vmware-tanzu/velero/pkg/generated/clientset/versioned/fake"
@@ -215,8 +213,6 @@ func New(kubeconfig string) *Settings {
 	clientSet.VeleroV1Interface = veleroV1Client.NewForConfigOrDie(config)
 	clientSet.ClientCgu = clientCgu.NewForConfigOrDie(config)
 	clientSet.RanV1alpha1Interface = clientCguV1.NewForConfigOrDie(config)
-	clientSet.ClusterClient = clusterClient.NewForConfigOrDie(config)
-	clientSet.ClusterV1Interface = clusterV1Client.NewForConfigOrDie(config)
 	clientSet.Config = config
 
 	clientSet.scheme = runtime.NewScheme()
@@ -423,10 +419,6 @@ func SetScheme(crScheme *runtime.Scheme) error {
 		return err
 	}
 
-	if err := kacv1.SchemeBuilder.AddToScheme(crScheme); err != nil {
-		return err
-	}
-
 	if err := monv1.AddToScheme(crScheme); err != nil {
 		return err
 	}
@@ -599,8 +591,6 @@ func GetTestClients(tcp TestClientParams) *Settings {
 			genericClientObjects = append(genericClientObjects, v)
 		case *agentInstallV1Beta1.AgentServiceConfig:
 			genericClientObjects = append(genericClientObjects, v)
-		case *kacv1.KlusterletAddonConfig:
-			genericClientObjects = append(genericClientObjects, v)
 		case *monv1.ServiceMonitor:
 			genericClientObjects = append(genericClientObjects, v)
 		// ArgoCD Client Objects
@@ -647,9 +637,6 @@ func GetTestClients(tcp TestClientParams) *Settings {
 		// MultiNetworkPolicy Client Objects
 		case *plumbingv1.MultiNetworkPolicy:
 			plumbingObjects = append(plumbingObjects, v)
-		// OCM Cluster Client Objects
-		case *clusterv1.ManagedCluster:
-			ocmObjects = append(ocmObjects, v)
 		// MCO Client Objects
 		case *mcv1.MachineConfig:
 			mcoObjects = append(mcoObjects, v)


### PR DESCRIPTION
This shifts the kac and managedcluster types to use scheme attachers in the functions themselves and removes them from the clients package.