### PR TITLE
Add Refactored Pod health monitoring functions previously defined in eco-gotests (ran subfolder)

### DIFF
--- a/pkg/pod/list.go
+++ b/pkg/pod/list.go
@@ -14,6 +14,12 @@ import (
 
 // List returns pod inventory in the given namespace.
 func List(apiClient *clients.Settings, nsname string, options ...metav1.ListOptions) ([]*Builder, error) {
+	if apiClient == nil {
+		glog.V(100).Infof("The apiClient is empty")
+
+		return nil, fmt.Errorf("podList 'apiClient' cannot be empty")
+	}
+
 	if nsname == "" {
 		glog.V(100).Infof("pod 'nsname' parameter can not be empty")
 
@@ -63,6 +69,12 @@ func ListInAllNamespaces(apiClient *clients.Settings, options ...metav1.ListOpti
 	logMessage := "Listing all pods in all namespaces"
 	passedOptions := metav1.ListOptions{}
 
+	if apiClient == nil {
+		glog.V(100).Infof("The apiClient is empty")
+
+		return nil, fmt.Errorf("podList 'apiClient' cannot be empty")
+	}
+
 	if len(options) > 1 {
 		glog.V(100).Infof("'options' parameter must be empty or single-valued")
 
@@ -104,6 +116,12 @@ func ListInAllNamespaces(apiClient *clients.Settings, options ...metav1.ListOpti
 func ListByNamePattern(apiClient *clients.Settings, namePattern, nsname string) ([]*Builder, error) {
 	glog.V(100).Infof("Listing pods in the nsname %s filtered by the name pattern %s", nsname, namePattern)
 
+	if apiClient == nil {
+		glog.V(100).Infof("The apiClient is empty")
+
+		return nil, fmt.Errorf("podList 'apiClient' cannot be empty")
+	}
+
 	if nsname == "" {
 		glog.V(100).Infof("pod 'nsname' parameter can not be empty")
 
@@ -143,6 +161,12 @@ func WaitForAllPodsInNamespaceRunning(
 	nsname string,
 	timeout time.Duration,
 	options ...metav1.ListOptions) (bool, error) {
+	if apiClient == nil {
+		glog.V(100).Infof("The apiClient is empty")
+
+		return false, fmt.Errorf("podList 'apiClient' cannot be empty")
+	}
+
 	if nsname == "" {
 		glog.V(100).Infof("'nsname' parameter can not be empty")
 
@@ -207,6 +231,12 @@ func WaitForAllPodsInNamespacesHealthy(
 ) error {
 	logMessage := fmt.Sprintf("Waiting for all pods in %v namespaces", nsNames)
 	passedOptions := metav1.ListOptions{}
+
+	if apiClient == nil {
+		glog.V(100).Infof("The apiClient is empty")
+
+		return fmt.Errorf("podList 'apiClient' cannot be empty")
+	}
 
 	if len(options) > 1 {
 		glog.V(100).Infof("'options' parameter must be empty or single-valued")

--- a/pkg/pod/list.go
+++ b/pkg/pod/list.go
@@ -233,7 +233,7 @@ func WaitForAllPodsInNamespacesHealthy(
 			continue
 		}
 
-		err := podObj.WaitUntilHealthy(timeout, checkReadiness, includeSucceeded, ignoreFailedPods)
+		err := podObj.WaitUntilHealthy(timeout, includeSucceeded, checkReadiness, ignoreFailedPods)
 		if err != nil {
 			glog.V(100).Infof("Failed to wait for all pods to be healthy due to %s", err.Error())
 

--- a/pkg/pod/list_test.go
+++ b/pkg/pod/list_test.go
@@ -1,0 +1,85 @@
+package pod
+
+import (
+	"testing"
+	"time"
+
+	"github.com/openshift-kni/eco-goinfra/pkg/clients"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestWaitForAllPodsInNamespacesHealthy(t *testing.T) {
+	testCases := []struct {
+		namespaces       []string
+		includeSucceeded bool
+		checkReadiness   bool
+		ignoreFailedPods bool
+		ignoreNamespaces []string
+		expectedErrMsg   string
+	}{
+		{
+			namespaces:       []string{"ns1"},
+			includeSucceeded: true,
+			checkReadiness:   false,
+			ignoreFailedPods: true,
+			ignoreNamespaces: []string{},
+			expectedErrMsg:   "",
+		},
+		{
+			namespaces:       []string{"ns1"},
+			includeSucceeded: true,
+			checkReadiness:   true,
+			ignoreFailedPods: true,
+			ignoreNamespaces: []string{},
+			expectedErrMsg:   "",
+		},
+		{
+			namespaces:       []string{"ns2"},
+			includeSucceeded: true,
+			checkReadiness:   true,
+			ignoreFailedPods: true,
+			ignoreNamespaces: []string{},
+			expectedErrMsg:   "context deadline exceeded",
+		},
+		{
+			namespaces:       []string{},
+			includeSucceeded: true,
+			checkReadiness:   true,
+			ignoreFailedPods: true,
+			ignoreNamespaces: []string{},
+			expectedErrMsg:   "context deadline exceeded",
+		},
+		{
+			namespaces:       []string{},
+			includeSucceeded: true,
+			checkReadiness:   true,
+			ignoreFailedPods: true,
+			ignoreNamespaces: []string{"ns2"},
+			expectedErrMsg:   "context deadline exceeded",
+		},
+	}
+
+	var runtimeObjects []runtime.Object
+	runtimeObjects = append(runtimeObjects, generateTestPod("test1", "ns1", corev1.PodRunning, corev1.PodReady, false))
+	runtimeObjects = append(runtimeObjects, generateTestPod("test2", "ns1", corev1.PodRunning, corev1.PodReady, false))
+	runtimeObjects = append(runtimeObjects, generateTestPod("test3", "ns1", corev1.PodRunning, corev1.PodReady, false))
+	runtimeObjects = append(runtimeObjects, generateTestPod("test4", "ns1", corev1.PodRunning, corev1.PodReady, false))
+	runtimeObjects = append(runtimeObjects, generateTestPod("test5", "ns1", corev1.PodRunning, corev1.PodReady, false))
+	runtimeObjects = append(runtimeObjects, generateTestPod("test1", "ns2", corev1.PodRunning, corev1.PodReady, false))
+	runtimeObjects = append(runtimeObjects, generateTestPod("test2", "ns2", corev1.PodRunning, corev1.PodInitialized,
+		false))
+
+	testSettings := clients.GetTestClients(clients.TestClientParams{
+		K8sMockObjects: runtimeObjects,
+	})
+
+	for _, testCase := range testCases {
+		err := WaitForAllPodsInNamespacesHealthy(testSettings, testCase.namespaces, 2*time.Second, testCase.includeSucceeded,
+			testCase.checkReadiness,
+			testCase.ignoreFailedPods, testCase.ignoreNamespaces)
+
+		assert.Equal(t, testCase.expectedErrMsg, getErrorString(err))
+	}
+}

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -301,7 +301,7 @@ func (builder *Builder) WaitUntilHealthy(timeout time.Duration, includeSucceeded
 		builder.Object.Status.Phase == corev1.PodFailed &&
 		builder.Object.Spec.RestartPolicy == corev1.RestartPolicyNever {
 		glog.V(100).Infof("Ignore failed pod with restart policy never. Message: %s",
-			statusesChecked, builder.Object.Status.Message)
+			builder.Object.Status.Message)
 
 		return nil
 	}

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -90,6 +90,12 @@ func NewBuilder(apiClient *clients.Settings, name, nsname, image string) *Builde
 func Pull(apiClient *clients.Settings, name, nsname string) (*Builder, error) {
 	glog.V(100).Infof("Pulling existing pod name: %s namespace:%s", name, nsname)
 
+	if apiClient == nil {
+		glog.V(100).Infof("The apiClient is empty")
+
+		return nil, fmt.Errorf("pod 'apiClient' cannot be empty")
+	}
+
 	builder := Builder{
 		apiClient: apiClient,
 		Definition: &corev1.Pod{

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -283,6 +283,55 @@ func (builder *Builder) WaitUntilRunning(timeout time.Duration) error {
 	return builder.WaitUntilInStatus(corev1.PodRunning, timeout)
 }
 
+// WaitUntilHealthy waits for the duration of the defined timeout or until the pod is healthy.
+// An healthy pod is in running phase and optionally in ready condition.
+//
+// timeout is the duration to wait for the pod to be healthy
+// includeSucceeded when true, implies that pod in succeeded phase is running.
+// checkReadiness when true, to also checks that the podCondition is ready.
+// ignoreFailedPods when true, to Ignore failed pod with restart policy set to never.
+func (builder *Builder) WaitUntilHealthy(timeout time.Duration, includeSucceeded, checkReadiness,
+	ignoreFailedPods bool) error {
+	statusesChecked := []corev1.PodPhase{corev1.PodRunning}
+
+	// Ignore failed pod with restart policy never. This could happen in image pruner or installer pods that
+	// will never restart. For those pods, instead of restarting the same pod, a new pod will be created
+	// to complete the task.
+	if ignoreFailedPods &&
+		builder.Object.Status.Phase == corev1.PodFailed &&
+		builder.Object.Spec.RestartPolicy == corev1.RestartPolicyNever {
+		glog.V(100).Infof("Ignore failed pod with restart policy never. Message: %s",
+			statusesChecked, builder.Object.Status.Message)
+
+		return nil
+	}
+
+	if includeSucceeded {
+		statusesChecked = append(statusesChecked, corev1.PodSucceeded)
+	}
+
+	podPhase, err := builder.WaitUntilInStatuses(statusesChecked, timeout)
+
+	if err != nil {
+		glog.V(100).Infof("pod condition is not in %v. Message: %s", statusesChecked, builder.Object.Status.Message)
+
+		return err
+	}
+
+	if !(checkReadiness && podPhase == corev1.PodRunning) {
+		return nil
+	}
+
+	err = builder.WaitUntilCondition(corev1.PodReady, timeout)
+	if err != nil {
+		glog.V(100).Infof("pod condition is not Ready. Message: %s", builder.Object.Status.Message)
+
+		return err
+	}
+
+	return nil
+}
+
 // WaitUntilInStatus waits for the duration of the defined timeout or until the pod gets to a specific status.
 func (builder *Builder) WaitUntilInStatus(status corev1.PodPhase, timeout time.Duration) error {
 	if valid, err := builder.validate(); !valid {
@@ -301,6 +350,39 @@ func (builder *Builder) WaitUntilInStatus(status corev1.PodPhase, timeout time.D
 			}
 
 			return updatePod.Status.Phase == status, nil
+		})
+}
+
+// WaitUntilInStatuses waits for the duration of the defined timeout or until the pod gets to any specific status
+// in a list of statues.
+func (builder *Builder) WaitUntilInStatuses(statuses []corev1.PodPhase,
+	timeout time.Duration) (corev1.PodPhase, error) {
+	if valid, err := builder.validate(); !valid {
+		return corev1.PodUnknown, err
+	}
+
+	glog.V(100).Infof("Waiting for the defined period until pod %s in namespace %s has status %v",
+		builder.Definition.Name, builder.Definition.Namespace, statuses)
+
+	var foundPhase corev1.PodPhase
+
+	return foundPhase, wait.PollUntilContextTimeout(
+		context.TODO(), time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+			updatePod, err := builder.apiClient.Pods(builder.Object.Namespace).Get(
+				context.TODO(), builder.Object.Name, metav1.GetOptions{})
+			if err != nil {
+				return false, nil
+			}
+
+			for _, phase := range statuses {
+				if updatePod.Status.Phase == phase {
+					foundPhase = phase
+
+					return true, nil
+				}
+			}
+
+			return false, nil
 		})
 }
 

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -2,11 +2,14 @@ package pod
 
 import (
 	"testing"
+	"time"
 
+	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/stretchr/testify/assert"
-	"k8s.io/apimachinery/pkg/api/resource"
-
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 )
 
 func buildValidContainterBuilder() *ContainerBuilder {
@@ -74,5 +77,239 @@ func TestWithCustomResourcesRequests(t *testing.T) {
 					resource.MustParse(v), testBuilder.definition.Resources.Requests[corev1.ResourceName(k)])
 			}
 		}
+	}
+}
+
+func buildPodTestBuilderWithFakeObjects(objects []runtime.Object, name, namespace string) (*Builder, error) {
+	fakeClient := k8sfake.NewSimpleClientset(objects...)
+
+	return Pull(&clients.Settings{
+		K8sClient:       fakeClient,
+		CoreV1Interface: fakeClient.CoreV1(),
+	}, name, namespace)
+}
+
+func generateTestPod(name, namespace string, phase corev1.PodPhase, conditionType corev1.PodConditionType,
+	neverRestart bool) *corev1.Pod {
+	pod := corev1.Pod{}
+	pod.Name = name
+	pod.Namespace = namespace
+	pod.Status.Phase = phase
+	condition := corev1.PodCondition{}
+	condition.Type = conditionType
+	condition.Status = corev1.ConditionTrue
+
+	pod.Status.Conditions = append(pod.Status.Conditions, condition)
+	if neverRestart {
+		pod.Spec.RestartPolicy = corev1.RestartPolicyNever
+	}
+
+	return &pod
+}
+
+func getErrorString(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	return err.Error()
+}
+
+func TestWaitUntilInStatuses(t *testing.T) {
+	testCases := []struct {
+		checkedPhases    []corev1.PodPhase
+		expectedPodPhase corev1.PodPhase
+		expectedErrMsg   string
+		pod              *corev1.Pod
+	}{
+		{
+			checkedPhases:    []corev1.PodPhase{corev1.PodRunning},
+			expectedPodPhase: "Running",
+			expectedErrMsg:   "",
+			pod:              generateTestPod("test1", "ns1", corev1.PodRunning, corev1.PodReady, false),
+		},
+		{
+			checkedPhases:    []corev1.PodPhase{corev1.PodRunning, corev1.PodSucceeded},
+			expectedPodPhase: "Running",
+			expectedErrMsg:   "",
+			pod:              generateTestPod("test2", "ns1", corev1.PodRunning, corev1.PodReady, false),
+		},
+		{
+			checkedPhases:    []corev1.PodPhase{corev1.PodRunning, corev1.PodSucceeded},
+			expectedPodPhase: "Succeeded",
+			expectedErrMsg:   "",
+			pod:              generateTestPod("test3", "ns2", corev1.PodSucceeded, corev1.PodReady, false),
+		},
+		{
+			checkedPhases:    []corev1.PodPhase{corev1.PodRunning, corev1.PodSucceeded},
+			expectedPodPhase: "",
+			expectedErrMsg:   "context deadline exceeded",
+			pod:              generateTestPod("test1", "ns1", corev1.PodFailed, corev1.PodReady, false),
+		},
+	}
+
+	for _, testCase := range testCases {
+		var runtimeObjects []runtime.Object
+		runtimeObjects = append(runtimeObjects, testCase.pod)
+		testBuilder, err := buildPodTestBuilderWithFakeObjects(runtimeObjects, testCase.pod.Name, testCase.pod.Namespace)
+		assert.Nil(t, err)
+
+		var phase corev1.PodPhase
+		phase, err = testBuilder.WaitUntilInStatuses(testCase.checkedPhases, 2*time.Second)
+
+		assert.Equal(t, testCase.expectedErrMsg, getErrorString(err))
+		assert.Equal(t, testCase.expectedPodPhase, phase)
+	}
+}
+
+func TestWaitUntilHealthy(t *testing.T) {
+	testCases := []struct {
+		includeSucceeded bool
+		checkReadiness   bool
+		ignoreFailedPods bool
+		expectedErrMsg   string
+		pod              *corev1.Pod
+	}{
+		{
+			includeSucceeded: true,
+			checkReadiness:   true,
+			ignoreFailedPods: true,
+			expectedErrMsg:   "",
+			pod:              generateTestPod("test1", "ns1", corev1.PodRunning, corev1.PodReady, false),
+		},
+		{
+			includeSucceeded: true,
+			checkReadiness:   true,
+			ignoreFailedPods: true,
+			expectedErrMsg:   "context deadline exceeded",
+			pod:              generateTestPod("test1", "ns1", corev1.PodRunning, corev1.PodInitialized, false),
+		},
+		{
+			includeSucceeded: false,
+			checkReadiness:   true,
+			ignoreFailedPods: true,
+			expectedErrMsg:   "context deadline exceeded",
+			pod:              generateTestPod("test1", "ns1", corev1.PodSucceeded, corev1.PodScheduled, false),
+		},
+		{
+			includeSucceeded: true,
+			checkReadiness:   true,
+			ignoreFailedPods: true,
+			expectedErrMsg:   "",
+			pod:              generateTestPod("test1", "ns1", corev1.PodSucceeded, corev1.PodScheduled, false),
+		},
+		{
+			includeSucceeded: true,
+			checkReadiness:   false,
+			ignoreFailedPods: true,
+			expectedErrMsg:   "",
+			pod:              generateTestPod("test1", "ns1", corev1.PodRunning, corev1.PodScheduled, false),
+		},
+		{
+			includeSucceeded: true,
+			checkReadiness:   true,
+			ignoreFailedPods: false,
+			expectedErrMsg:   "context deadline exceeded",
+			pod:              generateTestPod("test1", "ns1", corev1.PodFailed, corev1.PodScheduled, false),
+		},
+		{
+			includeSucceeded: true,
+			checkReadiness:   true,
+			ignoreFailedPods: true,
+			expectedErrMsg:   "",
+			pod:              generateTestPod("test1", "ns1", corev1.PodFailed, corev1.PodScheduled, true),
+		},
+		{
+			includeSucceeded: true,
+			checkReadiness:   true,
+			ignoreFailedPods: true,
+			expectedErrMsg:   "context deadline exceeded",
+			pod:              generateTestPod("test1", "ns1", corev1.PodFailed, corev1.PodScheduled, false),
+		},
+	}
+
+	for _, testCase := range testCases {
+		var runtimeObjects []runtime.Object
+		runtimeObjects = append(runtimeObjects, testCase.pod)
+		testBuilder, err := buildPodTestBuilderWithFakeObjects(runtimeObjects, testCase.pod.Name, testCase.pod.Namespace)
+		assert.Nil(t, err)
+
+		err = testBuilder.WaitUntilHealthy(2*time.Second, testCase.includeSucceeded, testCase.checkReadiness,
+			testCase.ignoreFailedPods)
+
+		assert.Equal(t, testCase.expectedErrMsg, getErrorString(err))
+	}
+}
+
+func TestWaitForAllPodsInNamespacesHealthy(t *testing.T) {
+	testCases := []struct {
+		namespaces       []string
+		includeSucceeded bool
+		checkReadiness   bool
+		ignoreFailedPods bool
+		ignoreNamespaces []string
+		expectedErrMsg   string
+	}{
+		{
+			namespaces:       []string{"ns1"},
+			includeSucceeded: true,
+			checkReadiness:   false,
+			ignoreFailedPods: true,
+			ignoreNamespaces: []string{},
+			expectedErrMsg:   "",
+		},
+		{
+			namespaces:       []string{"ns1"},
+			includeSucceeded: true,
+			checkReadiness:   true,
+			ignoreFailedPods: true,
+			ignoreNamespaces: []string{},
+			expectedErrMsg:   "",
+		},
+		{
+			namespaces:       []string{"ns2"},
+			includeSucceeded: true,
+			checkReadiness:   true,
+			ignoreFailedPods: true,
+			ignoreNamespaces: []string{},
+			expectedErrMsg:   "context deadline exceeded",
+		},
+		{
+			namespaces:       []string{""},
+			includeSucceeded: true,
+			checkReadiness:   true,
+			ignoreFailedPods: true,
+			ignoreNamespaces: []string{},
+			expectedErrMsg:   "context deadline exceeded",
+		},
+		{
+			namespaces:       []string{""},
+			includeSucceeded: true,
+			checkReadiness:   true,
+			ignoreFailedPods: true,
+			ignoreNamespaces: []string{"ns2"},
+			expectedErrMsg:   "context deadline exceeded",
+		},
+	}
+
+	var runtimeObjects []runtime.Object
+	runtimeObjects = append(runtimeObjects, generateTestPod("test1", "ns1", corev1.PodRunning, corev1.PodReady, false))
+	runtimeObjects = append(runtimeObjects, generateTestPod("test2", "ns1", corev1.PodRunning, corev1.PodReady, false))
+	runtimeObjects = append(runtimeObjects, generateTestPod("test3", "ns1", corev1.PodRunning, corev1.PodReady, false))
+	runtimeObjects = append(runtimeObjects, generateTestPod("test4", "ns1", corev1.PodRunning, corev1.PodReady, false))
+	runtimeObjects = append(runtimeObjects, generateTestPod("test5", "ns1", corev1.PodRunning, corev1.PodReady, false))
+	runtimeObjects = append(runtimeObjects, generateTestPod("test1", "ns2", corev1.PodRunning, corev1.PodReady, false))
+	runtimeObjects = append(runtimeObjects, generateTestPod("test2", "ns2", corev1.PodRunning, corev1.PodInitialized,
+		false))
+	fakeClient := k8sfake.NewSimpleClientset(runtimeObjects...)
+
+	for _, testCase := range testCases {
+		err := WaitForAllPodsInNamespacesHealthy(&clients.Settings{
+			K8sClient:       fakeClient,
+			CoreV1Interface: fakeClient.CoreV1()}, testCase.namespaces, 2*time.Second, testCase.includeSucceeded,
+			testCase.checkReadiness,
+			testCase.ignoreFailedPods, testCase.ignoreNamespaces)
+
+		assert.Equal(t, testCase.expectedErrMsg, getErrorString(err))
 	}
 }


### PR DESCRIPTION
Changes in this PR are now split, see https://github.com/openshift-kni/eco-goinfra/pull/570

Refactoring functions previously defined in eco-gotests RAN subfolder:
- IsPodHealthy https://github.com/openshift-kni/eco-gotests/blob/4b0fbe0b32ad910f8f4421337cfe84c4f92cefc1/tests/cnf/ran/internal/ranhelper/ranhelper.go#L14 . New function name is: WaitUntilHealthy 
- waitForAllPodsHealthy https://github.com/openshift-kni/eco-gotests/blob/4b0fbe0b32ad910f8f4421337cfe84c4f92cefc1/tests/cnf/ran/talm/internal/helper/cluster.go#L146 . New function name is: WaitForAllPodsInNamespacesHealthy
- Also adding Adding pod.WaitUntilInStatuses

Also modified the pod List function to return all namespaces when the namespace name is empty
Currently investigating unit tests