### PR TITLE
deployment: add glog to Delete() exists

### DIFF
--- a/pkg/deployment/deployment.go
+++ b/pkg/deployment/deployment.go
@@ -428,6 +428,9 @@ func (builder *Builder) Delete() error {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	if !builder.Exists() {
+		glog.V(100).Infof("Deployment %s in namespace %s does not exist",
+			builder.Definition.Name, builder.Definition.Namespace)
+
 		builder.Object = nil
 
 		return nil


### PR DESCRIPTION
In #672 it was mentioned that we are missing a `glog` entry for when a deployment does not exist.