### PR TITLE
bmh: add HostFirmwareSettings resource and unit tests

### DIFF
--- a/pkg/bmh/hfs.go
+++ b/pkg/bmh/hfs.go
@@ -1,0 +1,196 @@
+package bmh
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/golang/glog"
+	bmhv1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	"github.com/openshift-kni/eco-goinfra/pkg/clients"
+	"github.com/openshift-kni/eco-goinfra/pkg/msg"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	goclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// HFSBuilder provides a struct to interface with HostFirmwareSettings resources on a specific cluster.
+type HFSBuilder struct {
+	// Definition of the HostFirmwareSettings used to create the object.
+	Definition *bmhv1alpha1.HostFirmwareSettings
+	// Object of the HostFirmwareSettings as it is on the cluster.
+	Object    *bmhv1alpha1.HostFirmwareSettings
+	apiClient goclient.Client
+	errorMsg  string
+}
+
+// PullHFS pulls an existing HostFirmwareSettings from the cluster.
+func PullHFS(apiClient *clients.Settings, name, nsname string) (*HFSBuilder, error) {
+	glog.V(100).Infof("Pulling existing HostFirmwareSettings name %s under namespace %s from cluster", name, nsname)
+
+	if apiClient == nil {
+		glog.V(100).Infof("The apiClient is nil")
+
+		return nil, fmt.Errorf("hostFirmwareSettings 'apiClient' cannot be nil")
+	}
+
+	err := apiClient.AttachScheme(bmhv1alpha1.AddToScheme)
+	if err != nil {
+		glog.V(100).Infof("Failed to add bmhv1alpha1 scheme to client schemes")
+
+		return nil, err
+	}
+
+	builder := HFSBuilder{
+		apiClient: apiClient.Client,
+		Definition: &bmhv1alpha1.HostFirmwareSettings{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: nsname,
+			},
+		},
+	}
+
+	if name == "" {
+		glog.V(100).Infof("The name of the HostFirmwareSettings is empty")
+
+		return nil, fmt.Errorf("hostFirmwareSettings 'name' cannot be empty")
+	}
+
+	if nsname == "" {
+		glog.V(100).Infof("The nsname of the HostFirmwareSettings is empty")
+
+		return nil, fmt.Errorf("hostFirmwareSettings 'nsname' cannot be empty")
+	}
+
+	if !builder.Exists() {
+		return nil, fmt.Errorf("hostFirmwareSettings object %s does not exist in namespace %s", name, nsname)
+	}
+
+	builder.Definition = builder.Object
+
+	return &builder, nil
+}
+
+// Get returns the HostFirmwareSettings object if found.
+func (builder *HFSBuilder) Get() (*bmhv1alpha1.HostFirmwareSettings, error) {
+	if valid, err := builder.validate(); !valid {
+		return nil, err
+	}
+
+	glog.V(100).Infof(
+		"Getting HostFirmwareSettings object %s in namespace %s", builder.Definition.Name, builder.Definition.Namespace)
+
+	hostFirmwareSettings := &bmhv1alpha1.HostFirmwareSettings{}
+	err := builder.apiClient.Get(context.TODO(), goclient.ObjectKey{
+		Name:      builder.Definition.Name,
+		Namespace: builder.Definition.Namespace,
+	}, hostFirmwareSettings)
+
+	if err != nil {
+		glog.V(100).Infof(
+			"HostFirmwareSettings object %s does not exist in namespace %s",
+			builder.Definition.Name, builder.Definition.Namespace)
+
+		return nil, err
+	}
+
+	return hostFirmwareSettings, nil
+}
+
+// Exists checks whether the given HostFirmwareSettings exists on the cluster.
+func (builder *HFSBuilder) Exists() bool {
+	if valid, _ := builder.validate(); !valid {
+		return false
+	}
+
+	glog.V(100).Infof(
+		"Checking if HostFirmwareSettings %s exists in namespace %s", builder.Definition.Name, builder.Definition.Namespace)
+
+	var err error
+	builder.Object, err = builder.Get()
+
+	return err == nil || !k8serrors.IsNotFound(err)
+}
+
+// Create makes a HostFirmwareSettings on the cluster if it does not already exist.
+func (builder *HFSBuilder) Create() (*HFSBuilder, error) {
+	if valid, err := builder.validate(); !valid {
+		return nil, err
+	}
+
+	glog.V(100).Infof(
+		"Creating HostFirmwareSettings %s in namespace %s", builder.Definition.Name, builder.Definition.Namespace)
+
+	if builder.Exists() {
+		return builder, nil
+	}
+
+	err := builder.apiClient.Create(context.TODO(), builder.Definition)
+	if err != nil {
+		return nil, err
+	}
+
+	builder.Object = builder.Definition
+
+	return builder, err
+}
+
+// Delete removes a HostFirmwareSettings from the cluster if it exists.
+func (builder *HFSBuilder) Delete() error {
+	if valid, err := builder.validate(); !valid {
+		return err
+	}
+
+	glog.V(100).Infof(
+		"Deleting HostFirmwareSettings %s in namespace %s", builder.Definition.Name, builder.Definition.Namespace)
+
+	if !builder.Exists() {
+		glog.V(100).Infof(
+			"HostFirmwareSettings %s in namespace %s does not exist",
+			builder.Definition.Name, builder.Definition.Namespace)
+
+		builder.Object = nil
+
+		return nil
+	}
+
+	err := builder.apiClient.Delete(context.TODO(), builder.Object)
+	if err != nil {
+		return err
+	}
+
+	builder.Object = nil
+
+	return nil
+}
+
+// validate checks that the builder, definition, and apiClient are properly initialized and there is no errorMsg.
+func (builder *HFSBuilder) validate() (bool, error) {
+	resourceCRD := "hostFirmwareSettings"
+
+	if builder == nil {
+		glog.V(100).Infof("The %s builder is uninitialized", resourceCRD)
+
+		return false, fmt.Errorf("error: received nil %s builder", resourceCRD)
+	}
+
+	if builder.Definition == nil {
+		glog.V(100).Infof("The %s is uninitialized", resourceCRD)
+
+		return false, fmt.Errorf(msg.UndefinedCrdObjectErrString(resourceCRD))
+	}
+
+	if builder.apiClient == nil {
+		glog.V(100).Infof("The %s builder apiClient is nil", resourceCRD)
+
+		return false, fmt.Errorf("%s builder cannot have nil apiClient", resourceCRD)
+	}
+
+	if builder.errorMsg != "" {
+		glog.V(100).Infof("The %s builder has error message %s", resourceCRD, builder.errorMsg)
+
+		return false, fmt.Errorf(builder.errorMsg)
+	}
+
+	return true, nil
+}

