### PR TITLE
assisted/infraenv: add glog and return nil to Delete()

### DIFF
--- a/pkg/assisted/infraenv.go
+++ b/pkg/assisted/infraenv.go
@@ -832,7 +832,12 @@ func (builder *InfraEnvBuilder) Delete() error {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	if !builder.Exists() {
-		return fmt.Errorf("infraenv cannot be deleted because it does not exist")
+		glog.V(100).Infof("infraenv %s in namespace %s cannot be deleted because it does not exist",
+			builder.Definition.Name, builder.Definition.Namespace)
+
+		builder.Object = nil
+
+		return nil
 	}
 
 	err := builder.apiClient.Delete(context.TODO(), builder.Definition)


### PR DESCRIPTION
Built from: #379 

Adds a `glog` entry and returns nil instead of an error for Delete() that does not exist.

Similar to: #690 