### PR TITLE
pod: add WaitForAllPodsInNamespacesHealthy

### DIFF
--- a/pkg/pod/list.go
+++ b/pkg/pod/list.go
@@ -3,6 +3,7 @@ package pod
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -13,6 +14,12 @@ import (
 
 // List returns pod inventory in the given namespace.
 func List(apiClient *clients.Settings, nsname string, options ...metav1.ListOptions) ([]*Builder, error) {
+	if apiClient == nil {
+		glog.V(100).Infof("The apiClient is empty")
+
+		return nil, fmt.Errorf("podList 'apiClient' cannot be empty")
+	}
+
 	if nsname == "" {
 		glog.V(100).Infof("pod 'nsname' parameter can not be empty")
 
@@ -62,6 +69,12 @@ func ListInAllNamespaces(apiClient *clients.Settings, options ...metav1.ListOpti
 	logMessage := "Listing all pods in all namespaces"
 	passedOptions := metav1.ListOptions{}
 
+	if apiClient == nil {
+		glog.V(100).Infof("The apiClient is empty")
+
+		return nil, fmt.Errorf("podList 'apiClient' cannot be empty")
+	}
+
 	if len(options) > 1 {
 		glog.V(100).Infof("'options' parameter must be empty or single-valued")
 
@@ -103,6 +116,12 @@ func ListInAllNamespaces(apiClient *clients.Settings, options ...metav1.ListOpti
 func ListByNamePattern(apiClient *clients.Settings, namePattern, nsname string) ([]*Builder, error) {
 	glog.V(100).Infof("Listing pods in the nsname %s filtered by the name pattern %s", nsname, namePattern)
 
+	if apiClient == nil {
+		glog.V(100).Infof("The apiClient is empty")
+
+		return nil, fmt.Errorf("podList 'apiClient' cannot be empty")
+	}
+
 	if nsname == "" {
 		glog.V(100).Infof("pod 'nsname' parameter can not be empty")
 
@@ -142,6 +161,12 @@ func WaitForAllPodsInNamespaceRunning(
 	nsname string,
 	timeout time.Duration,
 	options ...metav1.ListOptions) (bool, error) {
+	if apiClient == nil {
+		glog.V(100).Infof("The apiClient is empty")
+
+		return false, fmt.Errorf("podList 'apiClient' cannot be empty")
+	}
+
 	if nsname == "" {
 		glog.V(100).Infof("'nsname' parameter can not be empty")
 
@@ -181,4 +206,86 @@ func WaitForAllPodsInNamespaceRunning(
 	}
 
 	return true, nil
+}
+
+// WaitForAllPodsInNamespacesHealthy waits until all pods in a list of namespaces that match options
+// are in healthy state.
+// An pod in a healthy state is in running phase and optionally in ready condition.
+//
+// nsNames lists the list of namespaces to monitor. Monitors all namespaces when empty.
+// timeout is the duration to wait for the pods to be healthy
+// includeSucceeded when true, implies that pods in succeeded phase are running.
+// checkReadiness when true, to also checks that the podConditions are ready.
+// ignoreFailedPods when true, to Ignore failed pods with restart policy set to never.
+// ignoreNamespaces is a list of namespaces to ignore.
+// options reduces the list of namespace to only the ones matching options.
+func WaitForAllPodsInNamespacesHealthy(
+	apiClient *clients.Settings,
+	nsNames []string,
+	timeout time.Duration,
+	includeSucceeded bool,
+	skipReadinessCheck bool,
+	ignoreRestartPolicyNever bool,
+	ignoreNamespaces []string,
+	options ...metav1.ListOptions,
+) error {
+	logMessage := fmt.Sprintf("Waiting for all pods in %v namespaces", nsNames)
+	passedOptions := metav1.ListOptions{}
+
+	if apiClient == nil {
+		glog.V(100).Infof("The apiClient is empty")
+
+		return fmt.Errorf("podList 'apiClient' cannot be empty")
+	}
+
+	if len(options) > 1 {
+		glog.V(100).Infof("'options' parameter must be empty or single-valued")
+
+		return fmt.Errorf("error: more than one ListOptions was passed")
+	}
+
+	if len(options) == 1 {
+		passedOptions = options[0]
+		logMessage += fmt.Sprintf(" with the options %v", passedOptions)
+	}
+
+	glog.V(100).Infof(logMessage + " are in running state")
+
+	var podList []*Builder
+
+	if len(nsNames) == 0 {
+		var err error
+		podList, err = ListInAllNamespaces(apiClient, passedOptions)
+
+		if err != nil {
+			glog.V(100).Infof("Failed to list all pods due to %s", err.Error())
+
+			return err
+		}
+	} else {
+		for _, ns := range nsNames {
+			podListForNs, err := List(apiClient, ns, passedOptions)
+			if err != nil {
+				glog.V(100).Infof("Failed to list all pods due to %s", err.Error())
+
+				return err
+			}
+			podList = append(podList, podListForNs...)
+		}
+	}
+
+	for _, podObj := range podList {
+		if slices.Contains(ignoreNamespaces, podObj.apiClient.Namespace) {
+			continue
+		}
+
+		err := podObj.WaitUntilHealthy(timeout, includeSucceeded, skipReadinessCheck, ignoreRestartPolicyNever)
+		if err != nil {
+			glog.V(100).Infof("Failed to wait for all pods to be healthy due to %s", err.Error())
+
+			return err
+		}
+	}
+
+	return nil
 }

--- a/pkg/pod/list.go
+++ b/pkg/pod/list.go
@@ -208,15 +208,15 @@ func WaitForAllPodsInNamespaceRunning(
 	return true, nil
 }
 
-// WaitForAllPodsInNamespacesHealthy waits until all pods in a list of namespaces that match options
-// are in healthy state.
-// An pod in a healthy state is in running phase and optionally in ready condition.
+// WaitForAllPodsInNamespacesHealthy waits until:
+// - all pods in a list of namespaces that match options are in healthy state.
+// - a pod in a healthy state is in running phase and optionally in ready condition.
 //
-// nsNames lists the list of namespaces to monitor. Monitors all namespaces when empty.
-// timeout is the duration to wait for the pods to be healthy
-// includeSucceeded when true, implies that pods in succeeded phase are running.
-// checkReadiness when true, to also checks that the podConditions are ready.
-// ignoreFailedPods when true, to Ignore failed pods with restart policy set to never.
+// nsNames passes the list of namespaces to monitor. Monitors all namespaces when empty.
+// timeout is the duration in seconds to wait for the pods to be healthy
+// includeSucceeded when true, considers that pods in succeeded phase are healthy.
+// skipReadiness when false, checks that the podCondition is ready.
+// ignoreRestartPolicyNever when true, ignores failed pods with restart policy set to never.
 // ignoreNamespaces is a list of namespaces to ignore.
 // options reduces the list of namespace to only the ones matching options.
 func WaitForAllPodsInNamespacesHealthy(
@@ -236,12 +236,6 @@ func WaitForAllPodsInNamespacesHealthy(
 		glog.V(100).Infof("The apiClient is empty")
 
 		return fmt.Errorf("podList 'apiClient' cannot be empty")
-	}
-
-	if len(options) > 1 {
-		glog.V(100).Infof("'options' parameter must be empty or single-valued")
-
-		return fmt.Errorf("error: more than one ListOptions was passed")
 	}
 
 	if len(options) == 1 {

--- a/pkg/pod/list_test.go
+++ b/pkg/pod/list_test.go
@@ -1,0 +1,85 @@
+package pod
+
+import (
+	"testing"
+	"time"
+
+	"github.com/openshift-kni/eco-goinfra/pkg/clients"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestWaitForAllPodsInNamespacesHealthy(t *testing.T) {
+	testCases := []struct {
+		namespaces               []string
+		includeSucceeded         bool
+		skipRedinessCheck        bool
+		ignoreRestartPolicyNever bool
+		ignoreNamespaces         []string
+		expectedErrMsg           string
+	}{
+		{
+			namespaces:               []string{"ns1"},
+			includeSucceeded:         true,
+			skipRedinessCheck:        true,
+			ignoreRestartPolicyNever: true,
+			ignoreNamespaces:         []string{},
+			expectedErrMsg:           "",
+		},
+		{
+			namespaces:               []string{"ns1"},
+			includeSucceeded:         true,
+			skipRedinessCheck:        false,
+			ignoreRestartPolicyNever: true,
+			ignoreNamespaces:         []string{},
+			expectedErrMsg:           "",
+		},
+		{
+			namespaces:               []string{"ns2"},
+			includeSucceeded:         true,
+			skipRedinessCheck:        false,
+			ignoreRestartPolicyNever: true,
+			ignoreNamespaces:         []string{},
+			expectedErrMsg:           "context deadline exceeded",
+		},
+		{
+			namespaces:               []string{},
+			includeSucceeded:         true,
+			skipRedinessCheck:        false,
+			ignoreRestartPolicyNever: true,
+			ignoreNamespaces:         []string{},
+			expectedErrMsg:           "context deadline exceeded",
+		},
+		{
+			namespaces:               []string{},
+			includeSucceeded:         true,
+			skipRedinessCheck:        false,
+			ignoreRestartPolicyNever: true,
+			ignoreNamespaces:         []string{"ns2"},
+			expectedErrMsg:           "context deadline exceeded",
+		},
+	}
+
+	var runtimeObjects []runtime.Object
+	runtimeObjects = append(runtimeObjects, generateTestPod("test1", "ns1", corev1.PodRunning, corev1.PodReady, false))
+	runtimeObjects = append(runtimeObjects, generateTestPod("test2", "ns1", corev1.PodRunning, corev1.PodReady, false))
+	runtimeObjects = append(runtimeObjects, generateTestPod("test3", "ns1", corev1.PodRunning, corev1.PodReady, false))
+	runtimeObjects = append(runtimeObjects, generateTestPod("test4", "ns1", corev1.PodRunning, corev1.PodReady, false))
+	runtimeObjects = append(runtimeObjects, generateTestPod("test5", "ns1", corev1.PodRunning, corev1.PodReady, false))
+	runtimeObjects = append(runtimeObjects, generateTestPod("test1", "ns2", corev1.PodRunning, corev1.PodReady, false))
+	runtimeObjects = append(runtimeObjects, generateTestPod("test2", "ns2", corev1.PodRunning, corev1.PodInitialized,
+		false))
+
+	testSettings := clients.GetTestClients(clients.TestClientParams{
+		K8sMockObjects: runtimeObjects,
+	})
+
+	for _, testCase := range testCases {
+		err := WaitForAllPodsInNamespacesHealthy(testSettings, testCase.namespaces, 2*time.Second, testCase.includeSucceeded,
+			testCase.skipRedinessCheck,
+			testCase.ignoreRestartPolicyNever, testCase.ignoreNamespaces)
+
+		assert.Equal(t, testCase.expectedErrMsg, getErrorString(err))
+	}
+}


### PR DESCRIPTION
Refactoring functions previously defined in eco-gotests RAN subfolder:

WaitForAllPodsInNamespacesHealthy https://github.com/openshift-kni/eco-gotests/blob/050a4e5ee720e9a776a90791c8354ac9c5aaf43e/tests/cnf/ran/talm/internal/helper/cluster.go#L146. New function name is: WaitForAllPodsInNamespacesHealthy