--- a/pkg/bmh/hfs_test.go
+++ b/pkg/bmh/hfs_test.go
@@ -1,0 +1,231 @@
+package bmh
+
+import (
+	"fmt"
+	"testing"
+
+	bmhv1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	"github.com/openshift-kni/eco-goinfra/pkg/clients"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+const (
+	defaultHFSName      = "hostfirmwaresettings-test"
+	defaultHFSNamespace = "test-ns"
+)
+
+func TestPullHFS(t *testing.T) {
+	testCases := []struct {
+		hfsName             string
+		hfsNamespace        string
+		addToRuntimeObjects bool
+		client              bool
+		expectedErrorText   string
+	}{
+		{
+			hfsName:             defaultHFSName,
+			hfsNamespace:        defaultHFSNamespace,
+			addToRuntimeObjects: true,
+			client:              true,
+			expectedErrorText:   "",
+		},
+		{
+			hfsName:             "",
+			hfsNamespace:        defaultHFSNamespace,
+			addToRuntimeObjects: true,
+			client:              true,
+			expectedErrorText:   "hostFirmwareSettings 'name' cannot be empty",
+		},
+		{
+			hfsName:             defaultHFSName,
+			hfsNamespace:        "",
+			addToRuntimeObjects: true,
+			client:              true,
+			expectedErrorText:   "hostFirmwareSettings 'nsname' cannot be empty",
+		},
+		{
+			hfsName:             defaultHFSName,
+			hfsNamespace:        defaultHFSNamespace,
+			addToRuntimeObjects: false,
+			client:              true,
+			expectedErrorText: fmt.Sprintf(
+				"hostFirmwareSettings object %s does not exist in namespace %s", defaultHFSName, defaultHFSNamespace),
+		},
+		{
+			hfsName:             defaultHFSName,
+			hfsNamespace:        defaultHFSNamespace,
+			addToRuntimeObjects: true,
+			client:              false,
+			expectedErrorText:   "hostFirmwareSettings 'apiClient' cannot be nil",
+		},
+	}
+
+	for _, testCase := range testCases {
+		var (
+			runtimeObjects []runtime.Object
+			testSettings   *clients.Settings
+		)
+
+		testHFS := buildDummyHFS(testCase.hfsName, testCase.hfsNamespace)
+
+		if testCase.addToRuntimeObjects {
+			runtimeObjects = append(runtimeObjects, testHFS)
+		}
+
+		if testCase.client {
+			testSettings = clients.GetTestClients(clients.TestClientParams{
+				K8sMockObjects:  runtimeObjects,
+				SchemeAttachers: testSchemes,
+			})
+		}
+
+		hfsBuilder, err := PullHFS(testSettings, testCase.hfsName, testCase.hfsNamespace)
+
+		if testCase.expectedErrorText == "" {
+			assert.Nil(t, err)
+			assert.Equal(t, testHFS.Name, hfsBuilder.Definition.Name)
+			assert.Equal(t, testHFS.Namespace, hfsBuilder.Definition.Namespace)
+		} else {
+			assert.EqualError(t, err, testCase.expectedErrorText)
+		}
+	}
+}
+
+func TestHFSGet(t *testing.T) {
+	testCases := []struct {
+		testBuilder   *HFSBuilder
+		expectedError string
+	}{
+		{
+			testBuilder:   buildValidHFSBuilder(buildTestClientWithDummyHFS()),
+			expectedError: "",
+		},
+		{
+			testBuilder:   buildValidHFSBuilder(buildTestClientWithHFSScheme()),
+			expectedError: "hostfirmwaresettingses.metal3.io \"hostfirmwaresettings-test\" not found",
+		},
+	}
+
+	for _, testCase := range testCases {
+		hfs, err := testCase.testBuilder.Get()
+
+		if testCase.expectedError == "" {
+			assert.Nil(t, err)
+			assert.Equal(t, testCase.testBuilder.Definition.Name, hfs.Name)
+			assert.Equal(t, testCase.testBuilder.Definition.Namespace, hfs.Namespace)
+		} else {
+			assert.EqualError(t, err, testCase.expectedError)
+		}
+	}
+}
+
+func TestHFSExists(t *testing.T) {
+	testCases := []struct {
+		testBuilder *HFSBuilder
+		exists      bool
+	}{
+		{
+			testBuilder: buildValidHFSBuilder(buildTestClientWithDummyHFS()),
+			exists:      true,
+		},
+		{
+			testBuilder: buildValidHFSBuilder(buildTestClientWithHFSScheme()),
+			exists:      false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		exists := testCase.testBuilder.Exists()
+		assert.Equal(t, testCase.exists, exists)
+	}
+}
+
+func TestHFSCreate(t *testing.T) {
+	testCases := []struct {
+		testBuilder   *HFSBuilder
+		expectedError error
+	}{
+		{
+			testBuilder:   buildValidHFSBuilder(buildTestClientWithHFSScheme()),
+			expectedError: nil,
+		},
+		{
+			testBuilder:   buildValidHFSBuilder(buildTestClientWithDummyHFS()),
+			expectedError: nil,
+		},
+	}
+
+	for _, testCase := range testCases {
+		hfsBuilder, err := testCase.testBuilder.Create()
+		assert.Equal(t, testCase.expectedError, err)
+
+		if testCase.expectedError == nil {
+			assert.Equal(t, hfsBuilder.Definition.Name, hfsBuilder.Object.Name)
+			assert.Equal(t, hfsBuilder.Definition.Namespace, hfsBuilder.Object.Namespace)
+		}
+	}
+}
+
+func TestHFSDelete(t *testing.T) {
+	testCases := []struct {
+		testBuilder       *HFSBuilder
+		expectedErrorText string
+	}{
+		{
+			testBuilder:       buildValidHFSBuilder(buildTestClientWithDummyHFS()),
+			expectedErrorText: "",
+		},
+		{
+			testBuilder:       buildValidHFSBuilder(buildTestClientWithHFSScheme()),
+			expectedErrorText: "",
+		},
+	}
+
+	for _, testCase := range testCases {
+		err := testCase.testBuilder.Delete()
+
+		if testCase.expectedErrorText == "" {
+			assert.Nil(t, err)
+			assert.Nil(t, testCase.testBuilder.Object)
+		} else {
+			assert.EqualError(t, err, testCase.expectedErrorText)
+		}
+	}
+}
+
+// buildDummyHFS returns a HostFirmwareSettings with the provided name and namespace.
+func buildDummyHFS(name, namespace string) *bmhv1alpha1.HostFirmwareSettings {
+	return &bmhv1alpha1.HostFirmwareSettings{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+}
+
+// buildTestClientWithDummyHFS returns a client with a mock HostFirmwareSettings.
+func buildTestClientWithDummyHFS() *clients.Settings {
+	return clients.GetTestClients(clients.TestClientParams{
+		K8sMockObjects: []runtime.Object{
+			buildDummyHFS(defaultHFSName, defaultHFSNamespace),
+		},
+		SchemeAttachers: testSchemes,
+	})
+}
+
+// buildTestClientWithHFSScheme returns a client with no objects but the HostFirmwareSettings scheme attached.
+func buildTestClientWithHFSScheme() *clients.Settings {
+	return clients.GetTestClients(clients.TestClientParams{
+		SchemeAttachers: testSchemes,
+	})
+}
+
+// buildValidHFSBuilder returns a valid Builder for testing.
+func buildValidHFSBuilder(apiClient *clients.Settings) *HFSBuilder {
+	return &HFSBuilder{
+		Definition: buildDummyHFS(defaultHFSName, defaultHFSNamespace),
+		apiClient:  apiClient,
+	}
+}


### PR DESCRIPTION
Adds the HostFirmwareSettings resource to the bmh package and unit tests for the functions it exports.