### PR TITLE
Assert: Adjust expected/actual parameter order

### DIFF
--- a/pkg/apiservers/kubeapiserver_test.go
+++ b/pkg/apiservers/kubeapiserver_test.go
@@ -91,7 +91,7 @@ func TestKubeAPIServerGet(t *testing.T) {
 		if testCase.expectedError == nil {
 			assert.Equal(t, testKubeAPIServer.Name, testCase.testKubeAPIServerBuilder.Definition.Name)
 		} else {
-			assert.Equal(t, err.Error(), testCase.expectedError.Error())
+			assert.Equal(t, testCase.expectedError.Error(), err.Error())
 		}
 	}
 }
@@ -113,7 +113,7 @@ func TestKubeAPIServerExist(t *testing.T) {
 
 	for _, testCase := range testCases {
 		status := testCase.testKubeAPIServerBuilder.Exists()
-		assert.Equal(t, status, testCase.expectedStatus)
+		assert.Equal(t, testCase.expectedStatus, status)
 	}
 }
 

--- a/pkg/apiservers/openshiftapiserver_test.go
+++ b/pkg/apiservers/openshiftapiserver_test.go
@@ -92,7 +92,7 @@ func TestOpenshiftAPIServerGet(t *testing.T) {
 		if testCase.expectedError == nil {
 			assert.Equal(t, testOpenshiftAPIServer.Name, testCase.testOpenshiftAPIServerBuilder.Definition.Name)
 		} else {
-			assert.Equal(t, err.Error(), testCase.expectedError.Error())
+			assert.Equal(t, testCase.expectedError.Error(), err.Error())
 		}
 	}
 }
@@ -116,7 +116,7 @@ func TestOpenshiftAPIServerExists(t *testing.T) {
 
 	for _, testCase := range testCases {
 		status := testCase.testOpenshiftAPIServerBuilder.Exists()
-		assert.Equal(t, status, testCase.expectedStatus)
+		assert.Equal(t, testCase.expectedStatus, status)
 	}
 }
 

--- a/pkg/argocd/applications_test.go
+++ b/pkg/argocd/applications_test.go
@@ -129,7 +129,7 @@ func TestApplicationExist(t *testing.T) {
 
 	for _, testCase := range testCases {
 		exist := testCase.testApplicationBuilder.Exists()
-		assert.Equal(t, exist, testCase.expectedStatus)
+		assert.Equal(t, testCase.expectedStatus, exist)
 	}
 }
 

--- a/pkg/argocd/argocd_test.go
+++ b/pkg/argocd/argocd_test.go
@@ -188,7 +188,7 @@ func TestArgoCdExist(t *testing.T) {
 
 	for _, testCase := range testCases {
 		exist := testCase.testArgoCd.Exists()
-		assert.Equal(t, exist, testCase.expectedStatus)
+		assert.Equal(t, testCase.expectedStatus, exist)
 	}
 }
 
@@ -209,7 +209,7 @@ func TestArgoCdCreate(t *testing.T) {
 
 	for _, testCase := range testCases {
 		testArgoCdBuilder, err := testCase.testArgoCd.Create()
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.Equal(t, testArgoCdBuilder.Definition, testArgoCdBuilder.Object)

--- a/pkg/assisted/agentclusterinstall_test.go
+++ b/pkg/assisted/agentclusterinstall_test.go
@@ -175,7 +175,7 @@ func TestPullAgentClusterInstall(t *testing.T) {
 		}
 
 		testBuilder, err := PullAgentClusterInstall(testSettings, testCase.name, testCase.namespace)
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError != nil {
 			assert.Nil(t, testBuilder)

--- a/pkg/assisted/agentserviceconfig_test.go
+++ b/pkg/assisted/agentserviceconfig_test.go
@@ -174,7 +174,7 @@ func TestPullAgentServiceConfig(t *testing.T) {
 		}
 
 		testBuilder, err := PullAgentServiceConfig(testSettings)
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError != nil {
 			assert.Nil(t, testBuilder)

--- a/pkg/bmh/baremetalhost_test.go
+++ b/pkg/bmh/baremetalhost_test.go
@@ -241,7 +241,7 @@ func TestBareMetalHostExists(t *testing.T) {
 
 	for _, testCase := range testCases {
 		exist := testCase.testBmHost.Exists()
-		assert.Equal(t, exist, testCase.expectedStatus)
+		assert.Equal(t, testCase.expectedStatus, exist)
 	}
 }
 
@@ -271,7 +271,7 @@ func TestBareMetalHostGet(t *testing.T) {
 			assert.Equal(t, bmHost.Name, testCase.testBmHost.Definition.Name)
 			assert.Equal(t, bmHost.Namespace, testCase.testBmHost.Definition.Namespace)
 		} else {
-			assert.Equal(t, err.Error(), testCase.expectedError.Error())
+			assert.Equal(t, testCase.expectedError.Error(), err.Error())
 		}
 	}
 }
@@ -302,7 +302,7 @@ func TestBareMetalHostCreate(t *testing.T) {
 			assert.Equal(t, ipAddressPoolBuilder.Definition.Name, ipAddressPoolBuilder.Object.Name)
 			assert.Equal(t, ipAddressPoolBuilder.Definition.Namespace, ipAddressPoolBuilder.Object.Namespace)
 		} else {
-			assert.Equal(t, err.Error(), testCase.expectedError.Error())
+			assert.Equal(t, testCase.expectedError.Error(), err.Error())
 		}
 	}
 }
@@ -763,7 +763,7 @@ func TestBareMetalHostCreateAndWaitUntilProvisioned(t *testing.T) {
 			assert.Equal(t, ipAddressPoolBuilder.Definition.Name, ipAddressPoolBuilder.Object.Name)
 			assert.Equal(t, ipAddressPoolBuilder.Definition.Namespace, ipAddressPoolBuilder.Object.Namespace)
 		} else {
-			assert.Equal(t, err.Error(), testCase.expectedError.Error())
+			assert.Equal(t, testCase.expectedError.Error(), err.Error())
 		}
 	}
 }
