### PR TITLE
baremetalhost: Delete() should return nil if not exists

### DIFF
--- a/pkg/bmh/baremetalhost.go
+++ b/pkg/bmh/baremetalhost.go
@@ -448,7 +448,12 @@ func (builder *BmhBuilder) Delete() (*BmhBuilder, error) {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	if !builder.Exists() {
-		return builder, fmt.Errorf("bmh cannot be deleted because it does not exist")
+		glog.V(100).Infof("bmh %s namespace: %s cannot be deleted because it does not exist",
+			builder.Definition.Name, builder.Definition.Namespace)
+
+		builder.Object = nil
+
+		return builder, nil
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)

--- a/pkg/bmh/baremetalhost_test.go
+++ b/pkg/bmh/baremetalhost_test.go
@@ -318,7 +318,7 @@ func TestBareMetalHostDelete(t *testing.T) {
 		},
 		{
 			testBmHost:    buildValidBmHostBuilder(clients.GetTestClients(clients.TestClientParams{})),
-			expectedError: fmt.Errorf("bmh cannot be deleted because it does not exist"),
+			expectedError: nil,
 		},
 		{
 			testBmHost:    buildInValidBmHostBuilder(buildBareMetalHostTestClientWithDummyObject()),
@@ -948,7 +948,7 @@ func TestBareMetalHostDeleteAndWaitUntilDeleted(t *testing.T) {
 		},
 		{
 			testBmHost:    buildValidBmHostBuilder(clients.GetTestClients(clients.TestClientParams{})),
-			expectedError: fmt.Errorf("bmh cannot be deleted because it does not exist"),
+			expectedError: nil,
 		},
 		{
 			testBmHost:    buildInValidBmHostBuilder(buildBareMetalHostTestClientWithDummyObject()),


### PR DESCRIPTION
Similar to other Delete() functions, we do not return errors when an object already doesn't exist.

Builds from changes in: #379 