### PR TITLE
context consistency: switch Background() to TODO()

### DIFF
--- a/pkg/bmc/bmc.go
+++ b/pkg/bmc/bmc.go
@@ -978,7 +978,7 @@ func redfishConnect(
 		Insecure: true,
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), sessionTimeout)
+	ctx, cancel := context.WithTimeout(context.TODO(), sessionTimeout)
 
 	client, err := gofish.ConnectContext(ctx, gofishConfig)
 	if err != nil {


### PR DESCRIPTION
Similar to: https://github.com/openshift-kni/eco-goinfra/pull/329

There are now 572 references to TODO() and 0 references to Background() outside of "schemes".