### PR TITLE
Update GolangCI-lint to v1.60.3

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,5 @@
 run:
-  skip-dirs:
-    - pkg/schemes
+  go: 1.22
   timeout: 15m0s
   skip-dirs-use-default: true
   fast: false
@@ -51,6 +50,9 @@ linters-settings:
           - "github.com/red-hat-storage/odf-operator"
           - "github.com/stmcginnis/gofish"
           - "github.com/prometheus-operator/prometheus-operator"
+  govet:
+    disable:
+      - printf
   revive:
     rules:
       - name: indent-error-flow
@@ -69,17 +71,18 @@ linters-settings:
   unused:
     check-exported: true
     go: "1.22"
+  staticcheck:
+    # https://staticcheck.io/docs/options#checks
+    checks:
+      - all
+      - "-SA1006"
   stylecheck:
-    # Select the Go version to target. The default is '1.13'.
-    go: "1.22"
     # https://staticcheck.io/docs/options#checks
     checks:
       - all
       - ST1001
 
 linters:
-  disable:
-    - structcheck
   enable:
     - asciicheck
     - bidichk
@@ -130,8 +133,10 @@ linters:
     - nlreturn
 
 output:
-  format: colored-line-number
+  formats: colored-line-number
 issues:
+  exclude-dirs:
+    - pkg/schemes
   include:
     - EXC0002 # disable excluding of issues about comments from golint
     - EXC0012  # EXC0012 revive: Annoying issue about not having a comment. The rare codebase has such comments

--- a/scripts/golangci-lint.sh
+++ b/scripts/golangci-lint.sh
@@ -4,7 +4,7 @@ set -e
 
 . "$(dirname "$0")"/common.sh
 
-GOLANGCI_LINT_VERSION="1.58.1"
+GOLANGCI_LINT_VERSION="1.60.3"
 
 # IsGoLangCiLintInstalled is used to check whether golangci-lint executable is on the $PATH.
 function IsGolangCiLintInstalled() {


### PR DESCRIPTION
- Fixed a number of deprecated linters in the configuration.
- Disabled the `printf` linter under `govet`.
- Disabled "SA1006" from staticcheck.

https://github.com/golangci/golangci-lint/releases/tag/v1.60.3

Related to: https://github.com/redhat-best-practices-for-k8s/certsuite/pull/2372
