### PR TITLE
pod:add WaitUntilInStatuses,WaitUntilHealthy funcs

### DIFF
--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -120,7 +120,7 @@ func TestWaitUntilInStatuses(t *testing.T) {
 		assert.Nil(t, err)
 
 		var phase *corev1.PodPhase
-		phase, err = testBuilder.WaitUntilInStatuses(testCase.checkedPhases, 2*time.Second)
+		phase, err = testBuilder.WaitUntilInOneOfStatuses(testCase.checkedPhases, 2*time.Second)
 
 		assert.Equal(t, testCase.expectedErrMsg, getErrorString(err))
 		assert.Equal(t, testCase.expectedPodPhase, *phase)

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -2,11 +2,14 @@ package pod
 
 import (
 	"testing"
+	"time"
 
+	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/stretchr/testify/assert"
-	"k8s.io/apimachinery/pkg/api/resource"
-
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 )
 
 func buildValidContainterBuilder() *ContainerBuilder {
@@ -75,4 +78,165 @@ func TestWithCustomResourcesRequests(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestWaitUntilInStatuses(t *testing.T) {
+	testCases := []struct {
+		checkedPhases    []corev1.PodPhase
+		expectedPodPhase corev1.PodPhase
+		expectedErrMsg   string
+		pod              *corev1.Pod
+	}{
+		{
+			checkedPhases:    []corev1.PodPhase{corev1.PodRunning},
+			expectedPodPhase: "Running",
+			expectedErrMsg:   "",
+			pod:              generateTestPod("test1", "ns1", corev1.PodRunning, corev1.PodReady, false),
+		},
+		{
+			checkedPhases:    []corev1.PodPhase{corev1.PodRunning, corev1.PodSucceeded},
+			expectedPodPhase: "Running",
+			expectedErrMsg:   "",
+			pod:              generateTestPod("test2", "ns1", corev1.PodRunning, corev1.PodReady, false),
+		},
+		{
+			checkedPhases:    []corev1.PodPhase{corev1.PodRunning, corev1.PodSucceeded},
+			expectedPodPhase: "Succeeded",
+			expectedErrMsg:   "",
+			pod:              generateTestPod("test3", "ns2", corev1.PodSucceeded, corev1.PodReady, false),
+		},
+		{
+			checkedPhases:    []corev1.PodPhase{corev1.PodRunning, corev1.PodSucceeded},
+			expectedPodPhase: "",
+			expectedErrMsg:   "context deadline exceeded",
+			pod:              generateTestPod("test1", "ns1", corev1.PodFailed, corev1.PodReady, false),
+		},
+	}
+
+	for _, testCase := range testCases {
+		var runtimeObjects []runtime.Object
+		runtimeObjects = append(runtimeObjects, testCase.pod)
+		testBuilder, err := buildPodTestBuilderWithFakeObjects(runtimeObjects, testCase.pod.Name, testCase.pod.Namespace)
+		assert.Nil(t, err)
+
+		var phase corev1.PodPhase
+		phase, err = testBuilder.WaitUntilInStatuses(testCase.checkedPhases, 2*time.Second)
+
+		assert.Equal(t, testCase.expectedErrMsg, getErrorString(err))
+		assert.Equal(t, testCase.expectedPodPhase, phase)
+	}
+}
+
+func TestWaitUntilHealthy(t *testing.T) {
+	testCases := []struct {
+		includeSucceeded bool
+		checkReadiness   bool
+		ignoreFailedPods bool
+		expectedErrMsg   string
+		pod              *corev1.Pod
+	}{
+		{
+			includeSucceeded: true,
+			checkReadiness:   true,
+			ignoreFailedPods: true,
+			expectedErrMsg:   "",
+			pod:              generateTestPod("test1", "ns1", corev1.PodRunning, corev1.PodReady, false),
+		},
+		{
+			includeSucceeded: true,
+			checkReadiness:   true,
+			ignoreFailedPods: true,
+			expectedErrMsg:   "context deadline exceeded",
+			pod:              generateTestPod("test1", "ns1", corev1.PodRunning, corev1.PodInitialized, false),
+		},
+		{
+			includeSucceeded: false,
+			checkReadiness:   true,
+			ignoreFailedPods: true,
+			expectedErrMsg:   "context deadline exceeded",
+			pod:              generateTestPod("test1", "ns1", corev1.PodSucceeded, corev1.PodScheduled, false),
+		},
+		{
+			includeSucceeded: true,
+			checkReadiness:   true,
+			ignoreFailedPods: true,
+			expectedErrMsg:   "",
+			pod:              generateTestPod("test1", "ns1", corev1.PodSucceeded, corev1.PodScheduled, false),
+		},
+		{
+			includeSucceeded: true,
+			checkReadiness:   false,
+			ignoreFailedPods: true,
+			expectedErrMsg:   "",
+			pod:              generateTestPod("test1", "ns1", corev1.PodRunning, corev1.PodScheduled, false),
+		},
+		{
+			includeSucceeded: true,
+			checkReadiness:   true,
+			ignoreFailedPods: false,
+			expectedErrMsg:   "context deadline exceeded",
+			pod:              generateTestPod("test1", "ns1", corev1.PodFailed, corev1.PodScheduled, false),
+		},
+		{
+			includeSucceeded: true,
+			checkReadiness:   true,
+			ignoreFailedPods: true,
+			expectedErrMsg:   "",
+			pod:              generateTestPod("test1", "ns1", corev1.PodFailed, corev1.PodScheduled, true),
+		},
+		{
+			includeSucceeded: true,
+			checkReadiness:   true,
+			ignoreFailedPods: true,
+			expectedErrMsg:   "context deadline exceeded",
+			pod:              generateTestPod("test1", "ns1", corev1.PodFailed, corev1.PodScheduled, false),
+		},
+	}
+
+	for _, testCase := range testCases {
+		var runtimeObjects []runtime.Object
+		runtimeObjects = append(runtimeObjects, testCase.pod)
+		testBuilder, err := buildPodTestBuilderWithFakeObjects(runtimeObjects, testCase.pod.Name, testCase.pod.Namespace)
+		assert.Nil(t, err)
+
+		err = testBuilder.WaitUntilHealthy(2*time.Second, testCase.includeSucceeded, testCase.checkReadiness,
+			testCase.ignoreFailedPods)
+
+		assert.Equal(t, testCase.expectedErrMsg, getErrorString(err))
+	}
+}
+
+func buildPodTestBuilderWithFakeObjects(objects []runtime.Object, name, namespace string) (*Builder, error) {
+	fakeClient := k8sfake.NewSimpleClientset(objects...)
+
+	return Pull(&clients.Settings{
+		K8sClient:       fakeClient,
+		CoreV1Interface: fakeClient.CoreV1(),
+	}, name, namespace)
+}
+
+func generateTestPod(name, namespace string, phase corev1.PodPhase, conditionType corev1.PodConditionType,
+	neverRestart bool) *corev1.Pod {
+	pod := corev1.Pod{}
+	pod.Name = name
+	pod.Namespace = namespace
+	pod.Status.Phase = phase
+	condition := corev1.PodCondition{}
+	condition.Type = conditionType
+	condition.Status = corev1.ConditionTrue
+
+	pod.Status.Conditions = append(pod.Status.Conditions, condition)
+	if neverRestart {
+		pod.Spec.RestartPolicy = corev1.RestartPolicyNever
+	}
+
+	return &pod
+}
+
+func getErrorString(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	return err.Error()
 }

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -119,74 +119,74 @@ func TestWaitUntilInStatuses(t *testing.T) {
 		testBuilder, err := buildPodTestBuilderWithFakeObjects(runtimeObjects, testCase.pod.Name, testCase.pod.Namespace)
 		assert.Nil(t, err)
 
-		var phase corev1.PodPhase
+		var phase *corev1.PodPhase
 		phase, err = testBuilder.WaitUntilInStatuses(testCase.checkedPhases, 2*time.Second)
 
 		assert.Equal(t, testCase.expectedErrMsg, getErrorString(err))
-		assert.Equal(t, testCase.expectedPodPhase, phase)
+		assert.Equal(t, testCase.expectedPodPhase, *phase)
 	}
 }
 
 func TestWaitUntilHealthy(t *testing.T) {
 	testCases := []struct {
 		includeSucceeded bool
-		checkReadiness   bool
+		skipReadiness    bool
 		ignoreFailedPods bool
 		expectedErrMsg   string
 		pod              *corev1.Pod
 	}{
 		{
 			includeSucceeded: true,
-			checkReadiness:   true,
+			skipReadiness:    false,
 			ignoreFailedPods: true,
 			expectedErrMsg:   "",
 			pod:              generateTestPod("test1", "ns1", corev1.PodRunning, corev1.PodReady, false),
 		},
 		{
 			includeSucceeded: true,
-			checkReadiness:   true,
+			skipReadiness:    false,
 			ignoreFailedPods: true,
 			expectedErrMsg:   "context deadline exceeded",
 			pod:              generateTestPod("test1", "ns1", corev1.PodRunning, corev1.PodInitialized, false),
 		},
 		{
 			includeSucceeded: false,
-			checkReadiness:   true,
+			skipReadiness:    false,
 			ignoreFailedPods: true,
 			expectedErrMsg:   "context deadline exceeded",
 			pod:              generateTestPod("test1", "ns1", corev1.PodSucceeded, corev1.PodScheduled, false),
 		},
 		{
 			includeSucceeded: true,
-			checkReadiness:   true,
+			skipReadiness:    false,
 			ignoreFailedPods: true,
 			expectedErrMsg:   "",
 			pod:              generateTestPod("test1", "ns1", corev1.PodSucceeded, corev1.PodScheduled, false),
 		},
 		{
 			includeSucceeded: true,
-			checkReadiness:   false,
+			skipReadiness:    true,
 			ignoreFailedPods: true,
 			expectedErrMsg:   "",
 			pod:              generateTestPod("test1", "ns1", corev1.PodRunning, corev1.PodScheduled, false),
 		},
 		{
 			includeSucceeded: true,
-			checkReadiness:   true,
+			skipReadiness:    false,
 			ignoreFailedPods: false,
 			expectedErrMsg:   "context deadline exceeded",
 			pod:              generateTestPod("test1", "ns1", corev1.PodFailed, corev1.PodScheduled, false),
 		},
 		{
 			includeSucceeded: true,
-			checkReadiness:   true,
+			skipReadiness:    false,
 			ignoreFailedPods: true,
 			expectedErrMsg:   "",
 			pod:              generateTestPod("test1", "ns1", corev1.PodFailed, corev1.PodScheduled, true),
 		},
 		{
 			includeSucceeded: true,
-			checkReadiness:   true,
+			skipReadiness:    false,
 			ignoreFailedPods: true,
 			expectedErrMsg:   "context deadline exceeded",
 			pod:              generateTestPod("test1", "ns1", corev1.PodFailed, corev1.PodScheduled, false),
@@ -199,7 +199,7 @@ func TestWaitUntilHealthy(t *testing.T) {
 		testBuilder, err := buildPodTestBuilderWithFakeObjects(runtimeObjects, testCase.pod.Name, testCase.pod.Namespace)
 		assert.Nil(t, err)
 
-		err = testBuilder.WaitUntilHealthy(2*time.Second, testCase.includeSucceeded, testCase.checkReadiness,
+		err = testBuilder.WaitUntilHealthy(2*time.Second, testCase.includeSucceeded, testCase.skipReadiness,
 			testCase.ignoreFailedPods)
 
 		assert.Equal(t, testCase.expectedErrMsg, getErrorString(err))


### PR DESCRIPTION
Refactoring functions previously defined in eco-gotests RAN subfolder:

IsPodHealthy https://github.com/openshift-kni/eco-gotests/blob/4b0fbe0b32ad910f8f4421337cfe84c4f92cefc1/tests/cnf/ran/internal/ranhelper/ranhelper.go#L14 . New function name is: WaitUntilHealthy