### PR TITLE
Update Go to v1.23.2

### DIFF
--- a/.github/workflows/eco-gotests-integration.yml
+++ b/.github/workflows/eco-gotests-integration.yml
@@ -16,11 +16,11 @@ jobs:
       ECO_GOTESTS_REPO: openshift-kni/eco-gotests
 
     steps:
-      - name: Set up Go 1.22
+      - name: Set up Go 1.23
         if: ${{ !contains(github.event.*.labels.*.name, 'ignore-dep-check') }}
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.6
+          go-version: 1.23.2
 
       - name: Check out the eco-goinfra code
         if: ${{ !contains(github.event.*.labels.*.name, 'ignore-dep-check') }}

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -17,10 +17,10 @@ jobs:
       SHELL: /bin/bash
 
     steps:
-      - name: Set up Go 1.22
+      - name: Set up Go 1.23
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.6
+          go-version: 1.23.2
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/sync-libs.yaml
+++ b/.github/workflows/sync-libs.yaml
@@ -21,10 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Go 1.22
+      - name: Set up Go 1.23
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.6
+          go-version: 1.23.2
 
       - name: Run sync script
         run: make lib-sync

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  go: 1.22
+  go: 1.23
   timeout: 15m0s
   skip-dirs-use-default: true
   fast: false
@@ -71,7 +71,7 @@ linters-settings:
     statements: 40
   unused:
     check-exported: true
-    go: "1.22"
+    go: "1.23"
   staticcheck:
     # https://staticcheck.io/docs/options#checks
     checks:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 The [eco-goinfra](https://github.com/openshift-kni/eco-goinfra) project contains a collection of generic [packages](./pkg) that can be used across various test projects.
 
 ### Project requirements
-* golang v1.22.x
+* golang v1.23.x
 
 ## Usage
 In order to re-use code from this project you need to import relevant package/packages in to your project code.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift-kni/eco-goinfra
 
-go 1.22
+go 1.23
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1


### PR DESCRIPTION
Related to: https://github.com/redhat-best-practices-for-k8s/certsuite/pull/2402

Don't worry about merging this until after the next release if needed.