@@ -794,7 +794,7 @@ func TestBareMetalHostWaitUntilProvisioned(t *testing.T) {
 	for _, testCase := range testCases {
 		err := testCase.testBmHost.WaitUntilProvisioned(1 * time.Millisecond)
 		if testCase.expectedError != nil {
-			assert.Equal(t, err.Error(), testCase.expectedError.Error())
+			assert.Equal(t, testCase.expectedError.Error(), err.Error())
 		} else {
 			assert.Nil(t, err)
 		}
@@ -827,7 +827,7 @@ func TestBareMetalHostWaitUntilProvisioning(t *testing.T) {
 	for _, testCase := range testCases {
 		err := testCase.testBmHost.WaitUntilProvisioning(1 * time.Millisecond)
 		if testCase.expectedError != nil {
-			assert.Equal(t, err.Error(), testCase.expectedError.Error())
+			assert.Equal(t, testCase.expectedError.Error(), err.Error())
 		} else {
 			assert.Nil(t, err)
 		}
@@ -860,7 +860,7 @@ func TestBareMetalHostWaitUntilReady(t *testing.T) {
 	for _, testCase := range testCases {
 		err := testCase.testBmHost.WaitUntilReady(1 * time.Millisecond)
 		if testCase.expectedError != nil {
-			assert.Equal(t, err.Error(), testCase.expectedError.Error())
+			assert.Equal(t, testCase.expectedError.Error(), err.Error())
 		} else {
 			assert.Nil(t, err)
 		}
@@ -893,7 +893,7 @@ func TestBareMetalHostWaitUntilAvailable(t *testing.T) {
 	for _, testCase := range testCases {
 		err := testCase.testBmHost.WaitUntilAvailable(1 * time.Millisecond)
 		if testCase.expectedError != nil {
-			assert.Equal(t, err.Error(), testCase.expectedError.Error())
+			assert.Equal(t, testCase.expectedError.Error(), err.Error())
 		} else {
 			assert.Nil(t, err)
 		}
@@ -930,7 +930,7 @@ func TestBareMetalHostWaitUntilInStatus(t *testing.T) {
 	for _, testCase := range testCases {
 		err := testCase.testBmHost.WaitUntilInStatus(bmhv1alpha1.StateAvailable, 1*time.Millisecond)
 		if testCase.expectedError != nil {
-			assert.Equal(t, err.Error(), testCase.expectedError.Error())
+			assert.Equal(t, testCase.expectedError.Error(), err.Error())
 		} else {
 			assert.Nil(t, err)
 		}

--- a/pkg/bmh/list_test.go
+++ b/pkg/bmh/list_test.go
@@ -66,7 +66,7 @@ func TestBareMetalHostList(t *testing.T) {
 		}
 
 		bmhBuilders, err := List(testSettings, testCase.nsName, testCase.listOptions...)
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil && len(testCase.listOptions) == 0 {
 			assert.Equal(t, len(testCase.BareMetalHosts), len(bmhBuilders))
@@ -115,7 +115,7 @@ func TestBareMetalHostListInAllNamespaces(t *testing.T) {
 		}
 
 		bmhBuilders, err := ListInAllNamespaces(testSettings, testCase.listOptions...)
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil && len(testCase.listOptions) == 0 {
 			assert.Equal(t, len(testCase.bareMetalHosts), len(bmhBuilders))
@@ -201,7 +201,7 @@ func TestBareMetalWaitForAllBareMetalHostsInGoodOperationalState(t *testing.T) {
 
 		status, err := WaitForAllBareMetalHostsInGoodOperationalState(
 			testSettings, testCase.nsName, 1*time.Second, testCase.listOptions...)
-		assert.Equal(t, err, testCase.expectedError)
-		assert.Equal(t, status, testCase.expectedStatus)
+		assert.Equal(t, testCase.expectedError, err)
+		assert.Equal(t, testCase.expectedStatus, status)
 	}
 }

--- a/pkg/cgu/cgu_test.go
+++ b/pkg/cgu/cgu_test.go
@@ -188,7 +188,7 @@ func TestNewCguBuilder(t *testing.T) {
 
 		if testCase.client {
 			assert.NotNil(t, testCguStructure)
-			assert.Equal(t, testCguStructure.errorMsg, testCase.expectedErrorText)
+			assert.Equal(t, testCase.expectedErrorText, testCguStructure.errorMsg)
 		} else {
 			assert.Nil(t, testCguStructure)
 		}
@@ -213,7 +213,7 @@ func TestCguWithCluster(t *testing.T) {
 	for _, testCase := range testCases {
 		testSettings := buildTestClientWithDummyCguObject()
 		cguBuilder := buildValidCguTestBuilder(testSettings).WithCluster(testCase.cluster)
-		assert.Equal(t, cguBuilder.errorMsg, testCase.expectedErrorText)
+		assert.Equal(t, testCase.expectedErrorText, cguBuilder.errorMsg)
 
 		if testCase.expectedErrorText == "" {
 			assert.Equal(t, cguBuilder.Definition.Spec.Clusters, []string{testCase.cluster})
@@ -239,7 +239,7 @@ func TestCguWithManagedPolicy(t *testing.T) {
 	for _, testCase := range testCases {
 		testSettings := buildTestClientWithDummyCguObject()
 		cguBuilder := buildValidCguTestBuilder(testSettings).WithManagedPolicy(testCase.policy)
-		assert.Equal(t, cguBuilder.errorMsg, testCase.expectedErrorText)
+		assert.Equal(t, testCase.expectedErrorText, cguBuilder.errorMsg)
 
 		if testCase.expectedErrorText == "" {
 			assert.Equal(t, cguBuilder.Definition.Spec.ManagedPolicies, []string{testCase.policy})
@@ -265,7 +265,7 @@ func TestCguWithCanary(t *testing.T) {
 	for _, testCase := range testCases {
 		testSettings := buildTestClientWithDummyCguObject()
 		cguBuilder := buildValidCguTestBuilder(testSettings).WithCanary(testCase.canary)
-		assert.Equal(t, cguBuilder.errorMsg, testCase.expectedErrorText)
+		assert.Equal(t, testCase.expectedErrorText, cguBuilder.errorMsg)
 
 		if testCase.expectedErrorText == "" {
 			assert.Equal(t, cguBuilder.Definition.Spec.RemediationStrategy.Canaries, []string{testCase.canary})
@@ -290,7 +290,7 @@ func TestCguCreate(t *testing.T) {
 
 	for _, testCase := range testCases {
 		cguBuilder, err := testCase.testCgu.Create()
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.Equal(t, cguBuilder.Definition, cguBuilder.Object)

--- a/pkg/cgu/cgulist_test.go
+++ b/pkg/cgu/cgulist_test.go
@@ -53,7 +53,7 @@ func TestCguListInAllNamespaces(t *testing.T) {
 		}
 
 		cguBuilders, err := ListInAllNamespaces(testSettings, testCase.listOptions...)
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil && len(testCase.listOptions) == 0 {
 			assert.Equal(t, len(cguBuilders), len(testCase.testCGU))

--- a/pkg/clusterlogging/clusterlogging_test.go
+++ b/pkg/clusterlogging/clusterlogging_test.go
@@ -169,7 +169,7 @@ func TestClusterLoggingGet(t *testing.T) {
 			assert.Equal(t, clusterLogging.Name, testCase.clusterLogging.Definition.Name)
 			assert.Equal(t, clusterLogging.Namespace, testCase.clusterLogging.Definition.Namespace)
 		} else {
-			assert.Equal(t, err.Error(), testCase.expectedError.Error())
+			assert.Equal(t, testCase.expectedError.Error(), err.Error())
 		}
 	}
 }
@@ -204,7 +204,7 @@ func TestClusterLoggingCreate(t *testing.T) {
 			assert.Equal(t, clusterLogging.Definition.Name, clusterLogging.Object.Name)
 			assert.Equal(t, clusterLogging.Definition.Namespace, clusterLogging.Object.Namespace)
 		} else {
-			assert.Equal(t, err.Error(), testCase.expectedError.Error())
+			assert.Equal(t, testCase.expectedError.Error(), err.Error())
 		}
 	}
 }
@@ -264,7 +264,7 @@ func TestClusterLoggingExist(t *testing.T) {
 
 	for _, testCase := range testCases {
 		exist := testCase.clusterLogging.Exists()
-		assert.Equal(t, exist, testCase.expectedStatus)
+		assert.Equal(t, testCase.expectedStatus, exist)
 	}
 }
 

--- a/pkg/console/consoleoperator_test.go
+++ b/pkg/console/consoleoperator_test.go
@@ -114,7 +114,7 @@ func TestConsoleOperatorExist(t *testing.T) {
 
 	for _, testCase := range testCases {
 		exist := testCase.testConsoleOperator.Exists()
-		assert.Equal(t, exist, testCase.expectedStatus)
+		assert.Equal(t, testCase.expectedStatus, exist)
 	}
 }
 

--- a/pkg/hive/clusterdeployment_test.go
+++ b/pkg/hive/clusterdeployment_test.go
@@ -219,7 +219,7 @@ func TestClusterDeploymentGet(t *testing.T) {
 	for _, testCase := range testCases {
 		clusterClusterDeployment, err := testCase.testClusterDeployment.Get()
 		if testCase.expectedError != nil {
-			assert.Equal(t, err.Error(), testCase.expectedError.Error())
+			assert.Equal(t, testCase.expectedError.Error(), err.Error())
 		}
 
 		if testCase.expectedError == nil {
@@ -250,7 +250,7 @@ func TestClusterDeploymentCreate(t *testing.T) {
 	for _, testCase := range testCases {
 		clusterClusterDeployment, err := testCase.testClusterDeployment.Create()
 		if testCase.expectedError != nil {
-			assert.Equal(t, err.Error(), testCase.expectedError.Error())
+			assert.Equal(t, testCase.expectedError.Error(), err.Error())
 		}
 
 		if testCase.expectedError == nil {
@@ -343,7 +343,7 @@ func TestClusterDeploymentExists(t *testing.T) {
 
 	for _, testCase := range testCases {
 		exist := testCase.testClusterDeployment.Exists()
-		assert.Equal(t, exist, testCase.expectedStatus)
+		assert.Equal(t, testCase.expectedStatus, exist)
 	}
 }
 
@@ -381,7 +381,7 @@ func TestClusterDeploymentWithAdditionalAgentSelectorLabels(t *testing.T) {
 		testSettings := buildClusterDeploymentClientWithDummyObject()
 		clusterDeployment := buildValidClusterDeploymentBuilder(testSettings).WithAdditionalAgentSelectorLabels(
 			testCase.additionalAgentSelector)
-		assert.Equal(t, clusterDeployment.errorMsg, testCase.expectedErrorText)
+		assert.Equal(t, testCase.expectedErrorText, clusterDeployment.errorMsg)
 
 		if testCase.expectedErrorText == "" {
 			assert.Equal(t, clusterDeployment.Definition.Spec.Platform.AgentBareMetal.AgentSelector.MatchLabels,
@@ -408,7 +408,7 @@ func TestClusterDeploymentWithPullSecret(t *testing.T) {
 	for _, testCase := range testCases {
 		testSettings := buildClusterDeploymentClientWithDummyObject()
 		clusterDeployment := buildValidClusterDeploymentBuilder(testSettings).WithPullSecret(testCase.psName)
-		assert.Equal(t, clusterDeployment.errorMsg, testCase.expectedErrorText)
+		assert.Equal(t, testCase.expectedErrorText, clusterDeployment.errorMsg)
 
 		if testCase.expectedErrorText == "" {
 			assert.Equal(t, clusterDeployment.Definition.Spec.PullSecretRef.Name, testCase.psName)

--- a/pkg/hive/clusterdeploymentlist_test.go
+++ b/pkg/hive/clusterdeploymentlist_test.go
@@ -53,7 +53,7 @@ func TestListClusterDeploymentsInAllNamespaces(t *testing.T) {
 		}
 
 		deploymentBuilder, err := ListClusterDeploymentsInAllNamespaces(testSettings, testCase.listOptions...)
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil && len(testCase.listOptions) == 0 {
 			assert.Equal(t, len(deploymentBuilder), len(testCase.clusterDeployment))

--- a/pkg/hive/clusterimageset_test.go
+++ b/pkg/hive/clusterimageset_test.go
@@ -143,7 +143,7 @@ func TestClusterImageSetGet(t *testing.T) {
 	for _, testCase := range testCases {
 		clusterImageSet, err := testCase.testClusterImageSet.Get()
 		if testCase.expectedError != nil {
-			assert.Equal(t, err.Error(), testCase.expectedError.Error())
+			assert.Equal(t, testCase.expectedError.Error(), err.Error())
 		}
 
 		if testCase.expectedError == nil {
@@ -174,7 +174,7 @@ func TestClusterImageSetCreate(t *testing.T) {
 	for _, testCase := range testCases {
 		clusterImageSet, err := testCase.testClusterImageSet.Create()
 		if testCase.expectedError != nil {
-			assert.Equal(t, err.Error(), testCase.expectedError.Error())
+			assert.Equal(t, testCase.expectedError.Error(), err.Error())
 		}
 
 		if testCase.expectedError == nil {
@@ -267,7 +267,7 @@ func TestClusterImageSetExists(t *testing.T) {
 
 	for _, testCase := range testCases {
 		exist := testCase.testClusterImageSet.Exists()
-		assert.Equal(t, exist, testCase.expectedStatus)
+		assert.Equal(t, testCase.expectedStatus, exist)
 	}
 }
 

--- a/pkg/hive/config_test.go
+++ b/pkg/hive/config_test.go
@@ -134,7 +134,7 @@ func TestConfigGet(t *testing.T) {
 	for _, testCase := range testCases {
 		hiveConfig, err := testCase.testConfig.Get()
 		if testCase.expectedError != nil {
-			assert.Equal(t, err.Error(), testCase.expectedError.Error())
+			assert.Equal(t, testCase.expectedError.Error(), err.Error())
 		}
 
 		if testCase.expectedError == nil {
@@ -164,7 +164,7 @@ func TestConfigExists(t *testing.T) {
 
 	for _, testCase := range testCases {
 		exist := testCase.testConfig.Exists()
-		assert.Equal(t, exist, testCase.expectedStatus)
+		assert.Equal(t, testCase.expectedStatus, exist)
 	}
 }
 

--- a/pkg/kmm/containers_test.go
+++ b/pkg/kmm/containers_test.go
@@ -162,7 +162,7 @@ func TestModuleLoaderContainerWithKernelMapping(t *testing.T) {
 		testBuilder.WithKernelMapping(testcase.mapping)
 
 		if testcase.expectedError != "" {
-			assert.Equal(t, testBuilder.errorMsg, testcase.expectedError)
+			assert.Equal(t, testcase.expectedError, testBuilder.errorMsg)
 		} else {
 			assert.Equal(t, testBuilder.definition.KernelMappings[0], *testcase.mapping)
 		}
@@ -203,7 +203,7 @@ func TestModuleLoaderContainerWithVersion(t *testing.T) {
 		testBuilder.WithVersion(testcase.version)
 
 		if testcase.expectedError != "" {
-			assert.Equal(t, testBuilder.errorMsg, testcase.expectedError)
+			assert.Equal(t, testcase.expectedError, testBuilder.errorMsg)
 		} else {
 			assert.Equal(t, testBuilder.definition.Version, testcase.version)
 		}

--- a/pkg/kmm/managedclustermodule_test.go
+++ b/pkg/kmm/managedclustermodule_test.go
@@ -208,7 +208,7 @@ func TestManagedClusterModuleExists(t *testing.T) {
 
 	for _, testCase := range testCases {
 		exist := testCase.testManagedClusterModule.Exists()
-		assert.Equal(t, exist, testCase.expectedStatus)
+		assert.Equal(t, testCase.expectedStatus, exist)
 	}
 }
 

--- a/pkg/kmm/module_test.go
+++ b/pkg/kmm/module_test.go
@@ -202,7 +202,7 @@ func TestModuleExists(t *testing.T) {
 
 	for _, testCase := range testCases {
 		exist := testCase.testModule.Exists()
-		assert.Equal(t, exist, testCase.expectedStatus)
+		assert.Equal(t, testCase.expectedStatus, exist)
 	}
 }
 

--- a/pkg/kmm/preflightvalidationocp_test.go
+++ b/pkg/kmm/preflightvalidationocp_test.go
@@ -312,7 +312,7 @@ func TestPreflightValidationExists(t *testing.T) {
 
 	for _, testCase := range testCases {
 		exist := testCase.testPreflight.Exists()
-		assert.Equal(t, exist, testCase.expectedStatus)
+		assert.Equal(t, testCase.expectedStatus, exist)
 	}
 }
 

--- a/pkg/lca/ibu_test.go
+++ b/pkg/lca/ibu_test.go
@@ -68,7 +68,7 @@ func TestImageBasedUpgradePull(t *testing.T) {
 		builderResult, err := PullImageBasedUpgrade(testSettings)
 
 		// Check the error
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.NotNil(t, builderResult)
@@ -112,7 +112,7 @@ func TestImageBasedUpgradeUpdate(t *testing.T) {
 		builderResult, err := ibuBuilder.WithSeedImage("quay.io/no-image").Update()
 
 		// Check the error
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.NotNil(t, builderResult)
@@ -156,7 +156,7 @@ func TestImageBasedUpgradeDelete(t *testing.T) {
 		builderResult, err := ibuBuilder.Delete()
 
 		// Check the error
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.Nil(t, builderResult.Object)
@@ -205,7 +205,7 @@ func TestImageBasedUpgradeGet(t *testing.T) {
 		builderResult, err := ibuBuilder.Get()
 
 		// Check the error
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.NotNil(t, builderResult)
@@ -255,7 +255,7 @@ func TestImageBasedUpgradeExists(t *testing.T) {
 		builderResult := ibuBuilder.Exists()
 
 		// Check the error
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.NotNil(t, builderResult)
@@ -305,7 +305,7 @@ func TestImageBasedUpgradeWithSeedImage(t *testing.T) {
 		builderResult := ibuBuilder.WithSeedImage(testCase.seedImage)
 
 		// Check the error
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.NotNil(t, builderResult)
@@ -359,7 +359,7 @@ func TestImageBasedUpgradeWithExtraManifests(t *testing.T) {
 			testCase.extraManifestsConfigMapName, testCase.extraManifestsConfigMapNamespace)
 
 		// Check the error
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.NotNil(t, builderResult)
@@ -413,7 +413,7 @@ func TestImageBasedUpgradeWithOadpContent(t *testing.T) {
 			testCase.oadpContentConfigMapName, testCase.oadpContentConfigMapNamespace)
 
 		// Check the error
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.NotNil(t, builderResult)
@@ -464,7 +464,7 @@ func TestImageBasedUpgradeWithSeedImageVersion(t *testing.T) {
 			testCase.seedImageVersion)
 
 		// Check the error
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.NotNil(t, builderResult)
@@ -515,7 +515,7 @@ func TestImageBasedUpgradeWithSeedImagePullSecretRef(t *testing.T) {
 			testCase.pullSecretName)
 
 		// Check the error
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.NotNil(t, builderResult)
@@ -560,7 +560,7 @@ func TestImageBasedUpgradeWaitUntilStageComplete(t *testing.T) {
 			testCase.stage)
 
 		// Check the error
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.NotNil(t, builderResult)
@@ -611,7 +611,7 @@ func TestImageBasedUpgradeWithStage(t *testing.T) {
 			testCase.stage)
 
 		// Check the error
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.NotNil(t, builderResult)

--- a/pkg/lca/seedgenerator_test.go
+++ b/pkg/lca/seedgenerator_test.go
@@ -84,7 +84,7 @@ func TestSeedGeneratorCreate(t *testing.T) {
 
 	for _, testCase := range testCases {
 		testSeedGeneratorBuilder, err := testCase.seedGenerator.Create()
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.Equal(t, testSeedGeneratorBuilder.Definition.Name, testSeedGeneratorBuilder.Object.Name)
@@ -154,7 +154,7 @@ func TestSeedGeneratorPull(t *testing.T) {
 		builderResult, err := PullSeedGenerator(testSettings, testCase.name)
 
 		// Check the error
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.NotNil(t, builderResult)
@@ -184,7 +184,7 @@ func TestSeedGeneratorDelete(t *testing.T) {
 
 	for _, testCase := range testCases {
 		testSeedGeneratorBuilder, err := testCase.seedGenerator.Delete()
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.Nil(t, testSeedGeneratorBuilder.Object)
@@ -215,7 +215,7 @@ func TestSeedGeneratorGet(t *testing.T) {
 	for _, testCase := range testCases {
 		testSeedGenerator, err := testCase.seedGenerator.Get()
 		if err != nil {
-			assert.Equal(t, err.Error(), testCase.expectedError.Error())
+			assert.Equal(t, testCase.expectedError.Error(), err.Error())
 		}
 
 		if testCase.expectedError == nil {
@@ -246,7 +246,7 @@ func TestSeedGeneratorExists(t *testing.T) {
 
 	for _, testCase := range testCases {
 		exist := testCase.seedGenerator.Exists()
-		assert.Equal(t, exist, testCase.expectedStatus)
+		assert.Equal(t, testCase.expectedStatus, exist)
 	}
 }
 
@@ -334,7 +334,7 @@ func TestSeedGeneratorWaitUntilComplete(t *testing.T) {
 		_, err := testSeedGeneratorBuilder.WaitUntilComplete(time.Second * 1)
 
 		// Check the error
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 	}
 }
 

--- a/pkg/mco/machineconfiglist_test.go
+++ b/pkg/mco/machineconfiglist_test.go
@@ -50,7 +50,7 @@ func TestListMC(t *testing.T) {
 		}
 
 		mcBuilders, err := ListMC(testSettings, testCase.listOptions...)
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil && len(testCase.listOptions) == 0 {
 			assert.Equal(t, len(testCase.machineConfigs), len(mcBuilders))

--- a/pkg/mco/mcplist_test.go
+++ b/pkg/mco/mcplist_test.go
@@ -56,7 +56,7 @@ func TestListMCP(t *testing.T) {
 		}
 
 		mcBuilders, err := ListMCP(testSettings, testCase.listOptions...)
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil && len(testCase.listOptions) == 0 {
 			assert.Equal(t, len(testCase.mcPools), len(mcBuilders))

--- a/pkg/metallb/adresspool_test.go
+++ b/pkg/metallb/adresspool_test.go
@@ -164,7 +164,7 @@ func TestIPAddressPoolGet(t *testing.T) {
 
 	for _, testCase := range testCases {
 		ipAddressPool, err := testCase.testIPAddressPool.Get()
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.Equal(t, ipAddressPool.Name, testCase.testIPAddressPool.Definition.Name)
@@ -189,7 +189,7 @@ func TestIPAddressPoolExist(t *testing.T) {
 
 	for _, testCase := range testCases {
 		exist := testCase.testIPAddressPool.Exists()
-		assert.Equal(t, exist, testCase.expectedStatus)
+		assert.Equal(t, testCase.expectedStatus, exist)
 	}
 }
 
@@ -210,7 +210,7 @@ func TestIPAddressPoolCreate(t *testing.T) {
 
 	for _, testCase := range testCases {
 		ipAddressPoolBuilder, err := testCase.testIPAddressPool.Create()
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.Equal(t, ipAddressPoolBuilder.Definition, ipAddressPoolBuilder.Object)

--- a/pkg/metallb/bfdprofile_test.go
+++ b/pkg/metallb/bfdprofile_test.go
@@ -158,7 +158,7 @@ func TestBFDProfileGet(t *testing.T) {
 
 	for _, testCase := range testCases {
 		bfdProfile, err := testCase.testBFDProfile.Get()
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.Equal(t, bfdProfile.Name, testCase.testBFDProfile.Definition.Name)
@@ -183,7 +183,7 @@ func TestBFDProfileExist(t *testing.T) {
 
 	for _, testCase := range testCases {
 		exist := testCase.testBFDProfile.Exists()
-		assert.Equal(t, exist, testCase.expectedStatus)
+		assert.Equal(t, testCase.expectedStatus, exist)
 	}
 }
 
@@ -204,7 +204,7 @@ func TestBFDProfileCreate(t *testing.T) {
 
 	for _, testCase := range testCases {
 		BFDProfileBuilder, err := testCase.testBFDProfile.Create()
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.Equal(t, BFDProfileBuilder.Definition, BFDProfileBuilder.Object)

--- a/pkg/metallb/bgpadvertisement_test.go
+++ b/pkg/metallb/bgpadvertisement_test.go
@@ -179,7 +179,7 @@ func TestBGPAdvertisementGet(t *testing.T) {
 
 	for _, testCase := range testCases {
 		bgpAdvertisement, err := testCase.testBGPAdvertisement.Get()
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.Equal(t, bgpAdvertisement.Name, testCase.testBGPAdvertisement.Definition.Name)
@@ -203,7 +203,7 @@ func TestBGPAdvertisementCreate(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		bgpAdvertisement, err := testCase.testBGPAdvertisement.Create()
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.Equal(t, bgpAdvertisement.Definition, bgpAdvertisement.Object)

--- a/pkg/metallb/frr_test.go
+++ b/pkg/metallb/frr_test.go
@@ -91,7 +91,7 @@ func TestFrrConfigurationCreate(t *testing.T) {
 
 	for _, testCase := range testCases {
 		testFrrConfigBuilder, err := testCase.testFrrConfiguration.Create()
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.Equal(t, testFrrConfigBuilder.Definition.Name, testFrrConfigBuilder.Object.Name)
@@ -172,7 +172,7 @@ func TestFrrConfigurationExist(t *testing.T) {
 
 	for _, testCase := range testCases {
 		exist := testCase.testFrrConfiguration.Exists()
-		assert.Equal(t, exist, testCase.expectedStatus)
+		assert.Equal(t, testCase.expectedStatus, exist)
 	}
 }
 

--- a/pkg/metallb/l2advertisement_test.go
+++ b/pkg/metallb/l2advertisement_test.go
@@ -158,7 +158,7 @@ func TestL2AdvertisementExist(t *testing.T) {
 
 	for _, testCase := range testCases {
 		exist := testCase.testL2Advertisement.Exists()
-		assert.Equal(t, exist, testCase.expectedStatus)
+		assert.Equal(t, testCase.expectedStatus, exist)
 	}
 }
 
@@ -179,7 +179,7 @@ func TestL2AdvertisementGet(t *testing.T) {
 
 	for _, testCase := range testCases {
 		l2Advertisement, err := testCase.testL2Advertisement.Get()
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.Equal(t, l2Advertisement.Name, testCase.testL2Advertisement.Definition.Name)
@@ -204,7 +204,7 @@ func TestL2AdvertisementCreate(t *testing.T) {
 
 	for _, testCase := range testCases {
 		ipAddressPoolBuilder, err := testCase.testL2Advertisement.Create()
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.Equal(t, ipAddressPoolBuilder.Definition.Name, ipAddressPoolBuilder.Object.Name)

--- a/pkg/metallb/metallb_test.go
+++ b/pkg/metallb/metallb_test.go
@@ -172,7 +172,7 @@ func TestMetalLbExist(t *testing.T) {
 
 	for _, testCase := range testCases {
 		exist := testCase.testMetalLb.Exists()
-		assert.Equal(t, exist, testCase.expectedStatus)
+		assert.Equal(t, testCase.expectedStatus, exist)
 	}
 }
 
@@ -193,7 +193,7 @@ func TestMetalLbGet(t *testing.T) {
 
 	for _, testCase := range testCases {
 		metalLb, err := testCase.testMetalLb.Get()
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.Equal(t, metalLb.Name, testCase.testMetalLb.Definition.Name)
@@ -218,7 +218,7 @@ func TestMetalLbCreate(t *testing.T) {
 
 	for _, testCase := range testCases {
 		testMetalLbBuilder, err := testCase.testMetalLb.Create()
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.Equal(t, testMetalLbBuilder.Definition.Name, testMetalLbBuilder.Object.Name)

--- a/pkg/nad/builder_test.go
+++ b/pkg/nad/builder_test.go
@@ -161,7 +161,7 @@ func TestNADNewNetworkBuilder(t *testing.T) {
 		}
 
 		if len(testCase.expectedErrorText) > 0 {
-			assert.Equal(t, testNetworkStructure.errorMsg, testCase.expectedErrorText)
+			assert.Equal(t, testCase.expectedErrorText, testNetworkStructure.errorMsg)
 		}
 	}
 }
@@ -191,7 +191,7 @@ func TestNADGet(t *testing.T) {
 		if testCase.expectedError == nil {
 			assert.Equal(t, network.Name, testCase.networkBuilder.Definition.Name)
 		} else {
-			assert.Equal(t, err.Error(), testCase.expectedError.Error())
+			assert.Equal(t, testCase.expectedError.Error(), err.Error())
 		}
 	}
 }
@@ -217,7 +217,7 @@ func TestNADCreate(t *testing.T) {
 
 	for _, testCase := range testCases {
 		netBuilder, err := testCase.testNetwork.Create()
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.Equal(t, netBuilder.Definition, netBuilder.Object)
@@ -341,7 +341,7 @@ func TestNADWithMasterPlugin(t *testing.T) {
 
 	for _, testCase := range testCases {
 		builder := testCase.testNetwork.WithMasterPlugin(testCase.plugin)
-		assert.Equal(t, builder.errorMsg, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, builder.errorMsg)
 
 		if testCase.expectedError == "" {
 			assert.Contains(t, builder.Definition.Spec.Config, testCase.plugin.Name)
@@ -371,7 +371,7 @@ func TestNADWithPlugins(t *testing.T) {
 
 	for _, testCase := range testCases {
 		builder := testCase.testNetwork.WithPlugins(testCase.name, &testCase.plugins)
-		assert.Equal(t, builder.errorMsg, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, builder.errorMsg)
 
 		if testCase.expectedError == "" {
 			for _, plugin := range testCase.plugins {
@@ -402,7 +402,7 @@ func TestNADGetString(t *testing.T) {
 
 	for _, testCase := range testCases {
 		testNetworkString, err := testCase.testNetwork.GetString()
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.NotEmpty(t, testNetworkString)

--- a/pkg/networkpolicy/networkpolicy_test.go
+++ b/pkg/networkpolicy/networkpolicy_test.go
@@ -514,7 +514,7 @@ func TestNewNetworkPolicyBuilder(t *testing.T) {
 		}), testCase.testName, testCase.testNamespace)
 
 		if testCase.expectedError {
-			assert.Equal(t, testNBP.errorMsg, testCase.expectedErrorText)
+			assert.Equal(t, testCase.expectedErrorText, testNBP.errorMsg)
 		} else {
 			assert.NotNil(t, testNBP)
 		}

--- a/pkg/nfd/nodefeaturediscovery_test.go
+++ b/pkg/nfd/nodefeaturediscovery_test.go
@@ -182,7 +182,7 @@ func TestNFDGet(t *testing.T) {
 		if testCase.expectedError == nil {
 			assert.NotNil(t, nfd)
 		} else {
-			assert.Equal(t, err.Error(), testCase.expectedError.Error())
+			assert.Equal(t, testCase.expectedError.Error(), err.Error())
 		}
 	}
 }
@@ -209,7 +209,7 @@ func TestNFDExist(t *testing.T) {
 
 	for _, testCase := range testCases {
 		exist := testCase.nfd.Exists()
-		assert.Equal(t, exist, testCase.expectedStatus)
+		assert.Equal(t, testCase.expectedStatus, exist)
 	}
 }
 
@@ -261,7 +261,7 @@ func TestNFDCreate(t *testing.T) {
 
 	for _, testCase := range testCases {
 		clusterPolicyBuilder, err := testCase.clusterPolicy.Create()
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.Equal(t, clusterPolicyBuilder.Definition.Name, clusterPolicyBuilder.Object.Name)

--- a/pkg/nmstate/list_test.go
+++ b/pkg/nmstate/list_test.go
@@ -68,7 +68,7 @@ func TestListPolicy(t *testing.T) {
 		}
 
 		netBuilders, err := ListPolicy(testSettings, testCase.listOptions...)
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil && len(testCase.listOptions) == 0 {
 			assert.Equal(t, len(netBuilders), len(testCase.testPolicy))
@@ -134,9 +134,9 @@ func TestCleanAllNMStatePolicies(t *testing.T) {
 		}
 
 		err := CleanAllNMStatePolicies(testSettings, testCase.listOptions...)
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 		netBuilders, err := ListPolicy(testSettings, testCase.listOptions...)
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 		assert.Equal(t, len(netBuilders), 0)
 	}
 }

--- a/pkg/nmstate/nmstate_test.go
+++ b/pkg/nmstate/nmstate_test.go
@@ -141,7 +141,7 @@ func TestNMStateNewBuilder(t *testing.T) {
 		}
 
 		if len(testCase.expectedErrorText) > 0 {
-			assert.Equal(t, testNMState.errorMsg, testCase.expectedErrorText)
+			assert.Equal(t, testCase.expectedErrorText, testNMState.errorMsg)
 		}
 	}
 }
@@ -168,9 +168,9 @@ func TestNMStateGet(t *testing.T) {
 	for _, testCase := range testCases {
 		nmState, err := testCase.nmStateBuilder.Get()
 		if testCase.expectedError != nil {
-			assert.Equal(t, err.Error(), testCase.expectedError.Error())
+			assert.Equal(t, testCase.expectedError.Error(), err.Error())
 		} else {
-			assert.Equal(t, err, testCase.expectedError)
+			assert.Equal(t, testCase.expectedError, err)
 		}
 
 		if testCase.expectedError == nil {
@@ -200,7 +200,7 @@ func TestNMStateCreate(t *testing.T) {
 
 	for _, testCase := range testCases {
 		nmStateBuilder, err := testCase.testNMState.Create()
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.Equal(t, nmStateBuilder.Definition.Name, nmStateBuilder.Object.Name)

--- a/pkg/nmstate/nodenetworkstate_test.go
+++ b/pkg/nmstate/nodenetworkstate_test.go
@@ -123,9 +123,9 @@ func TestStateBuilderGet(t *testing.T) {
 	for _, testCase := range testCases {
 		nodeNetState, err := testCase.nodeNetStateBuilder.Get()
 		if testCase.expectedError != nil {
-			assert.Equal(t, err.Error(), testCase.expectedError.Error())
+			assert.Equal(t, testCase.expectedError.Error(), err.Error())
 		} else {
-			assert.Equal(t, err, testCase.expectedError)
+			assert.Equal(t, testCase.expectedError, err)
 		}
 
 		if testCase.expectedError == nil {
@@ -184,7 +184,7 @@ func TestStateBuilderGetTotalVFs(t *testing.T) {
 
 	for _, testCase := range testCases {
 		vfsNumber, err := testCase.testNodeNetState.GetTotalVFs(testCase.sriovInterfaceName)
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 		assert.Equal(t, vfsNumber, testCase.vfsNumber)
 	}
 }
@@ -224,7 +224,7 @@ func TestStateBuilderGetInterfaceType(t *testing.T) {
 
 	for _, testCase := range testCases {
 		networkInterface, err := testCase.testNodeNetState.GetInterfaceType(testCase.interfaceName, testCase.interfaceType)
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.Equal(t, networkInterface.Name, testCase.interfaceName)
@@ -260,7 +260,7 @@ func TestStateBuilderGetSriovVfs(t *testing.T) {
 
 	for _, testCase := range testCases {
 		vfsList, err := testCase.testNodeNetState.GetSriovVfs(testCase.interfaceName)
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.Equal(t, testCase.vfsInUse, len(vfsList))

--- a/pkg/nmstate/policy_test.go
+++ b/pkg/nmstate/policy_test.go
@@ -67,7 +67,7 @@ func TestNewPolicyBuilder(t *testing.T) {
 		}
 
 		if len(testCase.expectedErrorText) > 0 {
-			assert.Equal(t, testPolicy.errorMsg, testCase.expectedErrorText)
+			assert.Equal(t, testCase.expectedErrorText, testPolicy.errorMsg)
 		}
 	}
 }
@@ -94,9 +94,9 @@ func TestPolicyGet(t *testing.T) {
 	for _, testCase := range testCases {
 		policyBuilder, err := testCase.policyBuilder.Get()
 		if testCase.expectedError != nil {
-			assert.Equal(t, err.Error(), testCase.expectedError.Error())
+			assert.Equal(t, testCase.expectedError.Error(), err.Error())
 		} else {
-			assert.Equal(t, err, testCase.expectedError)
+			assert.Equal(t, testCase.expectedError, err)
 		}
 
 		if testCase.expectedError == nil {
@@ -150,7 +150,7 @@ func TestPolicyCreate(t *testing.T) {
 
 	for _, testCase := range testCases {
 		nmStatePolicyBuilder, err := testCase.testPolicy.Create()
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.Equal(t, nmStatePolicyBuilder.Definition.Name, nmStatePolicyBuilder.Object.Name)
@@ -251,7 +251,7 @@ func TestPolicyWithInterfaceAndVFs(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		testPolicy := testCase.testNMStatePolicy.WithInterfaceAndVFs(testCase.sriovInterface, testCase.numberOfVF)
-		assert.Equal(t, testPolicy.errorMsg, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, testPolicy.errorMsg)
 		numberOfVFs := int(testCase.numberOfVF)
 		desireState := &DesiredState{}
 
@@ -307,7 +307,7 @@ func TestPolicyWithWithBondInterface(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		testPolicy := testCase.testNMStatePolicy.WithBondInterface(testCase.slavePorts, testCase.bondName, testCase.mode)
-		assert.Equal(t, testPolicy.errorMsg, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, testPolicy.errorMsg)
 
 		desireState := &DesiredState{}
 		if testCase.expectedError == "" {
@@ -357,7 +357,7 @@ func TestPolicyWithVlanInterface(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		testPolicy := testCase.testNMStatePolicy.WithVlanInterface(testCase.sriovInterface, testCase.vlanID)
-		assert.Equal(t, testPolicy.errorMsg, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, testPolicy.errorMsg)
 
 		desireState := &DesiredState{}
 		if testCase.expectedError == "" {
@@ -398,7 +398,7 @@ func TestPolicyWithAbsentInterface(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		testPolicy := testCase.testNMStatePolicy.WithAbsentInterface(testCase.baseInterface)
-		assert.Equal(t, testPolicy.errorMsg, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, testPolicy.errorMsg)
 
 		desireState := &DesiredState{}
 		if testCase.expectedError == "" {
@@ -449,7 +449,7 @@ func TestPolicyWaitUntilCondition(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		err := testCase.testNMStatePolicy.WaitUntilCondition(testCase.condition, 2*time.Second)
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 	}
 }
 

--- a/pkg/nodes/list_test.go
+++ b/pkg/nodes/list_test.go
@@ -54,7 +54,7 @@ func TestNodesList(t *testing.T) {
 		}
 
 		nodeBuilders, err := List(testSettings, testCase.listOptions...)
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil && len(testCase.listOptions) == 0 {
 			assert.Equal(t, len(nodeBuilders), len(testCase.nodes))

--- a/pkg/nodesconfig/nodesconfig_test.go
+++ b/pkg/nodesconfig/nodesconfig_test.go
@@ -120,7 +120,7 @@ func TestNodeConfigExist(t *testing.T) {
 
 	for _, testCase := range testCases {
 		exist := testCase.testNodesConfig.Exists()
-		assert.Equal(t, exist, testCase.expectedStatus)
+		assert.Equal(t, testCase.expectedStatus, exist)
 	}
 }
 
@@ -145,7 +145,7 @@ func TestNodesConfigGet(t *testing.T) {
 
 	for _, testCase := range testCases {
 		nodesConfigObj, err := testCase.testNodesConfig.Get()
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.Equal(t, nodesConfigObj, testCase.testNodesConfig.Definition)

--- a/pkg/nvidiagpu/clusterpolicy_test.go
+++ b/pkg/nvidiagpu/clusterpolicy_test.go
@@ -174,7 +174,7 @@ func TestNvidiaGPUGet(t *testing.T) {
 	for _, testCase := range testCases {
 		clusterPolicy, err := testCase.clusterPolicy.Get()
 		if testCase.expectedError != nil {
-			assert.Equal(t, err.Error(), testCase.expectedError.Error())
+			assert.Equal(t, testCase.expectedError.Error(), err.Error())
 		}
 
 		if testCase.expectedError == nil {
@@ -205,7 +205,7 @@ func TestNvidiaGPUExist(t *testing.T) {
 
 	for _, testCase := range testCases {
 		exist := testCase.clusterPolicy.Exists()
-		assert.Equal(t, exist, testCase.expectedStatus)
+		assert.Equal(t, testCase.expectedStatus, exist)
 	}
 }
 
@@ -257,7 +257,7 @@ func TestNvidiaGPUCreate(t *testing.T) {
 
 	for _, testCase := range testCases {
 		clusterPolicyBuilder, err := testCase.clusterPolicy.Create()
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.Equal(t, clusterPolicyBuilder.Definition.Name, clusterPolicyBuilder.Object.Name)

--- a/pkg/oadp/dataprotectionapplication_test.go
+++ b/pkg/oadp/dataprotectionapplication_test.go
@@ -181,7 +181,7 @@ func TestPullDPA(t *testing.T) {
 		}
 
 		testBuilder, err := PullDPA(testSettings, testCase.name, testCase.namespace)
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError != nil {
 			assert.Nil(t, testBuilder)

--- a/pkg/oauth/oauthclient_test.go
+++ b/pkg/oauth/oauthclient_test.go
@@ -64,7 +64,7 @@ func TestOAuthClientPull(t *testing.T) {
 		builderResult, err := PullOAuthClient(testSettings, testCase.oauthTestClientName)
 
 		// Check the error
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.NotNil(t, builderResult)
@@ -110,7 +110,7 @@ func TestOAuthClientUpdate(t *testing.T) {
 		// Test the Update function
 		builderResult, err := oauthClientBuilder.Update()
 
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		// Validate that the resource was updated
 		if testCase.expectedError == nil {
@@ -247,7 +247,7 @@ func TestOAuthClientGet(t *testing.T) {
 		builderResult, err := oauthClientBuilder.Get()
 
 		// Check the error
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.NotNil(t, builderResult)

--- a/pkg/ocm/placementbindinglist_test.go
+++ b/pkg/ocm/placementbindinglist_test.go
@@ -62,7 +62,7 @@ func TestListPlacementBindingsInAllNamespaces(t *testing.T) {
 		}
 
 		builders, err := ListPlacementBindingsInAllNamespaces(testSettings, testCase.listOptions...)
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil && len(testCase.listOptions) == 0 {
 			assert.Equal(t, len(testCase.placementBindings), len(builders))

--- a/pkg/ocm/placementrulelist_test.go
+++ b/pkg/ocm/placementrulelist_test.go
@@ -62,7 +62,7 @@ func TestListPlacementrulesInAllNamespaces(t *testing.T) {
 		}
 
 		builders, err := ListPlacementrulesInAllNamespaces(testSettings, testCase.listOptions...)
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil && len(testCase.listOptions) == 0 {
 			assert.Equal(t, len(testCase.placementRules), len(builders))

--- a/pkg/ocm/policy_test.go
+++ b/pkg/ocm/policy_test.go
@@ -356,7 +356,7 @@ func TestWithRemediationAction(t *testing.T) {
 	for _, testCase := range testCases {
 		testSettings := buildTestClientWithPolicyScheme()
 		policyBuilder := buildValidPolicyTestBuilder(testSettings).WithRemediationAction(testCase.action)
-		assert.Equal(t, policyBuilder.errorMsg, testCase.expectedErrorText)
+		assert.Equal(t, testCase.expectedErrorText, policyBuilder.errorMsg)
 
 		if testCase.expectedErrorText == "" {
 			assert.Equal(t, testCase.action, policyBuilder.Definition.Spec.RemediationAction)

--- a/pkg/ocm/policylist_test.go
+++ b/pkg/ocm/policylist_test.go
@@ -62,7 +62,7 @@ func TestListPoliciesInAllNamespaces(t *testing.T) {
 		}
 
 		builders, err := ListPoliciesInAllNamespaces(testSettings, testCase.listOptions...)
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil && len(testCase.listOptions) == 0 {
 			assert.Equal(t, len(testCase.policies), len(builders))

--- a/pkg/ocm/policysetlist_test.go
+++ b/pkg/ocm/policysetlist_test.go
@@ -62,7 +62,7 @@ func TestListPolicieSetsInAllNamespaces(t *testing.T) {
 		}
 
 		builders, err := ListPolicieSetsInAllNamespaces(testSettings, testCase.listOptions...)
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil && len(testCase.listOptions) == 0 {
 			assert.Equal(t, len(testCase.policySets), len(builders))

--- a/pkg/olm/catalogsource_test.go
+++ b/pkg/olm/catalogsource_test.go
@@ -184,7 +184,7 @@ func TestCatalogSourceGet(t *testing.T) {
 			assert.Nil(t, err)
 			assert.Equal(t, catalogSource.Name, testCase.catalogSource.Definition.Name)
 		} else {
-			assert.Equal(t, err.Error(), testCase.expectedError)
+			assert.Equal(t, testCase.expectedError, err.Error())
 		}
 	}
 }
@@ -211,7 +211,7 @@ func TestCatalogSourceExist(t *testing.T) {
 
 	for _, testCase := range testCases {
 		exist := testCase.catalogSource.Exists()
-		assert.Equal(t, exist, testCase.expectedStatus)
+		assert.Equal(t, testCase.expectedStatus, exist)
 	}
 }
 
@@ -237,7 +237,7 @@ func TestCatalogSourceCreate(t *testing.T) {
 
 	for _, testCase := range testCases {
 		catalogSourceBuilder, err := testCase.catalogSource.Create()
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.Equal(t, catalogSourceBuilder.Definition.Name, catalogSourceBuilder.Object.Name)

--- a/pkg/olm/clusterserviceversion_test.go
+++ b/pkg/olm/clusterserviceversion_test.go
@@ -119,7 +119,7 @@ func TestClusterServiceVersionGet(t *testing.T) {
 			assert.Nil(t, err)
 			assert.Equal(t, clusterService.Name, testCase.clusterService.Definition.Name)
 		} else {
-			assert.Equal(t, err.Error(), testCase.expectedError)
+			assert.Equal(t, testCase.expectedError, err.Error())
 		}
 	}
 }
@@ -142,7 +142,7 @@ func TestClusterServiceVersionExist(t *testing.T) {
 
 	for _, testCase := range testCases {
 		exist := testCase.clusterService.Exists()
-		assert.Equal(t, exist, testCase.expectedStatus)
+		assert.Equal(t, testCase.expectedStatus, exist)
 	}
 }
 

--- a/pkg/olm/installplan_test.go
+++ b/pkg/olm/installplan_test.go
@@ -179,7 +179,7 @@ func TestInstallPlanGet(t *testing.T) {
 			assert.Nil(t, err)
 			assert.Equal(t, installPlan.Name, testCase.installPlan.Definition.Name)
 		} else {
-			assert.Equal(t, err.Error(), testCase.expectedError)
+			assert.Equal(t, testCase.expectedError, err.Error())
 		}
 	}
 }
@@ -206,7 +206,7 @@ func TestInstallPlanExist(t *testing.T) {
 
 	for _, testCase := range testCases {
 		exist := testCase.installPlan.Exists()
-		assert.Equal(t, exist, testCase.expectedStatus)
+		assert.Equal(t, testCase.expectedStatus, exist)
 	}
 }
 
@@ -232,7 +232,7 @@ func TestInstallPlanCreate(t *testing.T) {
 
 	for _, testCase := range testCases {
 		installPlanBuilder, err := testCase.installPlan.Create()
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.Equal(t, installPlanBuilder.Definition.Name, installPlanBuilder.Object.Name)

--- a/pkg/olm/list_test.go
+++ b/pkg/olm/list_test.go
@@ -62,7 +62,7 @@ func TestListCatalogSources(t *testing.T) {
 		}
 
 		netBuilders, err := ListCatalogSources(testSettings, testCase.nsName, testCase.listOptions...)
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil && len(testCase.listOptions) == 0 {
 			assert.Equal(t, len(netBuilders), len(testCase.catalogSource))
@@ -128,7 +128,7 @@ func TestListClusterServiceVersion(t *testing.T) {
 		}
 
 		netBuilders, err := ListClusterServiceVersion(testSettings, testCase.nsName, testCase.listOptions...)
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil && len(testCase.listOptions) == 0 {
 			assert.Equal(t, len(netBuilders), len(testCase.clusterVersion))
@@ -209,7 +209,7 @@ func TestListClusterServiceVersionWithNamePattern(t *testing.T) {
 
 		netBuilders, err := ListClusterServiceVersionWithNamePattern(
 			testSettings, testCase.namePattern, testCase.nsName, testCase.listOptions...)
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil && len(testCase.listOptions) == 0 {
 			assert.Equal(t, len(netBuilders), len(testCase.clusterVersion))
@@ -263,7 +263,7 @@ func TestListClusterServiceVersionInAllNamespaces(t *testing.T) {
 		}
 
 		netBuilders, err := ListClusterServiceVersionInAllNamespaces(testSettings, testCase.listOptions...)
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil && len(testCase.listOptions) == 0 {
 			assert.Equal(t, len(netBuilders), len(testCase.clusterVersion))
@@ -329,7 +329,7 @@ func TestListInstallPlan(t *testing.T) {
 		}
 
 		netBuilders, err := ListInstallPlan(testSettings, testCase.nsName, testCase.listOptions...)
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil && len(testCase.listOptions) == 0 {
 			assert.Equal(t, len(netBuilders), len(testCase.installPlan))
@@ -395,7 +395,7 @@ func TestListPackageManifest(t *testing.T) {
 		}
 
 		packageManifests, err := ListPackageManifest(testSettings, testCase.nsName, testCase.listOptions...)
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil && len(testCase.listOptions) == 0 {
 			assert.Equal(t, len(packageManifests), len(testCase.packageManifest))

--- a/pkg/olm/operatorgroup_test.go
+++ b/pkg/olm/operatorgroup_test.go
@@ -185,7 +185,7 @@ func TestOperatorGroupGet(t *testing.T) {
 			assert.Nil(t, err)
 			assert.Equal(t, operatorGroup.Name, testCase.operatorGroup.Definition.Name)
 		} else {
-			assert.Equal(t, err.Error(), testCase.expectedError)
+			assert.Equal(t, testCase.expectedError, err.Error())
 		}
 	}
 }
@@ -212,7 +212,7 @@ func TestOperatorGroupExist(t *testing.T) {
 
 	for _, testCase := range testCases {
 		exist := testCase.operatorGroup.Exists()
-		assert.Equal(t, exist, testCase.expectedStatus)
+		assert.Equal(t, testCase.expectedStatus, exist)
 	}
 }
 
@@ -238,7 +238,7 @@ func TestOperatorGroupCreate(t *testing.T) {
 
 	for _, testCase := range testCases {
 		operatorGroupBuilder, err := testCase.operatorGroup.Create()
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.Equal(t, operatorGroupBuilder.Definition.Name, operatorGroupBuilder.Object.Name)

--- a/pkg/olm/packagemanifest_test.go
+++ b/pkg/olm/packagemanifest_test.go
@@ -219,7 +219,7 @@ func TestPackageManifestGet(t *testing.T) {
 			assert.Nil(t, err)
 			assert.Equal(t, packageManifest.Name, testCase.packageManifest.Definition.Name)
 		} else {
-			assert.Equal(t, err.Error(), testCase.expectedError)
+			assert.Equal(t, testCase.expectedError, err.Error())
 		}
 	}
 }
@@ -242,7 +242,7 @@ func TestPackageManifestExist(t *testing.T) {
 
 	for _, testCase := range testCases {
 		exist := testCase.packageManifest.Exists()
-		assert.Equal(t, exist, testCase.expectedStatus)
+		assert.Equal(t, testCase.expectedStatus, exist)
 	}
 }
 

--- a/pkg/olm/subscription_test.go
+++ b/pkg/olm/subscription_test.go
@@ -226,7 +226,7 @@ func TestSubscriptionGet(t *testing.T) {
 			assert.Nil(t, err)
 			assert.Equal(t, subscription.Name, testCase.subscription.Definition.Name)
 		} else {
-			assert.Equal(t, err.Error(), testCase.expectedError)
+			assert.Equal(t, testCase.expectedError, err.Error())
 		}
 	}
 }
@@ -249,7 +249,7 @@ func TestSubscriptionExist(t *testing.T) {
 
 	for _, testCase := range testCases {
 		exist := testCase.subscription.Exists()
-		assert.Equal(t, exist, testCase.expectedStatus)
+		assert.Equal(t, testCase.expectedStatus, exist)
 	}
 }
 
@@ -333,7 +333,7 @@ func TestSubscriptionCreate(t *testing.T) {
 
 	for _, testCase := range testCases {
 		catalogSourceBuilder, err := testCase.subscription.Create()
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.Equal(t, catalogSourceBuilder.Definition.Name, catalogSourceBuilder.Object.Name)
@@ -359,7 +359,7 @@ func TestSubscriptionWithChannel(t *testing.T) {
 	for _, testCase := range testCases {
 		testSettings := buildTestSubscriptionClientWithDummyObject()
 		subscriptionBuilder := buildValidSubscriptionBuilder(testSettings).WithChannel(testCase.channel)
-		assert.Equal(t, subscriptionBuilder.errorMsg, testCase.expectedErrorText)
+		assert.Equal(t, testCase.expectedErrorText, subscriptionBuilder.errorMsg)
 
 		if testCase.expectedErrorText == "" {
 			assert.Equal(t, subscriptionBuilder.Definition.Spec.Channel, testCase.channel)
@@ -385,7 +385,7 @@ func TestSubscriptionWithStartingCSV(t *testing.T) {
 	for _, testCase := range testCases {
 		testSettings := buildTestSubscriptionClientWithDummyObject()
 		subscriptionBuilder := buildValidSubscriptionBuilder(testSettings).WithStartingCSV(testCase.csv)
-		assert.Equal(t, subscriptionBuilder.errorMsg, testCase.expectedErrorText)
+		assert.Equal(t, testCase.expectedErrorText, subscriptionBuilder.errorMsg)
 
 		if testCase.expectedErrorText == "" {
 			assert.Equal(t, subscriptionBuilder.Definition.Spec.StartingCSV, testCase.csv)
@@ -411,7 +411,7 @@ func TestSubscriptionWithInstallPlanApproval(t *testing.T) {
 	for _, testCase := range testCases {
 		testSettings := buildTestSubscriptionClientWithDummyObject()
 		subscriptionBuilder := buildValidSubscriptionBuilder(testSettings).WithInstallPlanApproval(testCase.installPlan)
-		assert.Equal(t, subscriptionBuilder.errorMsg, testCase.expectedErrorText)
+		assert.Equal(t, testCase.expectedErrorText, subscriptionBuilder.errorMsg)
 
 		if testCase.expectedErrorText == "" {
 			assert.Equal(t, subscriptionBuilder.Definition.Spec.InstallPlanApproval, testCase.installPlan)

--- a/pkg/pod/network_test.go
+++ b/pkg/pod/network_test.go
@@ -454,7 +454,7 @@ func TestPodNetworkStaticIPMultiNetDualStackAnnotation(t *testing.T) {
 		if testCase.expectedError == nil {
 			assert.NotNil(t, annotation)
 		} else {
-			assert.Equal(t, err, testCase.expectedError)
+			assert.Equal(t, testCase.expectedError, err)
 		}
 	}
 }

--- a/pkg/rbac/clusterrole_test.go
+++ b/pkg/rbac/clusterrole_test.go
@@ -63,7 +63,7 @@ func TestNewClusterRoleBuilder(t *testing.T) {
 		}
 
 		if len(testCase.expectedErrorText) > 0 {
-			assert.Equal(t, testClusterRole.errorMsg, testCase.expectedErrorText)
+			assert.Equal(t, testCase.expectedErrorText, testClusterRole.errorMsg)
 		}
 	}
 }
@@ -168,7 +168,7 @@ func TestClusterRoleCreate(t *testing.T) {
 
 	for _, testCase := range testCases {
 		clusterRoleBuilder, err := testCase.testClusterRole.Create()
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.Equal(t, clusterRoleBuilder.Definition.Name, clusterRoleBuilder.Object.Name)

--- a/pkg/rbac/role_test.go
+++ b/pkg/rbac/role_test.go
@@ -81,7 +81,7 @@ func TestNewRoleBuilder(t *testing.T) {
 		}
 
 		if len(testCase.expectedErrorText) > 0 {
-			assert.Equal(t, testPolicy.errorMsg, testCase.expectedErrorText)
+			assert.Equal(t, testCase.expectedErrorText, testPolicy.errorMsg)
 		}
 	}
 }
@@ -200,7 +200,7 @@ func TestRoleCreate(t *testing.T) {
 
 	for _, testCase := range testCases {
 		roleBuilder, err := testCase.testRole.Create()
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.Equal(t, roleBuilder.Definition.Name, roleBuilder.Object.Name)

--- a/pkg/route/route_test.go
+++ b/pkg/route/route_test.go
@@ -48,7 +48,7 @@ func TestNewBuilder(t *testing.T) {
 	for _, test := range testcases {
 		testBuilder := NewBuilder(clients.GetTestClients(clients.TestClientParams{}),
 			test.name, test.namespace, test.targetService)
-		assert.Equal(t, testBuilder.errorMsg, test.expectedErrMsg)
+		assert.Equal(t, test.expectedErrMsg, testBuilder.errorMsg)
 	}
 }
 

--- a/pkg/scc/scc_test.go
+++ b/pkg/scc/scc_test.go
@@ -54,7 +54,7 @@ func TestSCCNewBuilder(t *testing.T) {
 	for _, testCase := range testCases {
 		testBuilder := NewBuilder(
 			clients.GetTestClients(clients.TestClientParams{}), testCase.name, testCase.user, testCase.seLinuxContent)
-		assert.Equal(t, testBuilder.errorMsg, testCase.expectedErrMsg)
+		assert.Equal(t, testCase.expectedErrMsg, testBuilder.errorMsg)
 	}
 }
 
@@ -154,7 +154,7 @@ func TestSCCGet(t *testing.T) {
 			assert.Nil(t, err)
 			assert.Equal(t, scc.Name, testCase.sccBuilder.Definition.Name)
 		} else {
-			assert.Equal(t, err.Error(), testCase.expectedError)
+			assert.Equal(t, testCase.expectedError, err.Error())
 		}
 	}
 }
@@ -181,7 +181,7 @@ func TestSCCExist(t *testing.T) {
 
 	for _, testCase := range testCases {
 		exist := testCase.sccBuilder.Exists()
-		assert.Equal(t, exist, testCase.expectedStatus)
+		assert.Equal(t, testCase.expectedStatus, exist)
 	}
 }
 
@@ -207,7 +207,7 @@ func TestSCCCreate(t *testing.T) {
 
 	for _, testCase := range testCases {
 		sccBuilder, err := testCase.testSCC.Create()
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.Equal(t, testCase.testSCC.Definition.Name, sccBuilder.Object.Name)
@@ -309,7 +309,7 @@ func TestSCCWithPrivilegedContainer(t *testing.T) {
 
 	for _, testCase := range testCases {
 		testCase.sccBuilder.WithPrivilegedContainer(testCase.allowPrivileged)
-		assert.Equal(t, testCase.sccBuilder.errorMsg, testCase.expectedErrorText)
+		assert.Equal(t, testCase.expectedErrorText, testCase.sccBuilder.errorMsg)
 
 		if testCase.expectedErrorText == "" {
 			assert.Equal(t, testCase.sccBuilder.Definition.AllowPrivilegedContainer, testCase.allowPrivileged)
@@ -342,7 +342,7 @@ func TestSCCWithPrivilegedEscalation(t *testing.T) {
 
 	for _, testCase := range testCases {
 		testCase.sccBuilder.WithPrivilegedEscalation(testCase.allowEscalation)
-		assert.Equal(t, testCase.sccBuilder.errorMsg, testCase.expectedErrorText)
+		assert.Equal(t, testCase.expectedErrorText, testCase.sccBuilder.errorMsg)
 
 		if testCase.expectedErrorText == "" {
 			assert.Equal(t, testCase.sccBuilder.Definition.DefaultAllowPrivilegeEscalation, &testCase.allowEscalation)
@@ -375,7 +375,7 @@ func TestSCCWithHostDirVolumePlugin(t *testing.T) {
 
 	for _, testCase := range testCases {
 		testCase.sccBuilder.WithHostDirVolumePlugin(testCase.allowPlugin)
-		assert.Equal(t, testCase.sccBuilder.errorMsg, testCase.expectedErrorText)
+		assert.Equal(t, testCase.expectedErrorText, testCase.sccBuilder.errorMsg)
 
 		if testCase.expectedErrorText == "" {
 			assert.Equal(t, testCase.sccBuilder.Definition.AllowHostDirVolumePlugin, testCase.allowPlugin)
@@ -408,7 +408,7 @@ func TestSCCWithHostIPC(t *testing.T) {
 
 	for _, testCase := range testCases {
 		testCase.sccBuilder.WithHostIPC(testCase.allowHostIPC)
-		assert.Equal(t, testCase.sccBuilder.errorMsg, testCase.expectedErrorText)
+		assert.Equal(t, testCase.expectedErrorText, testCase.sccBuilder.errorMsg)
 
 		if testCase.expectedErrorText == "" {
 			assert.Equal(t, testCase.sccBuilder.Definition.AllowHostIPC, testCase.allowHostIPC)
@@ -441,7 +441,7 @@ func TestSCCWithHostNetwork(t *testing.T) {
 
 	for _, testCase := range testCases {
 		testCase.sccBuilder.WithHostNetwork(testCase.allowHostNet)
-		assert.Equal(t, testCase.sccBuilder.errorMsg, testCase.expectedErrorText)
+		assert.Equal(t, testCase.expectedErrorText, testCase.sccBuilder.errorMsg)
 
 		if testCase.expectedErrorText == "" {
 			assert.Equal(t, testCase.sccBuilder.Definition.AllowHostNetwork, testCase.allowHostNet)
@@ -474,7 +474,7 @@ func TestSCCWithHostPID(t *testing.T) {
 
 	for _, testCase := range testCases {
 		testCase.sccBuilder.WithHostPID(testCase.allowHostPID)
-		assert.Equal(t, testCase.sccBuilder.errorMsg, testCase.expectedErrorText)
+		assert.Equal(t, testCase.expectedErrorText, testCase.sccBuilder.errorMsg)
 
 		if testCase.expectedErrorText == "" {
 			assert.Equal(t, testCase.sccBuilder.Definition.AllowHostPID, testCase.allowHostPID)
@@ -507,7 +507,7 @@ func TestSCCWithHostPorts(t *testing.T) {
 
 	for _, testCase := range testCases {
 		testCase.sccBuilder.WithHostPorts(testCase.allowHostPorts)
-		assert.Equal(t, testCase.sccBuilder.errorMsg, testCase.expectedErrorText)
+		assert.Equal(t, testCase.expectedErrorText, testCase.sccBuilder.errorMsg)
 
 		if testCase.expectedErrorText == "" {
 			assert.Equal(t, testCase.sccBuilder.Definition.AllowHostPorts, testCase.allowHostPorts)
@@ -540,7 +540,7 @@ func TestSCCWithReadOnlyRootFilesystem(t *testing.T) {
 
 	for _, testCase := range testCases {
 		testCase.sccBuilder.WithReadOnlyRootFilesystem(testCase.readOnlyFS)
-		assert.Equal(t, testCase.sccBuilder.errorMsg, testCase.expectedErrorText)
+		assert.Equal(t, testCase.expectedErrorText, testCase.sccBuilder.errorMsg)
 
 		if testCase.expectedErrorText == "" {
 			assert.Equal(t, testCase.sccBuilder.Definition.ReadOnlyRootFilesystem, testCase.readOnlyFS)
@@ -573,7 +573,7 @@ func TestSCCWithDropCapabilities(t *testing.T) {
 
 	for _, testCase := range testCases {
 		testCase.sccBuilder.WithDropCapabilities(testCase.dropCapability)
-		assert.Equal(t, testCase.sccBuilder.errorMsg, testCase.expectedErrorText)
+		assert.Equal(t, testCase.expectedErrorText, testCase.sccBuilder.errorMsg)
 
 		if testCase.expectedErrorText == "" {
 			assert.Equal(t, testCase.sccBuilder.Definition.RequiredDropCapabilities, testCase.dropCapability)
@@ -606,7 +606,7 @@ func TestSCCWithAllowCapabilities(t *testing.T) {
 
 	for _, testCase := range testCases {
 		testCase.sccBuilder.WithAllowCapabilities(testCase.allowCapability)
-		assert.Equal(t, testCase.sccBuilder.errorMsg, testCase.expectedErrorText)
+		assert.Equal(t, testCase.expectedErrorText, testCase.sccBuilder.errorMsg)
 
 		if testCase.expectedErrorText == "" {
 			assert.Equal(t, testCase.sccBuilder.Definition.AllowedCapabilities, testCase.allowCapability)
@@ -639,7 +639,7 @@ func TestSCCWithDefaultAddCapabilities(t *testing.T) {
 
 	for _, testCase := range testCases {
 		testCase.sccBuilder.WithDefaultAddCapabilities(testCase.defaultAddCapability)
-		assert.Equal(t, testCase.sccBuilder.errorMsg, testCase.expectedErrorText)
+		assert.Equal(t, testCase.expectedErrorText, testCase.sccBuilder.errorMsg)
 
 		if testCase.expectedErrorText == "" {
 			assert.Equal(t, testCase.sccBuilder.Definition.DefaultAddCapabilities, testCase.defaultAddCapability)
@@ -667,7 +667,7 @@ func TestSCCWithPriority(t *testing.T) {
 
 	for _, testCase := range testCases {
 		testCase.sccBuilder.WithPriority(&testCase.priority)
-		assert.Equal(t, testCase.sccBuilder.errorMsg, testCase.expectedErrorText)
+		assert.Equal(t, testCase.expectedErrorText, testCase.sccBuilder.errorMsg)
 
 		if testCase.expectedErrorText == "" {
 			assert.Equal(t, testCase.sccBuilder.Definition.Priority, &testCase.priority)
@@ -700,7 +700,7 @@ func TestSCCWithFSGroup(t *testing.T) {
 
 	for _, testCase := range testCases {
 		testCase.sccBuilder.WithFSGroup(testCase.fsGroup)
-		assert.Equal(t, testCase.sccBuilder.errorMsg, testCase.expectedErrorText)
+		assert.Equal(t, testCase.expectedErrorText, testCase.sccBuilder.errorMsg)
 
 		if testCase.expectedErrorText == "" {
 			assert.Equal(t, testCase.sccBuilder.Definition.FSGroup.Type, securityV1.FSGroupStrategyType(testCase.fsGroup))
@@ -737,7 +737,7 @@ func TestSCCWithFSGroupRange(t *testing.T) {
 
 	for _, testCase := range testCases {
 		testCase.sccBuilder.WithFSGroupRange(testCase.fsGroupMin, testCase.fsGroupMax)
-		assert.Equal(t, testCase.sccBuilder.errorMsg, testCase.expectedErrorText)
+		assert.Equal(t, testCase.expectedErrorText, testCase.sccBuilder.errorMsg)
 
 		if testCase.expectedErrorText == "" {
 			assert.Equal(t, testCase.sccBuilder.Definition.FSGroup.Ranges,
@@ -771,7 +771,7 @@ func TestSCCWithGroups(t *testing.T) {
 
 	for _, testCase := range testCases {
 		testCase.sccBuilder.WithGroups(testCase.groups)
-		assert.Equal(t, testCase.sccBuilder.errorMsg, testCase.expectedErrorText)
+		assert.Equal(t, testCase.expectedErrorText, testCase.sccBuilder.errorMsg)
 
 		if testCase.expectedErrorText == "" {
 			assert.Equal(t, testCase.sccBuilder.Definition.Groups, testCase.groups)
@@ -804,7 +804,7 @@ func TestSCCWithSeccompProfiles(t *testing.T) {
 
 	for _, testCase := range testCases {
 		testCase.sccBuilder.WithSeccompProfiles(testCase.seccompProfiles)
-		assert.Equal(t, testCase.sccBuilder.errorMsg, testCase.expectedErrorText)
+		assert.Equal(t, testCase.expectedErrorText, testCase.sccBuilder.errorMsg)
 
 		if testCase.expectedErrorText == "" {
 			assert.Equal(t, testCase.sccBuilder.Definition.SeccompProfiles, testCase.seccompProfiles)
@@ -837,7 +837,7 @@ func TestSCCWithSupplementalGroups(t *testing.T) {
 
 	for _, testCase := range testCases {
 		testCase.sccBuilder.WithSupplementalGroups(testCase.supplementalGroupsType)
-		assert.Equal(t, testCase.sccBuilder.errorMsg, testCase.expectedErrorText)
+		assert.Equal(t, testCase.expectedErrorText, testCase.sccBuilder.errorMsg)
 
 		if testCase.expectedErrorText == "" {
 			assert.Equal(t, testCase.sccBuilder.Definition.SupplementalGroups.Type,
@@ -871,7 +871,7 @@ func TestSCCWithUsers(t *testing.T) {
 
 	for _, testCase := range testCases {
 		testCase.sccBuilder.WithUsers(testCase.users)
-		assert.Equal(t, testCase.sccBuilder.errorMsg, testCase.expectedErrorText)
+		assert.Equal(t, testCase.expectedErrorText, testCase.sccBuilder.errorMsg)
 
 		if testCase.expectedErrorText == "" {
 			assert.Equal(t, testCase.sccBuilder.Definition.Users, testCase.users)
@@ -904,7 +904,7 @@ func TestSCCWithVolumes(t *testing.T) {
 
 	for _, testCase := range testCases {
 		testCase.sccBuilder.WithVolumes(testCase.volumes)
-		assert.Equal(t, testCase.sccBuilder.errorMsg, testCase.expectedErrorText)
+		assert.Equal(t, testCase.expectedErrorText, testCase.sccBuilder.errorMsg)
 
 		if testCase.expectedErrorText == "" {
 			assert.Equal(t, testCase.sccBuilder.Definition.Volumes, testCase.volumes)

--- a/pkg/sriov/list_test.go
+++ b/pkg/sriov/list_test.go
@@ -62,7 +62,7 @@ func TestNetworkList(t *testing.T) {
 		}
 
 		netBuilders, err := List(testSettings, testCase.nsName, testCase.listOptions...)
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil && len(testCase.listOptions) == 0 {
 			assert.Equal(t, len(netBuilders), len(testCase.testNetwork))
@@ -133,7 +133,7 @@ func TestNetworkCleanAllNetworksByTargetNamespace(t *testing.T) {
 
 		err := CleanAllNetworksByTargetNamespace(
 			testSettings, testCase.operatorNsName, testCase.targetNsName, testCase.listOptions...)
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			netBuilders, err := List(testSettings, testCase.operatorNsName)
@@ -356,7 +356,7 @@ func TestCleanAllNetworkNodePolicies(t *testing.T) {
 		}
 
 		err := CleanAllNetworkNodePolicies(testSettings, testCase.nsName, testCase.listOptions...)
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			netBuilders, err := ListPolicy(testSettings, testCase.nsName)
@@ -414,7 +414,7 @@ func TestListPoolConfigs(t *testing.T) {
 		}
 
 		poolConfigBuilders, err := ListPoolConfigs(testSettings, testCase.nsName)
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.Equal(t, len(poolConfigBuilders), len(testCase.poolConfigs))
@@ -470,7 +470,7 @@ func TestCleanPoolConfigs(t *testing.T) {
 		}
 
 		err := CleanAllPoolConfigs(testSettings, testCase.operatorNamespace)
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			poolConfigBuilders, err := ListPoolConfigs(testSettings, testCase.operatorNamespace)

--- a/pkg/sriov/network_test.go
+++ b/pkg/sriov/network_test.go
@@ -185,7 +185,7 @@ func TestNewNetworkBuilder(t *testing.T) {
 		assert.NotNil(t, testNetworkStructure)
 
 		if len(testCase.expectedErrorText) > 0 {
-			assert.Equal(t, testNetworkStructure.errorMsg, testCase.expectedErrorText)
+			assert.Equal(t, testCase.expectedErrorText, testNetworkStructure.errorMsg)
 		}
 	}
 }
@@ -229,7 +229,7 @@ func TestWithLogLevel(t *testing.T) {
 	for _, testCase := range testCases {
 		testSettings := buildTestClientWithDummyObject()
 		netBuilder := buildValidSriovNetworkTestBuilder(testSettings).WithLogLevel(testCase.loglevel)
-		assert.Equal(t, netBuilder.errorMsg, testCase.expectedErrorText)
+		assert.Equal(t, testCase.expectedErrorText, netBuilder.errorMsg)
 
 		if testCase.expectedErrorText == "" {
 			assert.Equal(t, netBuilder.Definition.Spec.LogLevel, testCase.loglevel)
@@ -255,7 +255,7 @@ func TestWithVlan(t *testing.T) {
 	for _, testCase := range testCases {
 		testSettings := buildTestClientWithDummyObject()
 		netBuilder := buildValidSriovNetworkTestBuilder(testSettings).WithVLAN(testCase.vlanID)
-		assert.Equal(t, netBuilder.errorMsg, testCase.expectedErrorText)
+		assert.Equal(t, testCase.expectedErrorText, netBuilder.errorMsg)
 
 		if testCase.expectedErrorText == "" {
 			assert.Equal(t, netBuilder.Definition.Spec.Vlan, int(testCase.vlanID))
@@ -293,7 +293,7 @@ func TestWithVlanProto(t *testing.T) {
 	for _, testCase := range testCases {
 		testSettings := buildTestClientWithDummyObject()
 		netBuilder := buildValidSriovNetworkTestBuilder(testSettings).WithVlanProto(testCase.vlanProtocol)
-		assert.Equal(t, netBuilder.errorMsg, testCase.expectedErrorText)
+		assert.Equal(t, testCase.expectedErrorText, netBuilder.errorMsg)
 
 		if testCase.expectedErrorText == "" {
 			assert.Equal(t, netBuilder.Definition.Spec.VlanProto, testCase.vlanProtocol)
@@ -536,7 +536,7 @@ func TestGet(t *testing.T) {
 
 	for _, testCase := range testCases {
 		network, err := testCase.networkBuilder.Get()
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.Equal(t, network.Name, testCase.networkBuilder.Definition.Name)
@@ -561,7 +561,7 @@ func TestCreate(t *testing.T) {
 
 	for _, testCase := range testCases {
 		netBuilder, err := testCase.testNetwork.Create()
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.Equal(t, netBuilder.Definition, netBuilder.Object)

--- a/pkg/sriov/networknodestate_test.go
+++ b/pkg/sriov/networknodestate_test.go
@@ -52,7 +52,7 @@ func TestNewNetworkNodeStateBuilder(t *testing.T) {
 		assert.NotNil(t, testNetworkStructure)
 
 		if len(testCase.expectedErrorText) > 0 {
-			assert.Equal(t, testNetworkStructure.errorMsg, testCase.expectedErrorText)
+			assert.Equal(t, testCase.expectedErrorText, testNetworkStructure.errorMsg)
 		}
 	}
 }

--- a/pkg/sriov/operatorconfig_test.go
+++ b/pkg/sriov/operatorconfig_test.go
@@ -120,7 +120,7 @@ func TestNewOperatorConfigBuilder(t *testing.T) {
 		testSettings := clients.GetTestClients(clients.TestClientParams{})
 		testPolicyStructure := generatePolicyBuilder(testSettings, testCase.operatorConfigNamespace)
 		assert.NotNil(t, testPolicyStructure)
-		assert.Equal(t, testPolicyStructure.errorMsg, testCase.expectedErrorText)
+		assert.Equal(t, testCase.expectedErrorText, testPolicyStructure.errorMsg)
 	}
 }
 
@@ -148,7 +148,7 @@ func TestOperatorConfigCreate(t *testing.T) {
 			assert.Nil(t, err)
 			assert.Equal(t, oCBuilder.Definition.Name, oCBuilder.Object.Name)
 		} else {
-			assert.Equal(t, err, testCase.expectedError)
+			assert.Equal(t, testCase.expectedError, err)
 		}
 	}
 }
@@ -172,7 +172,7 @@ func TestOperatorConfigExistGet(t *testing.T) {
 
 	for _, testCase := range testCases {
 		operatorConfig, err := testCase.operatorConfig.Get()
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.Equal(t, operatorConfig.Name, testCase.operatorConfig.Definition.Name)

--- a/pkg/sriov/policy_test.go
+++ b/pkg/sriov/policy_test.go
@@ -207,7 +207,7 @@ func TestNewPolicyBuilder(t *testing.T) {
 			testCase.nicNames,
 			testCase.nodeSelector)
 		assert.NotNil(t, testPolicyStructure)
-		assert.Equal(t, testPolicyStructure.errorMsg, testCase.expectedErrorText)
+		assert.Equal(t, testCase.expectedErrorText, testPolicyStructure.errorMsg)
 	}
 }
 
@@ -237,7 +237,7 @@ func TestPolicyWithDevType(t *testing.T) {
 	for _, testCase := range testCases {
 		testSettings := buildTestClientWithDummyPolicyObject()
 		netBuilder := buildValidSriovPolicyTestBuilder(testSettings).WithDevType(testCase.devType)
-		assert.Equal(t, netBuilder.errorMsg, testCase.expectedErrorText)
+		assert.Equal(t, testCase.expectedErrorText, netBuilder.errorMsg)
 
 		if testCase.expectedErrorText == "" {
 			assert.Equal(t, netBuilder.Definition.Spec.DeviceType, testCase.devType)
@@ -276,7 +276,7 @@ func TestPolicyVFRange(t *testing.T) {
 	for _, testCase := range testCases {
 		testSettings := buildTestClientWithDummyPolicyObject()
 		netBuilder := buildValidSriovPolicyTestBuilder(testSettings).WithVFRange(testCase.firstVF, testCase.lastVF)
-		assert.Equal(t, netBuilder.errorMsg, testCase.expectedErrorText)
+		assert.Equal(t, testCase.expectedErrorText, netBuilder.errorMsg)
 
 		if testCase.expectedErrorText == "" {
 			assert.Equal(t, fmt.Sprintf("%s#%d-%d", "eth1", testCase.firstVF, testCase.lastVF),
@@ -311,7 +311,7 @@ func TestPolicyWithMTU(t *testing.T) {
 	for _, testCase := range testCases {
 		testSettings := buildTestClientWithDummyPolicyObject()
 		netBuilder := buildValidSriovPolicyTestBuilder(testSettings).WithMTU(testCase.mtu)
-		assert.Equal(t, netBuilder.errorMsg, testCase.expectedErrorText)
+		assert.Equal(t, testCase.expectedErrorText, netBuilder.errorMsg)
 
 		if testCase.expectedErrorText == "" {
 			assert.Equal(t, testCase.mtu, netBuilder.Definition.Spec.Mtu)
@@ -335,7 +335,7 @@ func TestPolicyWithRDMA(t *testing.T) {
 	for _, testCase := range testCases {
 		testSettings := buildTestClientWithDummyPolicyObject()
 		netBuilder := buildValidSriovPolicyTestBuilder(testSettings).WithRDMA(testCase.rdma)
-		assert.Equal(t, netBuilder.errorMsg, testCase.expectedErrorText)
+		assert.Equal(t, testCase.expectedErrorText, netBuilder.errorMsg)
 		assert.Equal(t, testCase.rdma, netBuilder.Definition.Spec.IsRdma)
 	}
 }
@@ -356,7 +356,7 @@ func TestPolicyVhostNet(t *testing.T) {
 	for _, testCase := range testCases {
 		testSettings := buildTestClientWithDummyPolicyObject()
 		netBuilder := buildValidSriovPolicyTestBuilder(testSettings).WithVhostNet(testCase.vhostNet)
-		assert.Equal(t, netBuilder.errorMsg, testCase.expectedErrorText)
+		assert.Equal(t, testCase.expectedErrorText, netBuilder.errorMsg)
 		assert.Equal(t, testCase.vhostNet, netBuilder.Definition.Spec.NeedVhostNet)
 	}
 }
@@ -377,7 +377,7 @@ func TestPolicyWithExternallyManaged(t *testing.T) {
 	for _, testCase := range testCases {
 		testSettings := buildTestClientWithDummyPolicyObject()
 		netBuilder := buildValidSriovPolicyTestBuilder(testSettings).WithExternallyManaged(testCase.externallyManaged)
-		assert.Equal(t, netBuilder.errorMsg, testCase.expectedErrorText)
+		assert.Equal(t, testCase.expectedErrorText, netBuilder.errorMsg)
 		assert.Equal(t, testCase.externallyManaged, netBuilder.Definition.Spec.ExternallyManaged)
 	}
 }
@@ -414,7 +414,7 @@ func TestPolicyGet(t *testing.T) {
 
 	for _, testCase := range testCases {
 		policy, err := testCase.policyBuilder.Get()
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.Equal(t, policy.Name, testCase.policyBuilder.Definition.Name)
@@ -439,7 +439,7 @@ func TestPolicyCreate(t *testing.T) {
 
 	for _, testCase := range testCases {
 		netBuilder, err := testCase.testPolicy.Create()
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.Equal(t, netBuilder.Definition, netBuilder.Object)

--- a/pkg/sriov/poolconfig_test.go
+++ b/pkg/sriov/poolconfig_test.go
@@ -50,7 +50,7 @@ func TestNewPoolConfigBuilder(t *testing.T) {
 		assert.NotNil(t, testPoolconfigStructure)
 
 		if len(testCase.expectedErrorText) > 0 {
-			assert.Equal(t, testPoolconfigStructure.errorMsg, testCase.expectedErrorText)
+			assert.Equal(t, testCase.expectedErrorText, testPoolconfigStructure.errorMsg)
 		}
 	}
 }
@@ -72,7 +72,7 @@ func TestPooConfigCreate(t *testing.T) {
 
 	for _, testCase := range testCases {
 		testBuilder, err := testCase.testPoolConfig.Create()
-		assert.Equal(t, err, testCase.expectedError)
+		assert.Equal(t, testCase.expectedError, err)
 
 		if testCase.expectedError == nil {
 			assert.Equal(t, testBuilder.Definition, testBuilder.Object)
@@ -194,7 +194,7 @@ func TestWithNodeSelector(t *testing.T) {
 	for _, testCase := range testCases {
 		testSettings := buildTestPoolConfigClientWithDummyObject()
 		testBuilder := buildValidPoolConfigTestBuilder(testSettings).WithNodeSelector(testCase.nodeSelector)
-		assert.Equal(t, testBuilder.errorMsg, testCase.expectedErrorText)
+		assert.Equal(t, testCase.expectedErrorText, testBuilder.errorMsg)
 
 		if testCase.expectedErrorText == "" {
 			assert.Equal(t, testBuilder.Definition.Spec.NodeSelector.MatchLabels, testCase.nodeSelector)
@@ -232,7 +232,7 @@ func TestWithMaxUnavailable(t *testing.T) {
 	for _, testCase := range testCases {
 		testSettings := buildTestPoolConfigClientWithDummyObject()
 		testBuilder := buildValidPoolConfigTestBuilder(testSettings).WithMaxUnavailable(testCase.maxUnavailable)
-		assert.Equal(t, testBuilder.errorMsg, testCase.expectedErrorText)
+		assert.Equal(t, testCase.expectedErrorText, testBuilder.errorMsg)
 
 		if testCase.expectedErrorText == "" {
 			assert.Equal(t, testBuilder.Definition.Spec.MaxUnavailable.IntVal, testCase.maxUnavailable.IntVal)

--- a/pkg/velero/backup_test.go
+++ b/pkg/velero/backup_test.go
@@ -43,7 +43,7 @@ func TestNewBackupBuilder(t *testing.T) {
 
 	for _, test := range testcases {
 		testBuilder := NewBackupBuilder(clients.GetTestClients(clients.TestClientParams{}), test.name, test.namespace)
-		assert.Equal(t, testBuilder.errorMsg, test.expectedErrMsg)
+		assert.Equal(t, test.expectedErrMsg, testBuilder.errorMsg)
 	}
 }
 
@@ -154,7 +154,7 @@ func TestWithStorageLocation(t *testing.T) {
 
 		testBuilder.WithStorageLocation(test.location)
 
-		assert.Equal(t, testBuilder.errorMsg, test.expectedErrorMsg)
+		assert.Equal(t, test.expectedErrorMsg, testBuilder.errorMsg)
 	}
 }
 
@@ -180,7 +180,7 @@ func TestWithIncludedNamespace(t *testing.T) {
 			testBuilder.WithIncludedNamespace(namespace)
 		}
 
-		assert.Equal(t, testBuilder.errorMsg, test.expectedErrorMsg)
+		assert.Equal(t, test.expectedErrorMsg, testBuilder.errorMsg)
 
 		if test.expectedErrorMsg == "" {
 			assert.Len(t, testBuilder.Definition.Spec.IncludedNamespaces, len(test.namespaces))
@@ -210,7 +210,7 @@ func TestWithIncludedClusterScopedResource(t *testing.T) {
 			testBuilder.WithIncludedClusterScopedResource(clusterScopedResources)
 		}
 
-		assert.Equal(t, testBuilder.errorMsg, test.expectedErrorMsg)
+		assert.Equal(t, test.expectedErrorMsg, testBuilder.errorMsg)
 
 		if test.expectedErrorMsg == "" {
 			assert.Len(t, testBuilder.Definition.Spec.IncludedClusterScopedResources, len(test.clusterScopedResources))
@@ -240,7 +240,7 @@ func TestWithIncludedNamespaceScopedResource(t *testing.T) {
 			testBuilder.WithIncludedNamespaceScopedResource(namespace)
 		}
 
-		assert.Equal(t, testBuilder.errorMsg, test.expectedErrorMsg)
+		assert.Equal(t, test.expectedErrorMsg, testBuilder.errorMsg)
 
 		if test.expectedErrorMsg == "" {
 			assert.Len(t, testBuilder.Definition.Spec.IncludedNamespaceScopedResources, len(test.namespaceResources))
@@ -270,7 +270,7 @@ func TestWithExcludedClusterScopedResources(t *testing.T) {
 			testBuilder.WithExcludedClusterScopedResource(clusterScopedResources)
 		}
 
-		assert.Equal(t, testBuilder.errorMsg, test.expectedErrorMsg)
+		assert.Equal(t, test.expectedErrorMsg, testBuilder.errorMsg)
 
 		if test.expectedErrorMsg == "" {
 			assert.Len(t, testBuilder.Definition.Spec.ExcludedClusterScopedResources, len(test.clusterScopedResources))
@@ -300,7 +300,7 @@ func TestWithExcludedNamespaceScopedResources(t *testing.T) {
 			testBuilder.WithExcludedNamespaceScopedResources(namespaceResources)
 		}
 
-		assert.Equal(t, testBuilder.errorMsg, test.expectedErrorMsg)
+		assert.Equal(t, test.expectedErrorMsg, testBuilder.errorMsg)
 
 		if test.expectedErrorMsg == "" {
 			assert.Len(t, testBuilder.Definition.Spec.ExcludedNamespaceScopedResources, len(test.namespaceResources))

--- a/pkg/velero/restore_test.go
+++ b/pkg/velero/restore_test.go
@@ -47,7 +47,7 @@ func TestNewRestoreBuilder(t *testing.T) {
 	for _, test := range testcases {
 		testBuilder := NewRestoreBuilder(
 			clients.GetTestClients(clients.TestClientParams{}), test.name, test.namespace, test.backupName)
-		assert.Equal(t, testBuilder.errorMsg, test.expectedErrMsg)
+		assert.Equal(t, test.expectedErrMsg, testBuilder.errorMsg)
 	}
 }
 
@@ -159,6 +159,6 @@ func TestRestoreWithStorageLocation(t *testing.T) {
 
 		testBuilder.WithStorageLocation(test.location)
 
-		assert.Equal(t, testBuilder.errorMsg, test.expectedErrorMsg)
+		assert.Equal(t, test.expectedErrorMsg, testBuilder.errorMsg)
 	}
 }


### PR DESCRIPTION
I noticed a number of spots where `assert.Equal` was being used incorrectly.  The order is `expected, actual` instead of `actual, expected` for the values of the parameters.