### PR TITLE
mco: tests and runtime client for machine config

### DIFF
--- a/pkg/clients/clients.go
+++ b/pkg/clients/clients.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
 
-	clientMachineConfigFake "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned/fake"
 	clientMachineConfigV1 "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned/typed/machineconfiguration.openshift.io/v1"
 
 	agentInstallV1Beta1 "github.com/openshift-kni/eco-goinfra/pkg/schemes/assisted/api/v1beta1"
@@ -230,7 +229,7 @@ func GetTestClients(tcp TestClientParams) *Settings {
 func GetModifiableTestClients(tcp TestClientParams) (*Settings, *fakeRuntimeClient.ClientBuilder) {
 	clientSet := &Settings{}
 
-	var k8sClientObjects, genericClientObjects, mcoObjects []runtime.Object
+	var k8sClientObjects, genericClientObjects []runtime.Object
 
 	//nolint:varnamelen
 	for _, v := range tcp.K8sMockObjects {
@@ -302,9 +301,6 @@ func GetModifiableTestClients(tcp TestClientParams) (*Settings, *fakeRuntimeClie
 			genericClientObjects = append(genericClientObjects, v)
 		case *agentInstallV1Beta1.AgentServiceConfig:
 			genericClientObjects = append(genericClientObjects, v)
-		// MCO Client Objects
-		case *mcv1.MachineConfig:
-			mcoObjects = append(mcoObjects, v)
 		}
 	}
 
@@ -315,8 +311,6 @@ func GetModifiableTestClients(tcp TestClientParams) (*Settings, *fakeRuntimeClie
 	clientSet.NetworkingV1Interface = clientSet.K8sClient.NetworkingV1()
 	clientSet.RbacV1Interface = clientSet.K8sClient.RbacV1()
 	clientSet.StorageV1Interface = clientSet.K8sClient.StorageV1()
-	clientSet.MachineconfigurationV1Interface = clientMachineConfigFake.NewSimpleClientset(
-		mcoObjects...).MachineconfigurationV1()
 
 	// Update the generic client with schemes of generic resources
 	clientSet.scheme = runtime.NewScheme()

--- a/pkg/mco/kubeletconfig_test.go
+++ b/pkg/mco/kubeletconfig_test.go
@@ -104,10 +104,10 @@ func TestPullKubeletConfig(t *testing.T) {
 			testSettings   *clients.Settings
 		)
 
-		testKAC := buildDummyKubeletConfig(testCase.name)
+		testKubeletConfig := buildDummyKubeletConfig(testCase.name)
 
 		if testCase.addToRuntimeObjects {
-			runtimeObjects = append(runtimeObjects, testKAC)
+			runtimeObjects = append(runtimeObjects, testKubeletConfig)
 		}
 
 		if testCase.client {
@@ -121,7 +121,7 @@ func TestPullKubeletConfig(t *testing.T) {
 		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
-			assert.Equal(t, testKAC.Name, testBuilder.Definition.Name)
+			assert.Equal(t, testKubeletConfig.Name, testBuilder.Definition.Name)
 		}
 	}
 }

--- a/pkg/mco/machineconfig_test.go
+++ b/pkg/mco/machineconfig_test.go
@@ -1,8 +1,12 @@
 package mco
 
 import (
+	"fmt"
+	"testing"
+
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -11,6 +15,417 @@ const defaultMachineConfigName = "test-machine-config"
 
 var testSchemes = []clients.SchemeAttacher{
 	mcv1.Install,
+}
+
+func TestNewMachineConfigBuilder(t *testing.T) {
+	testCases := []struct {
+		name              string
+		client            bool
+		expectedErrorText string
+	}{
+		{
+			name:              defaultMachineConfigName,
+			client:            true,
+			expectedErrorText: "",
+		},
+		{
+			name:              "",
+			client:            true,
+			expectedErrorText: "machineconfig 'name' cannot be empty",
+		},
+		{
+			name:              defaultMachineConfigName,
+			client:            false,
+			expectedErrorText: "",
+		},
+	}
+
+	for _, testCase := range testCases {
+		var testSettings *clients.Settings
+
+		if testCase.client {
+			testSettings = clients.GetTestClients(clients.TestClientParams{})
+		}
+
+		testBuilder := NewMCBuilder(testSettings, testCase.name)
+
+		if testCase.client {
+			assert.Equal(t, testCase.expectedErrorText, testBuilder.errorMsg)
+
+			if testCase.expectedErrorText == "" {
+				assert.Equal(t, testCase.name, testBuilder.Definition.Name)
+			}
+		} else {
+			assert.Nil(t, testBuilder)
+		}
+	}
+}
+
+func TestPullMachineConfig(t *testing.T) {
+	testCases := []struct {
+		name                string
+		addToRuntimeObjects bool
+		client              bool
+		expectedError       error
+	}{
+		{
+			name:                defaultMachineConfigName,
+			addToRuntimeObjects: true,
+			client:              true,
+			expectedError:       nil,
+		},
+		{
+			name:                "",
+			addToRuntimeObjects: true,
+			client:              true,
+			expectedError:       fmt.Errorf("machineconfig 'name' cannot be empty"),
+		},
+		{
+			name:                defaultMachineConfigName,
+			addToRuntimeObjects: false,
+			client:              true,
+			expectedError:       fmt.Errorf("machineconfig object %s does not exist", defaultMachineConfigName),
+		},
+		{
+			name:                defaultMachineConfigName,
+			addToRuntimeObjects: true,
+			client:              false,
+			expectedError:       fmt.Errorf("machineconfig 'apiClient' cannot be nil"),
+		},
+	}
+
+	for _, testCase := range testCases {
+		var (
+			runtimeObjects []runtime.Object
+			testSettings   *clients.Settings
+		)
+
+		testMC := buildDummyMachineConfig(testCase.name)
+
+		if testCase.addToRuntimeObjects {
+			runtimeObjects = append(runtimeObjects, testMC)
+		}
+
+		if testCase.client {
+			testSettings = clients.GetTestClients(clients.TestClientParams{
+				K8sMockObjects:  runtimeObjects,
+				SchemeAttachers: testSchemes,
+			})
+		}
+
+		testBuilder, err := PullMachineConfig(testSettings, testCase.name)
+		assert.Equal(t, testCase.expectedError, err)
+
+		if testCase.expectedError == nil {
+			assert.Equal(t, testMC.Name, testBuilder.Definition.Name)
+		}
+	}
+}
+
+func TestMachineConfigGet(t *testing.T) {
+	testCases := []struct {
+		testBuilder   *MCBuilder
+		expectedError string
+	}{
+		{
+			testBuilder:   buildValidMachineConfigTestBuilder(buildTestClientWithDummyMachineConfig()),
+			expectedError: "",
+		},
+		{
+			testBuilder:   buildInvalidMachineConfigTestBuilder(buildTestClientWithDummyMachineConfig()),
+			expectedError: "machineconfig 'name' cannot be empty",
+		},
+		{
+			testBuilder:   buildValidMachineConfigTestBuilder(clients.GetTestClients(clients.TestClientParams{})),
+			expectedError: "machineconfigs.machineconfiguration.openshift.io \"test-machine-config\" not found",
+		},
+	}
+
+	for _, testCase := range testCases {
+		machineConfig, err := testCase.testBuilder.Get()
+
+		if testCase.expectedError == "" {
+			assert.Nil(t, err)
+			assert.Equal(t, testCase.testBuilder.Definition.Name, machineConfig.Name)
+		} else {
+			assert.EqualError(t, err, testCase.expectedError)
+		}
+	}
+}
+
+func TestMachineConfigCreate(t *testing.T) {
+	testCases := []struct {
+		testBuilder   *MCBuilder
+		expectedError error
+	}{
+		{
+			testBuilder:   buildValidMachineConfigTestBuilder(buildTestClientWithDummyMachineConfig()),
+			expectedError: nil,
+		},
+		{
+			testBuilder:   buildInvalidMachineConfigTestBuilder(buildTestClientWithDummyMachineConfig()),
+			expectedError: fmt.Errorf("machineconfig 'name' cannot be empty"),
+		},
+		{
+			testBuilder:   buildValidMachineConfigTestBuilder(clients.GetTestClients(clients.TestClientParams{})),
+			expectedError: nil,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testBuilder, err := testCase.testBuilder.Create()
+		assert.Equal(t, testCase.expectedError, err)
+
+		if testCase.expectedError == nil {
+			assert.Equal(t, testBuilder.Definition.Name, testBuilder.Object.Name)
+		}
+	}
+}
+
+func TestMachineConfigUpdate(t *testing.T) {
+	testCases := []struct {
+		testBuilder   *MCBuilder
+		expectedError string
+	}{
+		{
+			testBuilder:   buildValidMachineConfigTestBuilder(buildTestClientWithDummyMachineConfig()),
+			expectedError: "",
+		},
+		{
+			testBuilder:   buildInvalidMachineConfigTestBuilder(buildTestClientWithDummyMachineConfig()),
+			expectedError: "machineconfig 'name' cannot be empty",
+		},
+		{
+			testBuilder:   buildValidMachineConfigTestBuilder(clients.GetTestClients(clients.TestClientParams{})),
+			expectedError: "machineconfigs.machineconfiguration.openshift.io \"test-machine-config\" not found",
+		},
+	}
+
+	for _, testCase := range testCases {
+		assert.False(t, testCase.testBuilder.Definition.Spec.FIPS)
+
+		testCase.testBuilder.Definition.ResourceVersion = "999"
+		testCase.testBuilder.Definition.Spec.FIPS = true
+
+		_, err := testCase.testBuilder.Update()
+
+		if testCase.expectedError == "" {
+			assert.Nil(t, err)
+			assert.True(t, testCase.testBuilder.Object.Spec.FIPS)
+		} else {
+			assert.EqualError(t, err, testCase.expectedError)
+		}
+	}
+}
+
+func TestMachineConfigDelete(t *testing.T) {
+	testCases := []struct {
+		testBuilder   *MCBuilder
+		expectedError error
+	}{
+		{
+			testBuilder:   buildValidMachineConfigTestBuilder(buildTestClientWithDummyMachineConfig()),
+			expectedError: nil,
+		},
+		{
+			testBuilder:   buildInvalidMachineConfigTestBuilder(buildTestClientWithDummyMachineConfig()),
+			expectedError: fmt.Errorf("machineconfig 'name' cannot be empty"),
+		},
+		{
+			testBuilder:   buildValidMachineConfigTestBuilder(clients.GetTestClients(clients.TestClientParams{})),
+			expectedError: nil,
+		},
+	}
+
+	for _, testCase := range testCases {
+		err := testCase.testBuilder.Delete()
+		assert.Equal(t, testCase.expectedError, err)
+
+		if testCase.expectedError == nil {
+			assert.Nil(t, testCase.testBuilder.Object)
+		}
+	}
+}
+
+func TestMachineConfigExists(t *testing.T) {
+	testCases := []struct {
+		testBuilder *MCBuilder
+		exists      bool
+	}{
+		{
+			testBuilder: buildValidMachineConfigTestBuilder(buildTestClientWithDummyMachineConfig()),
+			exists:      true,
+		},
+		{
+			testBuilder: buildInvalidMachineConfigTestBuilder(buildTestClientWithDummyMachineConfig()),
+			exists:      false,
+		},
+		{
+			testBuilder: buildValidMachineConfigTestBuilder(clients.GetTestClients(clients.TestClientParams{})),
+			exists:      false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		exists := testCase.testBuilder.Exists()
+		assert.Equal(t, testCase.exists, exists)
+	}
+}
+
+func TestMachineConfigWithLabel(t *testing.T) {
+	testCases := []struct {
+		key           string
+		expectedError string
+	}{
+		{
+			key:           "test",
+			expectedError: "",
+		},
+		{
+			key:           "",
+			expectedError: "'key' cannot be empty",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testBuilder := buildValidMachineConfigTestBuilder(clients.GetTestClients(clients.TestClientParams{}))
+		testBuilder = testBuilder.WithLabel(testCase.key, "test")
+
+		assert.Equal(t, testCase.expectedError, testBuilder.errorMsg)
+
+		if testCase.expectedError == "" {
+			assert.Equal(t, "test", testBuilder.Definition.Labels[testCase.key])
+		}
+	}
+}
+
+func TestMachineConfigWithOptions(t *testing.T) {
+	testCases := []struct {
+		testBuilder   *MCBuilder
+		options       MCAdditionalOptions
+		expectedError string
+	}{
+		{
+			testBuilder: buildValidMachineConfigTestBuilder(clients.GetTestClients(clients.TestClientParams{})),
+			options: func(builder *MCBuilder) (*MCBuilder, error) {
+				builder.Definition.Spec.FIPS = true
+
+				return builder, nil
+			},
+			expectedError: "",
+		},
+		{
+			testBuilder: buildInvalidMachineConfigTestBuilder(clients.GetTestClients(clients.TestClientParams{})),
+			options: func(builder *MCBuilder) (*MCBuilder, error) {
+				return builder, nil
+			},
+			expectedError: "machineconfig 'name' cannot be empty",
+		},
+		{
+			testBuilder: buildValidMachineConfigTestBuilder(clients.GetTestClients(clients.TestClientParams{})),
+			options: func(builder *MCBuilder) (*MCBuilder, error) {
+				return builder, fmt.Errorf("error adding additional option")
+			},
+			expectedError: "error adding additional option",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testBuilder := testCase.testBuilder.WithOptions(testCase.options)
+		assert.Equal(t, testCase.expectedError, testBuilder.errorMsg)
+
+		if testCase.expectedError == "" {
+			assert.True(t, testBuilder.Definition.Spec.FIPS)
+		}
+	}
+}
+
+func TestMachineConfigWithKernelArguments(t *testing.T) {
+	testCases := []struct {
+		kernelArgs    []string
+		expectedError string
+	}{
+		{
+			kernelArgs:    []string{"test"},
+			expectedError: "",
+		},
+		{
+			kernelArgs:    nil,
+			expectedError: "'kernelArgs' cannot be empty",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testBuilder := buildValidMachineConfigTestBuilder(clients.GetTestClients(clients.TestClientParams{}))
+		testBuilder = testBuilder.WithKernelArguments(testCase.kernelArgs)
+
+		assert.Equal(t, testCase.expectedError, testBuilder.errorMsg)
+
+		if testCase.expectedError == "" {
+			assert.Equal(t, testCase.kernelArgs, testBuilder.Definition.Spec.KernelArguments)
+		}
+	}
+}
+
+func TestMachineConfigWithExtensions(t *testing.T) {
+	testCases := []struct {
+		extensions    []string
+		expectedError string
+	}{
+		{
+			extensions:    []string{"test"},
+			expectedError: "",
+		},
+		{
+			extensions:    nil,
+			expectedError: "'extensions' cannot be empty",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testBuilder := buildValidMachineConfigTestBuilder(clients.GetTestClients(clients.TestClientParams{}))
+		testBuilder = testBuilder.WithExtensions(testCase.extensions)
+
+		assert.Equal(t, testCase.expectedError, testBuilder.errorMsg)
+
+		if testCase.expectedError == "" {
+			assert.Equal(t, testCase.extensions, testBuilder.Definition.Spec.Extensions)
+		}
+	}
+}
+
+func TestMachineConfigWithFIPS(t *testing.T) {
+	testBuilder := buildValidMachineConfigTestBuilder(clients.GetTestClients(clients.TestClientParams{}))
+	testBuilder = testBuilder.WithFIPS(true)
+
+	assert.True(t, testBuilder.Definition.Spec.FIPS)
+}
+
+func TestMachineConfigWithKernelType(t *testing.T) {
+	testCases := []struct {
+		kernelType    string
+		expectedError string
+	}{
+		{
+			kernelType:    "test",
+			expectedError: "",
+		},
+		{
+			kernelType:    "",
+			expectedError: "'kernelType' cannot be empty",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testBuilder := buildValidMachineConfigTestBuilder(clients.GetTestClients(clients.TestClientParams{}))
+		testBuilder = testBuilder.WithKernelType(testCase.kernelType)
+
+		assert.Equal(t, testCase.expectedError, testBuilder.errorMsg)
+
+		if testCase.expectedError == "" {
+			assert.Equal(t, testCase.kernelType, testBuilder.Definition.Spec.KernelType)
+		}
+	}
 }
 
 // buildDummyMachineConfig returns a MachineConfig with the provided name.
@@ -28,10 +443,16 @@ func buildTestClientWithDummyMachineConfig() *clients.Settings {
 		K8sMockObjects: []runtime.Object{
 			buildDummyMachineConfig(defaultMachineConfigName),
 		},
+		SchemeAttachers: testSchemes,
 	})
 }
 
 // buildValidMachineConfigTestBuilder returns a valid MCBuilder for testing.
 func buildValidMachineConfigTestBuilder(apiClient *clients.Settings) *MCBuilder {
 	return NewMCBuilder(apiClient, defaultMachineConfigName)
+}
+
+// buildInvalidMachineConfigTestBuilder returns a valid MCBuilder for testing.
+func buildInvalidMachineConfigTestBuilder(apiClient *clients.Settings) *MCBuilder {
+	return NewMCBuilder(apiClient, "")
 }

--- a/pkg/mco/machineconfiglist_test.go
+++ b/pkg/mco/machineconfiglist_test.go
@@ -6,15 +6,13 @@ import (
 
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/stretchr/testify/assert"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
-
-const defaultLabelSelector = "test-label-selector"
 
 func TestListMC(t *testing.T) {
 	testCases := []struct {
 		machineConfigs []*MCBuilder
-		listOptions    []metav1.ListOptions
+		listOptions    []runtimeclient.ListOptions
 		expectedError  error
 		client         bool
 	}{
@@ -26,19 +24,19 @@ func TestListMC(t *testing.T) {
 		},
 		{
 			machineConfigs: []*MCBuilder{buildValidMachineConfigTestBuilder(buildTestClientWithDummyMachineConfig())},
-			listOptions:    []metav1.ListOptions{{LabelSelector: defaultLabelSelector}},
+			listOptions:    []runtimeclient.ListOptions{{Continue: "test"}},
 			expectedError:  nil,
 			client:         true,
 		},
 		{
 			machineConfigs: []*MCBuilder{buildValidMachineConfigTestBuilder(buildTestClientWithDummyMachineConfig())},
-			listOptions:    []metav1.ListOptions{{LabelSelector: defaultLabelSelector}, {LabelSelector: defaultLabelSelector}},
+			listOptions:    []runtimeclient.ListOptions{{Continue: "test"}, {Continue: "test"}},
 			expectedError:  fmt.Errorf("error: more than one ListOptions was passed"),
 			client:         true,
 		},
 		{
 			machineConfigs: []*MCBuilder{buildValidMachineConfigTestBuilder(buildTestClientWithDummyMachineConfig())},
-			listOptions:    []metav1.ListOptions{{LabelSelector: defaultLabelSelector}},
+			listOptions:    []runtimeclient.ListOptions{{Continue: "test"}},
 			expectedError:  fmt.Errorf("failed to list MachineConfigs, 'apiClient' parameter is empty"),
 			client:         false,
 		},


### PR DESCRIPTION
* Switches the MachineConfig resource to use the runtime client and adds unit tests for the file.
* Removes the MCO client from the test clients. Note that it is still in clients.Settings until MCP is converted to runtime client.
* Renames a variable in the KubeletConfig tests that had been copied from the ocm package.