### PR TITLE
daemonset,replicaset,service: added getGVR func

### DIFF
--- a/pkg/daemonset/daemonset.go
+++ b/pkg/daemonset/daemonset.go
@@ -12,6 +12,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
 	appsv1Typed "k8s.io/client-go/kubernetes/typed/apps/v1"
 )
@@ -430,6 +431,15 @@ func (builder *Builder) IsReady(timeout time.Duration) bool {
 		})
 
 	return err == nil
+}
+
+// GetGVR returns the GroupVersionResource for the daemonset.
+func GetGVR() schema.GroupVersionResource {
+	return schema.GroupVersionResource{
+		Group:    "apps",
+		Version:  "v1",
+		Resource: "daemonsets",
+	}
 }
 
 // validate will check that the builder and builder definition are properly initialized before

--- a/pkg/replicaset/replicaset.go
+++ b/pkg/replicaset/replicaset.go
@@ -12,6 +12,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
@@ -425,6 +426,11 @@ func (builder *Builder) IsReady(timeout time.Duration) bool {
 		})
 
 	return err == nil
+}
+
+// GetGVR returns the GroupVersionResource for replicaset.
+func GetGVR() schema.GroupVersionResource {
+	return schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "replicasets"}
 }
 
 // validate will check that the builder and builder definition are properly initialized before

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -408,10 +408,16 @@ func DefineServicePort(port, targetPort int32, protocol corev1.Protocol) (*corev
 }
 
 // GetServiceGVR returns service's GroupVersionResource which could be used for Clean function.
+// Deprecated: This function is being name-changed to GetGVR in the future and will be deprecated.
 func GetServiceGVR() schema.GroupVersionResource {
 	return schema.GroupVersionResource{
 		Group: "", Version: "v1", Resource: "services",
 	}
+}
+
+// GetGVR returns service's GroupVersionResource which could be used for Clean function.
+func GetGVR() schema.GroupVersionResource {
+	return schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}
 }
 
 // isValidPort checks if a port is valid.


### PR DESCRIPTION
Adds `GetGVR()` functions to the `daemonset` and `replicaset` packages.

`GetServiceGVR()` exists in the `service` package but is inconsistent with the calls to other `GetGVR()` functions so I made a duplicated.  Once this merges I can go change the references to `GetServiceGVR()` in the eco-gotests repo and then we can remove this here.