### PR TITLE
rbac: v1 to rbacv1 import consistency

### DIFF
--- a/pkg/rbac/clusterrole.go
+++ b/pkg/rbac/clusterrole.go
@@ -7,7 +7,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
-	v1 "k8s.io/api/rbac/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -19,9 +19,9 @@ ClusterRoleBuilder provides struct for clusterrole object
 */
 type ClusterRoleBuilder struct {
 	// Clusterrole definition. Used to create a clusterrole object.
-	Definition *v1.ClusterRole
+	Definition *rbacv1.ClusterRole
 	// Created clusterrole object
-	Object *v1.ClusterRole
+	Object *rbacv1.ClusterRole
 	// Used in functions that define or mutate clusterrole definition. errorMsg is processed before clusterrole
 	// object is created.
 	errorMsg  string
@@ -32,7 +32,7 @@ type ClusterRoleBuilder struct {
 type ClusterRoleAdditionalOptions func(builder *ClusterRoleBuilder) (*ClusterRoleBuilder, error)
 
 // NewClusterRoleBuilder creates new instance of ClusterRoleBuilder.
-func NewClusterRoleBuilder(apiClient *clients.Settings, name string, rule v1.PolicyRule) *ClusterRoleBuilder {
+func NewClusterRoleBuilder(apiClient *clients.Settings, name string, rule rbacv1.PolicyRule) *ClusterRoleBuilder {
 	glog.V(100).Infof(
 		"Initializing new clusterrole structure with the following params: "+
 			"name: %s, policy rule: %v",
@@ -40,7 +40,7 @@ func NewClusterRoleBuilder(apiClient *clients.Settings, name string, rule v1.Pol
 
 	builder := ClusterRoleBuilder{
 		apiClient: apiClient,
-		Definition: &v1.ClusterRole{
+		Definition: &rbacv1.ClusterRole{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 			},
@@ -53,13 +53,13 @@ func NewClusterRoleBuilder(apiClient *clients.Settings, name string, rule v1.Pol
 		builder.errorMsg = "clusterrole 'name' cannot be empty"
 	}
 
-	builder.WithRules([]v1.PolicyRule{rule})
+	builder.WithRules([]rbacv1.PolicyRule{rule})
 
 	return &builder
 }
 
 // WithRules appends additional rules to the clusterrole definition.
-func (builder *ClusterRoleBuilder) WithRules(rules []v1.PolicyRule) *ClusterRoleBuilder {
+func (builder *ClusterRoleBuilder) WithRules(rules []rbacv1.PolicyRule) *ClusterRoleBuilder {
 	if valid, _ := builder.validate(); !valid {
 		return builder
 	}
@@ -137,7 +137,7 @@ func PullClusterRole(apiClient *clients.Settings, name string) (*ClusterRoleBuil
 
 	builder := ClusterRoleBuilder{
 		apiClient: apiClient,
-		Definition: &v1.ClusterRole{
+		Definition: &rbacv1.ClusterRole{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 			},

--- a/pkg/rbac/clusterrole_test.go
+++ b/pkg/rbac/clusterrole_test.go
@@ -9,40 +9,40 @@ import (
 
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/stretchr/testify/assert"
-	v1 "k8s.io/api/rbac/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 )
 
 func TestNewClusterRoleBuilder(t *testing.T) {
 	testCases := []struct {
 		name              string
-		rule              v1.PolicyRule
+		rule              rbacv1.PolicyRule
 		expectedErrorText string
 		client            bool
 	}{
 		{
 			name: "test",
-			rule: v1.PolicyRule{
+			rule: rbacv1.PolicyRule{
 				Resources: []string{"pods"}, APIGroups: []string{"v1"}, Verbs: []string{"get"}},
 			client:            true,
 			expectedErrorText: "",
 		},
 		{
 			name: "test",
-			rule: v1.PolicyRule{
+			rule: rbacv1.PolicyRule{
 				Resources: []string{"pods"}, APIGroups: []string{"v1"}, Verbs: []string{"get"}},
 			client:            false,
 			expectedErrorText: "clusterRole builder cannot have nil apiClient",
 		},
 		{
 			name: "",
-			rule: v1.PolicyRule{
+			rule: rbacv1.PolicyRule{
 				Resources: []string{"pods"}, APIGroups: []string{"v1"}, Verbs: []string{"get"}},
 			client:            true,
 			expectedErrorText: "clusterrole 'name' cannot be empty",
 		},
 		{
 			name: "test",
-			rule: v1.PolicyRule{
+			rule: rbacv1.PolicyRule{
 				Resources: []string{"pods"}, APIGroups: []string{"v1"}},
 			client:            true,
 			expectedErrorText: "clusterrole rule must contain at least one Verb entry",
@@ -69,8 +69,8 @@ func TestNewClusterRoleBuilder(t *testing.T) {
 }
 
 func TestPullClusterRole(t *testing.T) {
-	generateClusterRole := func(name string) *v1.ClusterRole {
-		return &v1.ClusterRole{
+	generateClusterRole := func(name string) *rbacv1.ClusterRole {
+		return &rbacv1.ClusterRole{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 			},
@@ -269,25 +269,29 @@ func TestClusterRoleUpdate(t *testing.T) {
 
 func TestClusterRoleWithRules(t *testing.T) {
 	testCases := []struct {
-		rule              []v1.PolicyRule
+		rule              []rbacv1.PolicyRule
 		expectedError     bool
 		expectedErrorText string
 	}{
 		{
-			rule:              []v1.PolicyRule{{Resources: []string{"pods"}, APIGroups: []string{"v1"}, Verbs: []string{"get"}}},
+			rule: []rbacv1.PolicyRule{{Resources: []string{"pods"},
+				APIGroups: []string{"v1"}, Verbs: []string{"get"}}},
 			expectedError:     false,
 			expectedErrorText: "",
 		},
 		{
-			rule: []v1.PolicyRule{
-				{Resources: []string{"pods"}, APIGroups: []string{"v1"}, Verbs: []string{"get"}},
-				{Resources: []string{"pods"}, APIGroups: []string{"v1"}, Verbs: []string{"get"}},
+			rule: []rbacv1.PolicyRule{
+				{Resources: []string{"pods"},
+					APIGroups: []string{"v1"}, Verbs: []string{"get"}},
+				{Resources: []string{"pods"},
+					APIGroups: []string{"v1"}, Verbs: []string{"get"}},
 			},
 			expectedError:     false,
 			expectedErrorText: "",
 		},
 		{
-			rule:              []v1.PolicyRule{{Resources: []string{"pods"}, APIGroups: []string{"v1"}}},
+			rule: []rbacv1.PolicyRule{{Resources: []string{"pods"},
+				APIGroups: []string{"v1"}}},
 			expectedError:     true,
 			expectedErrorText: "clusterrole rule must contain at least one Verb entry",
 		},
@@ -329,12 +333,12 @@ func buildValidClusterRoleBuilder(apiClient *clients.Settings) *ClusterRoleBuild
 	return NewClusterRoleBuilder(
 		apiClient,
 		defaultRoleName,
-		v1.PolicyRule{Resources: []string{"pods"}, APIGroups: []string{"v1"}, Verbs: []string{"get"}})
+		rbacv1.PolicyRule{Resources: []string{"pods"}, APIGroups: []string{"v1"}, Verbs: []string{"get"}})
 }
 
 // buildValidClusterRoleBuilder returns a valid Builder for testing purposes.
 func buildInvalidClusterRoleTestBuilder(apiClient *clients.Settings) *ClusterRoleBuilder {
-	return NewClusterRoleBuilder(apiClient, defaultRoleName, v1.PolicyRule{})
+	return NewClusterRoleBuilder(apiClient, defaultRoleName, rbacv1.PolicyRule{})
 }
 
 func buildTestClientWithClusterRoleDummyObject() *clients.Settings {
@@ -344,7 +348,7 @@ func buildTestClientWithClusterRoleDummyObject() *clients.Settings {
 }
 
 func buildDummyClusterRoleObject() []runtime.Object {
-	return append([]runtime.Object{}, &v1.ClusterRole{
+	return append([]runtime.Object{}, &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: defaultRoleName,
 		},

--- a/pkg/rbac/clusterrolebinding.go
+++ b/pkg/rbac/clusterrolebinding.go
@@ -8,7 +8,7 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
 	"golang.org/x/exp/slices"
-	v1 "k8s.io/api/rbac/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -17,9 +17,9 @@ import (
 // containing connection to the cluster and the clusterrolebinding definitions.
 type ClusterRoleBindingBuilder struct {
 	// Clusterrolebinding definition. Used to create a clusterrolebinding object.
-	Definition *v1.ClusterRoleBinding
+	Definition *rbacv1.ClusterRoleBinding
 	// Created clusterrolebinding object
-	Object *v1.ClusterRoleBinding
+	Object *rbacv1.ClusterRoleBinding
 	// Used in functions that define or mutate clusterrolebinding definition.
 	// errorMsg is processed before the clusterrolebinding object is created.
 	errorMsg  string
@@ -31,7 +31,7 @@ type ClusterRoleBindingAdditionalOptions func(builder *ClusterRoleBindingBuilder
 
 // NewClusterRoleBindingBuilder creates a new instance of ClusterRoleBindingBuilder.
 func NewClusterRoleBindingBuilder(
-	apiClient *clients.Settings, name, clusterRole string, subject v1.Subject) *ClusterRoleBindingBuilder {
+	apiClient *clients.Settings, name, clusterRole string, subject rbacv1.Subject) *ClusterRoleBindingBuilder {
 	glog.V(100).Infof(
 		"Initializing new clusterrolebinding structure with the following params: "+
 			"name: %s, clusterrole: %s, subject %v",
@@ -39,11 +39,11 @@ func NewClusterRoleBindingBuilder(
 
 	builder := ClusterRoleBindingBuilder{
 		apiClient: apiClient,
-		Definition: &v1.ClusterRoleBinding{
+		Definition: &rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 			},
-			RoleRef: v1.RoleRef{
+			RoleRef: rbacv1.RoleRef{
 				APIGroup: "rbac.authorization.k8s.io",
 				Name:     clusterRole,
 				Kind:     "ClusterRole",
@@ -51,7 +51,7 @@ func NewClusterRoleBindingBuilder(
 		},
 	}
 
-	builder.WithSubjects([]v1.Subject{subject})
+	builder.WithSubjects([]rbacv1.Subject{subject})
 
 	if name == "" {
 		glog.V(100).Infof("The name of the clusterrolebinding is empty")
@@ -63,7 +63,7 @@ func NewClusterRoleBindingBuilder(
 }
 
 // WithSubjects appends additional subjects to clusterrolebinding definition.
-func (builder *ClusterRoleBindingBuilder) WithSubjects(subjects []v1.Subject) *ClusterRoleBindingBuilder {
+func (builder *ClusterRoleBindingBuilder) WithSubjects(subjects []rbacv1.Subject) *ClusterRoleBindingBuilder {
 	if valid, _ := builder.validate(); !valid {
 		return builder
 	}
@@ -136,7 +136,7 @@ func PullClusterRoleBinding(apiClient *clients.Settings, name string) (*ClusterR
 
 	builder := ClusterRoleBindingBuilder{
 		apiClient: apiClient,
-		Definition: &v1.ClusterRoleBinding{
+		Definition: &rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 			},

--- a/pkg/rbac/role.go
+++ b/pkg/rbac/role.go
@@ -7,7 +7,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
-	v1 "k8s.io/api/rbac/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -15,9 +15,9 @@ import (
 // RoleBuilder provides a struct for role object containing connection to the cluster and the role definitions.
 type RoleBuilder struct {
 	// Role definition. Used to create a role object
-	Definition *v1.Role
+	Definition *rbacv1.Role
 	// Created role object
-	Object *v1.Role
+	Object *rbacv1.Role
 
 	// Used in functions that define or mutate role definition. errorMsg is processed
 	// before the role object is created
@@ -29,14 +29,14 @@ type RoleBuilder struct {
 type RoleAdditionalOptions func(builder *RoleBuilder) (*RoleBuilder, error)
 
 // NewRoleBuilder create a new instance of RoleBuilder.
-func NewRoleBuilder(apiClient *clients.Settings, name, nsname string, rule v1.PolicyRule) *RoleBuilder {
+func NewRoleBuilder(apiClient *clients.Settings, name, nsname string, rule rbacv1.PolicyRule) *RoleBuilder {
 	glog.V(100).Infof(
 		"Initializing new role structure with the following params: "+
 			"name: %s, namespace: %s, rule %v", name, nsname, rule)
 
 	builder := &RoleBuilder{
 		apiClient: apiClient,
-		Definition: &v1.Role{
+		Definition: &rbacv1.Role{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
@@ -60,13 +60,13 @@ func NewRoleBuilder(apiClient *clients.Settings, name, nsname string, rule v1.Po
 		return builder
 	}
 
-	builder.WithRules([]v1.PolicyRule{rule})
+	builder.WithRules([]rbacv1.PolicyRule{rule})
 
 	return builder
 }
 
 // WithRules adds the specified PolicyRule to the Role.
-func (builder *RoleBuilder) WithRules(rules []v1.PolicyRule) *RoleBuilder {
+func (builder *RoleBuilder) WithRules(rules []rbacv1.PolicyRule) *RoleBuilder {
 	if valid, _ := builder.validate(); !valid {
 		return builder
 	}
@@ -155,7 +155,7 @@ func PullRole(apiClient *clients.Settings, name, nsname string) (*RoleBuilder, e
 
 	builder := RoleBuilder{
 		apiClient: apiClient,
-		Definition: &v1.Role{
+		Definition: &rbacv1.Role{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,

--- a/pkg/rbac/role_test.go
+++ b/pkg/rbac/role_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/stretchr/testify/assert"
-	v1 "k8s.io/api/rbac/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 )
 
 var (
@@ -21,14 +21,14 @@ func TestNewRoleBuilder(t *testing.T) {
 	testCases := []struct {
 		name              string
 		nsName            string
-		rule              v1.PolicyRule
+		rule              rbacv1.PolicyRule
 		expectedErrorText string
 		client            bool
 	}{
 		{
 			name:   "test",
 			nsName: "testns",
-			rule: v1.PolicyRule{
+			rule: rbacv1.PolicyRule{
 				Resources: []string{"pods"}, APIGroups: []string{"v1"}, Verbs: []string{"get"}},
 			client:            true,
 			expectedErrorText: "",
@@ -36,7 +36,7 @@ func TestNewRoleBuilder(t *testing.T) {
 		{
 			name:   "test",
 			nsName: "testns",
-			rule: v1.PolicyRule{
+			rule: rbacv1.PolicyRule{
 				Resources: []string{"pods"}, APIGroups: []string{"v1"}, Verbs: []string{"get"}},
 			client:            false,
 			expectedErrorText: "role builder cannot have nil apiClient",
@@ -44,7 +44,7 @@ func TestNewRoleBuilder(t *testing.T) {
 		{
 			name:   "",
 			nsName: "testns",
-			rule: v1.PolicyRule{
+			rule: rbacv1.PolicyRule{
 				Resources: []string{"pods"}, APIGroups: []string{"v1"}, Verbs: []string{"get"}},
 			client:            true,
 			expectedErrorText: "role 'name' cannot be empty",
@@ -52,7 +52,7 @@ func TestNewRoleBuilder(t *testing.T) {
 		{
 			name:   "test",
 			nsName: "",
-			rule: v1.PolicyRule{
+			rule: rbacv1.PolicyRule{
 				Resources: []string{"pods"}, APIGroups: []string{"v1"}, Verbs: []string{"get"}},
 			client:            true,
 			expectedErrorText: "role 'nsname' cannot be empty",
@@ -60,7 +60,7 @@ func TestNewRoleBuilder(t *testing.T) {
 		{
 			name:   "test",
 			nsName: "testns",
-			rule: v1.PolicyRule{
+			rule: rbacv1.PolicyRule{
 				Resources: []string{"pods"}, APIGroups: []string{"v1"}},
 			client:            true,
 			expectedErrorText: "role must contain at least one Verb",
@@ -87,8 +87,8 @@ func TestNewRoleBuilder(t *testing.T) {
 }
 
 func TestPullRole(t *testing.T) {
-	generateRole := func(name, nsName string) *v1.Role {
-		return &v1.Role{
+	generateRole := func(name, nsName string) *rbacv1.Role {
+		return &rbacv1.Role{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsName,
@@ -301,17 +301,18 @@ func TestRoleUpdate(t *testing.T) {
 
 func TestRoleWithRules(t *testing.T) {
 	testCases := []struct {
-		rule              []v1.PolicyRule
+		rule              []rbacv1.PolicyRule
 		expectedError     bool
 		expectedErrorText string
 	}{
 		{
-			rule:              []v1.PolicyRule{{Resources: []string{"pods"}, APIGroups: []string{"v1"}, Verbs: []string{"get"}}},
+			rule: []rbacv1.PolicyRule{{Resources: []string{"pods"},
+				APIGroups: []string{"v1"}, Verbs: []string{"get"}}},
 			expectedError:     false,
 			expectedErrorText: "",
 		},
 		{
-			rule: []v1.PolicyRule{
+			rule: []rbacv1.PolicyRule{
 				{Resources: []string{"pods"}, APIGroups: []string{"v1"}, Verbs: []string{"get"}},
 				{Resources: []string{"pods"}, APIGroups: []string{"v1"}, Verbs: []string{"get"}},
 			},
@@ -319,7 +320,8 @@ func TestRoleWithRules(t *testing.T) {
 			expectedErrorText: "",
 		},
 		{
-			rule:              []v1.PolicyRule{{Resources: []string{"pods"}, APIGroups: []string{"v1"}}},
+			rule: []rbacv1.PolicyRule{{Resources: []string{"pods"},
+				APIGroups: []string{"v1"}}},
 			expectedError:     true,
 			expectedErrorText: "role must contain at least one Verb",
 		},
@@ -362,12 +364,12 @@ func buildValidRoleBuilder(apiClient *clients.Settings) *RoleBuilder {
 		apiClient,
 		defaultRoleName,
 		defaultRoleNsName,
-		v1.PolicyRule{Resources: []string{"pods"}, APIGroups: []string{"v1"}, Verbs: []string{"get"}})
+		rbacv1.PolicyRule{Resources: []string{"pods"}, APIGroups: []string{"v1"}, Verbs: []string{"get"}})
 }
 
 // buildValidTestBuilder returns a valid Builder for testing purposes.
 func buildInvalidRoleTestBuilder(apiClient *clients.Settings) *RoleBuilder {
-	return NewRoleBuilder(apiClient, defaultRoleName, defaultRoleNsName, v1.PolicyRule{})
+	return NewRoleBuilder(apiClient, defaultRoleName, defaultRoleNsName, rbacv1.PolicyRule{})
 }
 
 func buildTestClientWithDummyObject() *clients.Settings {
@@ -377,7 +379,7 @@ func buildTestClientWithDummyObject() *clients.Settings {
 }
 
 func buildDummyRoleObject() []runtime.Object {
-	return append([]runtime.Object{}, &v1.Role{
+	return append([]runtime.Object{}, &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      defaultRoleName,
 			Namespace: defaultRoleNsName,

--- a/pkg/rbac/rolebinding.go
+++ b/pkg/rbac/rolebinding.go
@@ -8,7 +8,7 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
 	"golang.org/x/exp/slices"
-	v1 "k8s.io/api/rbac/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -17,9 +17,9 @@ import (
 // to the cluster RoleBinding definition.
 type RoleBindingBuilder struct {
 	// Rolebinding definition. Used to create rolebinding object
-	Definition *v1.RoleBinding
+	Definition *rbacv1.RoleBinding
 	// Created rolebinding object
-	Object *v1.RoleBinding
+	Object *rbacv1.RoleBinding
 
 	// Used in functions that define or mutate rolebinding definition. errorMsg is processed
 	// before the rolebinding object is created
@@ -33,19 +33,19 @@ type RoleBindingAdditionalOptions func(builder *RoleBindingBuilder) (*RoleBindin
 // NewRoleBindingBuilder creates new instance of RoleBindingBuilder.
 func NewRoleBindingBuilder(apiClient *clients.Settings,
 	name, nsname, role string,
-	subject v1.Subject) *RoleBindingBuilder {
+	subject rbacv1.Subject) *RoleBindingBuilder {
 	glog.V(100).Infof(
 		"Initializing new rolebinding structure with the following params: "+
 			"name: %s, namespace: %s, role: %s, subject %v", name, nsname, role, subject)
 
 	builder := RoleBindingBuilder{
 		apiClient: apiClient,
-		Definition: &v1.RoleBinding{
+		Definition: &rbacv1.RoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,
 			},
-			RoleRef: v1.RoleRef{
+			RoleRef: rbacv1.RoleRef{
 				APIGroup: "rbac.authorization.k8s.io",
 				Name:     role,
 				Kind:     "Role",
@@ -65,13 +65,13 @@ func NewRoleBindingBuilder(apiClient *clients.Settings,
 		builder.errorMsg = "RoleBinding 'nsname' cannot be empty"
 	}
 
-	builder.WithSubjects([]v1.Subject{subject})
+	builder.WithSubjects([]rbacv1.Subject{subject})
 
 	return &builder
 }
 
 // WithSubjects adds specified Subject to the RoleBinding.
-func (builder *RoleBindingBuilder) WithSubjects(subjects []v1.Subject) *RoleBindingBuilder {
+func (builder *RoleBindingBuilder) WithSubjects(subjects []rbacv1.Subject) *RoleBindingBuilder {
 	if valid, _ := builder.validate(); !valid {
 		return builder
 	}
@@ -142,7 +142,7 @@ func PullRoleBinding(apiClient *clients.Settings, name, nsname string) (*RoleBin
 
 	builder := RoleBindingBuilder{
 		apiClient: apiClient,
-		Definition: &v1.RoleBinding{
+		Definition: &rbacv1.RoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsname,


### PR DESCRIPTION
Similar to: https://github.com/openshift-kni/eco-goinfra/pull/387

Just changing `v1` to `rbacv1` to better match the rest of the repo.