### PR TITLE
cgu: reset resource version in force update

### DIFF
--- a/pkg/cgu/cgu.go
+++ b/pkg/cgu/cgu.go
@@ -306,6 +306,7 @@ func (builder *CguBuilder) Update(force bool) (*CguBuilder, error) {
 		// Deleting the cgu may take time, so wait for it to be deleted before recreating. Otherwise,
 		// the create happens before the delete finishes and this update results in just deletion.
 		builder, err := builder.DeleteAndWait(time.Minute)
+		builder.Definition.ResourceVersion = ""
 
 		if err != nil {
 			glog.V(100).Infof(


### PR DESCRIPTION
Similar to #483, when the CGU has ResourceVersion set on the definition, it can cause the create to fail. This results in the CGU being deleted but not created by the force update.

This situation can be achieved by calling WaitForCondition on a CGU before a force update while the CGU gets updated on the cluster in between. Has appeared in the TALM tests.