### PR TITLE
mco: unit tests and runtime client for mcp list 

### DIFF
--- a/pkg/clients/clients.go
+++ b/pkg/clients/clients.go
@@ -11,7 +11,6 @@ import (
 
 	clientConfigV1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	v1security "github.com/openshift/client-go/security/clientset/versioned/typed/security/v1"
-	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 
 	apiExt "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -22,8 +21,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
-
-	clientMachineConfigV1 "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned/typed/machineconfiguration.openshift.io/v1"
 
 	agentInstallV1Beta1 "github.com/openshift-kni/eco-goinfra/pkg/schemes/assisted/api/v1beta1"
 	configV1 "github.com/openshift/api/config/v1"
@@ -55,7 +52,6 @@ type Settings struct {
 	K8sClient      kubernetes.Interface
 	coreV1Client.CoreV1Interface
 	clientConfigV1.ConfigV1Interface
-	clientMachineConfigV1.MachineconfigurationV1Interface
 	networkV1Client.NetworkingV1Interface
 	appsV1Client.AppsV1Interface
 	rbacV1Client.RbacV1Interface
@@ -100,7 +96,6 @@ func New(kubeconfig string) *Settings {
 	clientSet := &Settings{}
 	clientSet.CoreV1Interface = coreV1Client.NewForConfigOrDie(config)
 	clientSet.ConfigV1Interface = clientConfigV1.NewForConfigOrDie(config)
-	clientSet.MachineconfigurationV1Interface = clientMachineConfigV1.NewForConfigOrDie(config)
 	clientSet.AppsV1Interface = appsV1Client.NewForConfigOrDie(config)
 	clientSet.NetworkingV1Interface = networkV1Client.NewForConfigOrDie(config)
 	clientSet.RbacV1Interface = rbacV1Client.NewForConfigOrDie(config)
@@ -139,10 +134,6 @@ func New(kubeconfig string) *Settings {
 // SetScheme returns mutated apiClient's scheme.
 func SetScheme(crScheme *runtime.Scheme) error {
 	if err := scheme.AddToScheme(crScheme); err != nil {
-		return err
-	}
-
-	if err := mcv1.AddToScheme(crScheme); err != nil {
 		return err
 	}
 

--- a/pkg/mco/mcplist_test.go
+++ b/pkg/mco/mcplist_test.go
@@ -1,0 +1,161 @@
+package mco
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/openshift-kni/eco-goinfra/pkg/clients"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const defaultMCPListLabel = "test-label-value"
+
+func TestListMCP(t *testing.T) {
+	testCases := []struct {
+		mcPools       []*MCPBuilder
+		listOptions   []runtimeclient.ListOptions
+		expectedError error
+		client        bool
+	}{
+		{
+			mcPools:       []*MCPBuilder{buildValidMCPTestBuilder(buildTestClientWithDummyMCP())},
+			listOptions:   nil,
+			expectedError: nil,
+			client:        true,
+		},
+		{
+			mcPools:       []*MCPBuilder{buildValidMCPTestBuilder(buildTestClientWithDummyMCP())},
+			listOptions:   []runtimeclient.ListOptions{{Continue: "test"}},
+			expectedError: nil,
+			client:        true,
+		},
+		{
+			mcPools:       []*MCPBuilder{buildValidMCPTestBuilder(buildTestClientWithDummyMCP())},
+			listOptions:   []runtimeclient.ListOptions{{Continue: "test"}, {Continue: "test"}},
+			expectedError: fmt.Errorf("error: more than one ListOptions was passed"),
+			client:        true,
+		},
+		{
+			mcPools:       []*MCPBuilder{buildValidMCPTestBuilder(buildTestClientWithDummyMCP())},
+			listOptions:   []runtimeclient.ListOptions{{Continue: "test"}},
+			expectedError: fmt.Errorf("failed to list MachineConfigPools, 'apiClient' parameter is empty"),
+			client:        false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		var testSettings *clients.Settings
+
+		if testCase.client {
+			testSettings = buildTestClientWithDummyMCP()
+		}
+
+		mcBuilders, err := ListMCP(testSettings, testCase.listOptions...)
+		assert.Equal(t, err, testCase.expectedError)
+
+		if testCase.expectedError == nil && len(testCase.listOptions) == 0 {
+			assert.Equal(t, len(testCase.mcPools), len(mcBuilders))
+		}
+	}
+}
+
+func TestListMCPByMachineConfigSelector(t *testing.T) {
+	testCases := []struct {
+		client        bool
+		hasLabel      bool
+		expectedError error
+	}{
+		{
+			client:        true,
+			hasLabel:      true,
+			expectedError: nil,
+		},
+		{
+			client:        false,
+			hasLabel:      true,
+			expectedError: fmt.Errorf("failed to list MachineConfigPools, 'apiClient' parameter is empty"),
+		},
+		{
+			client:   true,
+			hasLabel: false,
+			expectedError: fmt.Errorf(
+				"cannot find MachineConfigPool that targets machineConfig with label: %s", defaultMCPListLabel),
+		},
+	}
+
+	for _, testCase := range testCases {
+		var testSettings *clients.Settings
+
+		if testCase.client {
+			mcp := buildDummyMCP(defaultMCPName)
+
+			if testCase.hasLabel {
+				mcp.Spec.MachineConfigSelector = &metav1.LabelSelector{
+					MatchLabels: map[string]string{"test": defaultMCPListLabel},
+				}
+			}
+
+			testSettings = clients.GetTestClients(clients.TestClientParams{
+				K8sMockObjects:  []runtime.Object{mcp},
+				SchemeAttachers: testSchemes,
+			})
+		}
+
+		testBuilder, err := ListMCPByMachineConfigSelector(testSettings, defaultMCPListLabel)
+		assert.Equal(t, testCase.expectedError, err)
+
+		if testCase.expectedError == nil {
+			assert.NotNil(t, testBuilder)
+			assert.Equal(t, defaultMCPName, testBuilder.Definition.Name)
+		}
+	}
+}
+
+func TestListMCPWaitToBeStableFor(t *testing.T) {
+	testCases := []struct {
+		client        bool
+		stable        bool
+		expectedError error
+	}{
+		{
+			client:        true,
+			stable:        true,
+			expectedError: nil,
+		},
+		{
+			client:        false,
+			stable:        true,
+			expectedError: fmt.Errorf("failed to list MachineConfigPools, 'apiClient' parameter is empty"),
+		},
+		{
+			client:        true,
+			stable:        false,
+			expectedError: context.DeadlineExceeded,
+		},
+	}
+
+	for _, testCase := range testCases {
+		var testSettings *clients.Settings
+
+		if testCase.client {
+			mcp := buildDummyMCP(defaultMCPName)
+
+			if !testCase.stable {
+				mcp.Status.DegradedMachineCount = 1
+			}
+
+			testSettings = clients.GetTestClients(clients.TestClientParams{
+				K8sMockObjects:  []runtime.Object{mcp},
+				SchemeAttachers: testSchemes,
+			})
+		}
+
+		err := ListMCPWaitToBeStableFor(testSettings, 500*time.Millisecond, time.Second)
+		assert.Equal(t, testCase.expectedError, err)
+	}
+}


### PR DESCRIPTION
Added unit tests and switched to the runtime client for the MCP list functions. Also adds unit tests to the remaining untested MCP functions. Now that the package is complete, removes the machineconfig client from clients.