### PR TITLE
Ensure Delete() funcs use Definition

### DIFF
--- a/pkg/daemonset/daemonset.go
+++ b/pkg/daemonset/daemonset.go
@@ -297,7 +297,7 @@ func (builder *Builder) Delete() error {
 	}
 
 	err := builder.apiClient.Delete(
-		context.TODO(), builder.Object.Name, metav1.DeleteOptions{})
+		context.TODO(), builder.Definition.Name, metav1.DeleteOptions{})
 
 	if err != nil {
 		return err

--- a/pkg/deployment/deployment.go
+++ b/pkg/deployment/deployment.go
@@ -434,7 +434,7 @@ func (builder *Builder) Delete() error {
 	}
 
 	err := builder.apiClient.Deployments(builder.Definition.Namespace).Delete(
-		context.TODO(), builder.Object.Name, metav1.DeleteOptions{})
+		context.TODO(), builder.Definition.Name, metav1.DeleteOptions{})
 
 	if err != nil {
 		return err

--- a/pkg/icsp/icsp.go
+++ b/pkg/icsp/icsp.go
@@ -145,7 +145,7 @@ func (builder *ICSPBuilder) Delete() error {
 	}
 
 	err := builder.apiClient.ImageContentSourcePolicies().Delete(
-		context.TODO(), builder.Object.Name, metav1.DeleteOptions{})
+		context.TODO(), builder.Definition.Name, metav1.DeleteOptions{})
 
 	if err != nil {
 		return err

--- a/pkg/machine/machineset.go
+++ b/pkg/machine/machineset.go
@@ -197,8 +197,8 @@ func (builder *SetBuilder) Delete() error {
 		return fmt.Errorf("machineSet cannot be deleted because it does not exist")
 	}
 
-	err := builder.apiClient.MachineSets(builder.Object.Namespace).Delete(
-		context.TODO(), builder.Object.Name, metav1.DeleteOptions{})
+	err := builder.apiClient.MachineSets(builder.Definition.Namespace).Delete(
+		context.TODO(), builder.Definition.Name, metav1.DeleteOptions{})
 
 	if err != nil {
 		return fmt.Errorf("cannot delete MachineSet: %w", err)

--- a/pkg/mco/machineconfig.go
+++ b/pkg/mco/machineconfig.go
@@ -161,7 +161,7 @@ func (builder *MCBuilder) Delete() error {
 		return nil
 	}
 
-	err := builder.apiClient.Delete(context.TODO(), builder.Object)
+	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
 	if err != nil {
 		return fmt.Errorf("cannot delete machineconfig: %w", err)
 	}

--- a/pkg/namespace/namespace.go
+++ b/pkg/namespace/namespace.go
@@ -182,7 +182,7 @@ func (builder *Builder) Delete() error {
 		return nil
 	}
 
-	err := builder.apiClient.Namespaces().Delete(context.TODO(), builder.Object.Name, metav1.DeleteOptions{})
+	err := builder.apiClient.Namespaces().Delete(context.TODO(), builder.Definition.Name, metav1.DeleteOptions{})
 
 	if err != nil {
 		return err

--- a/pkg/ocm/managedcluster.go
+++ b/pkg/ocm/managedcluster.go
@@ -171,7 +171,7 @@ func (builder *ManagedClusterBuilder) Delete() error {
 		return nil
 	}
 
-	err := builder.apiClient.Delete(context.TODO(), builder.Object)
+	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
 	if err != nil {
 		return fmt.Errorf("cannot delete managedCluster: %w", err)
 	}

--- a/pkg/rbac/clusterrole.go
+++ b/pkg/rbac/clusterrole.go
@@ -191,7 +191,7 @@ func (builder *ClusterRoleBuilder) Delete() error {
 	}
 
 	err := builder.apiClient.ClusterRoles().Delete(
-		context.TODO(), builder.Object.Name, metav1.DeleteOptions{})
+		context.TODO(), builder.Definition.Name, metav1.DeleteOptions{})
 
 	if err != nil {
 		return err

--- a/pkg/rbac/clusterrolebinding.go
+++ b/pkg/rbac/clusterrolebinding.go
@@ -190,7 +190,7 @@ func (builder *ClusterRoleBindingBuilder) Delete() error {
 	}
 
 	err := builder.apiClient.ClusterRoleBindings().Delete(
-		context.TODO(), builder.Object.Name, metav1.DeleteOptions{})
+		context.TODO(), builder.Definition.Name, metav1.DeleteOptions{})
 
 	if err != nil {
 		return err

--- a/pkg/rbac/role.go
+++ b/pkg/rbac/role.go
@@ -216,7 +216,7 @@ func (builder *RoleBuilder) Delete() error {
 	}
 
 	err := builder.apiClient.Roles(builder.Definition.Namespace).Delete(
-		context.TODO(), builder.Object.Name, metav1.DeleteOptions{})
+		context.TODO(), builder.Definition.Name, metav1.DeleteOptions{})
 
 	if err != nil {
 		return err

--- a/pkg/rbac/rolebinding.go
+++ b/pkg/rbac/rolebinding.go
@@ -203,7 +203,7 @@ func (builder *RoleBindingBuilder) Delete() error {
 	}
 
 	err := builder.apiClient.RoleBindings(builder.Definition.Namespace).Delete(
-		context.TODO(), builder.Object.Name, metav1.DeleteOptions{})
+		context.TODO(), builder.Definition.Name, metav1.DeleteOptions{})
 
 	builder.Object = nil
 

--- a/pkg/replicaset/replicaset.go
+++ b/pkg/replicaset/replicaset.go
@@ -313,7 +313,7 @@ func (builder *Builder) Delete() error {
 	}
 
 	err := builder.apiClient.ReplicaSets(builder.Definition.Namespace).Delete(
-		context.TODO(), builder.Object.Name, metav1.DeleteOptions{})
+		context.TODO(), builder.Definition.Name, metav1.DeleteOptions{})
 
 	if err != nil {
 		return err

--- a/pkg/secret/secret.go
+++ b/pkg/secret/secret.go
@@ -149,7 +149,7 @@ func (builder *Builder) Delete() error {
 	}
 
 	err := builder.apiClient.Secrets(builder.Definition.Namespace).Delete(
-		context.TODO(), builder.Object.Name, metav1.DeleteOptions{})
+		context.TODO(), builder.Definition.Name, metav1.DeleteOptions{})
 
 	if err != nil {
 		return err

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -174,7 +174,7 @@ func (builder *Builder) Delete() error {
 	}
 
 	err := builder.apiClient.Services(builder.Definition.Namespace).Delete(
-		context.TODO(), builder.Object.Name, metav1.DeleteOptions{})
+		context.TODO(), builder.Definition.Name, metav1.DeleteOptions{})
 
 	if err != nil {
 		return err

--- a/pkg/sriov/poolconfig.go
+++ b/pkg/sriov/poolconfig.go
@@ -110,7 +110,7 @@ func (builder *PoolConfigBuilder) Delete() error {
 		return nil
 	}
 
-	err := builder.apiClient.Delete(context.TODO(), builder.Object)
+	err := builder.apiClient.Delete(context.TODO(), builder.Definition)
 
 	if err != nil {
 		return err

--- a/pkg/storage/storageclass.go
+++ b/pkg/storage/storageclass.go
@@ -250,7 +250,7 @@ func (builder *ClassBuilder) Delete() error {
 	}
 
 	err := builder.apiClient.StorageClasses().Delete(
-		context.TODO(), builder.Object.Name, metav1.DeleteOptions{})
+		context.TODO(), builder.Definition.Name, metav1.DeleteOptions{})
 
 	if err != nil {
 		return err


### PR DESCRIPTION
Be consistent in the `Delete()` funcs in that they should be using the `builder.Definition` instead of the `builder.Object` structs when referencing variables.  It's a mix right now and I feel that the `Definition` should be where we are gathering that information.