### PR TITLE
fmt: fix error return(s)

### DIFF
--- a/pkg/daemonset/daemonset.go
+++ b/pkg/daemonset/daemonset.go
@@ -321,7 +321,7 @@ func (builder *Builder) CreateAndWaitUntilReady(timeout time.Duration) (*Builder
 	if err != nil {
 		glog.V(100).Infof("Failed to create daemonset. Error is: '%s'", err.Error())
 
-		return nil, fmt.Errorf(err.Error())
+		return nil, err
 	}
 
 	// Polls every retryInterval to determine if daemonset is available.

--- a/pkg/replicaset/replicaset.go
+++ b/pkg/replicaset/replicaset.go
@@ -338,7 +338,7 @@ func (builder *Builder) CreateAndWaitUntilReady(timeout time.Duration) (*Builder
 	if err != nil {
 		glog.V(100).Infof("Failed to create replicaset. Error is: '%s'", err.Error())
 
-		return nil, fmt.Errorf(err.Error())
+		return nil, err
 	}
 
 	// Polls every retryInterval to determine if replicaset is available.


### PR DESCRIPTION
Seems to be an extraneous `fmt.Errorf` on these two packages `daemonset` and `replicaset`.