### PR TITLE
deployment: remove pointer from containerSpec

### DIFF
--- a/pkg/deployment/deployment.go
+++ b/pkg/deployment/deployment.go
@@ -37,7 +37,7 @@ type AdditionalOptions func(builder *Builder) (*Builder, error)
 
 // NewBuilder creates a new instance of Builder.
 func NewBuilder(
-	apiClient *clients.Settings, name, nsname string, labels map[string]string, containerSpec *corev1.Container) *Builder {
+	apiClient *clients.Settings, name, nsname string, labels map[string]string, containerSpec corev1.Container) *Builder {
 	glog.V(100).Infof(
 		"Initializing new deployment structure with the following params: "+
 			"name: %s, namespace: %s, labels: %s, containerSpec %v",
@@ -63,7 +63,7 @@ func NewBuilder(
 		},
 	}
 
-	builder.WithAdditionalContainerSpecs([]corev1.Container{*containerSpec})
+	builder.WithAdditionalContainerSpecs([]corev1.Container{containerSpec})
 
 	if name == "" {
 		glog.V(100).Infof("The name of the deployment is empty")

--- a/pkg/deployment/deployment_test.go
+++ b/pkg/deployment/deployment_test.go
@@ -127,7 +127,7 @@ func buildValidTestBuilder() *Builder {
 		AppsV1Interface: k8sfake.NewSimpleClientset().AppsV1(),
 	}, "test-name", "test-namespace", map[string]string{
 		"test-key": "test-value",
-	}, &corev1.Container{
+	}, corev1.Container{
 		Name: "test-container",
 	})
 }
@@ -141,7 +141,7 @@ func buildTestBuilderWithFakeObjects(objects []runtime.Object) *Builder {
 		AppsV1Interface: fakeClient.AppsV1(),
 	}, "test-name", "test-namespace", map[string]string{
 		"test-key": "test-value",
-	}, &corev1.Container{
+	}, corev1.Container{
 		Name: "test-container",
 	})
 }


### PR DESCRIPTION
To match the `daemonset` line of the same operation.  The `daemonset` package doesn't require the containerSpec to be a pointer so we can remove it here to prevent `nil` dereferencing.