### PR TITLE
clusterlogging: add errorMsg check to validate

### DIFF
--- a/pkg/clusterlogging/clusterlogforwarder.go
+++ b/pkg/clusterlogging/clusterlogforwarder.go
@@ -298,7 +298,7 @@ func (builder *ClusterLogForwarderBuilder) Update(force bool) (*ClusterLogForwar
 // validate will check that the builder and builder definition are properly initialized before
 // accessing any member fields.
 func (builder *ClusterLogForwarderBuilder) validate() (bool, error) {
-	resourceCRD := "ClusterLogForwarder"
+	resourceCRD := "clusterLogForwarder"
 
 	if builder == nil {
 		glog.V(100).Infof("The %s builder is uninitialized", resourceCRD)
@@ -316,6 +316,12 @@ func (builder *ClusterLogForwarderBuilder) validate() (bool, error) {
 		glog.V(100).Infof("The %s builder apiclient is nil", resourceCRD)
 
 		return false, fmt.Errorf("%s builder cannot have nil apiClient", resourceCRD)
+	}
+
+	if builder.errorMsg != "" {
+		glog.V(100).Infof("The %s builder has error message %s", resourceCRD, builder.errorMsg)
+
+		return false, fmt.Errorf(builder.errorMsg)
 	}
 
 	return true, nil

--- a/pkg/clusterlogging/clusterlogforwarder_test.go
+++ b/pkg/clusterlogging/clusterlogforwarder_test.go
@@ -187,29 +187,30 @@ func TestClusterLogForwarderExist(t *testing.T) {
 func TestClusterLogForwarderGet(t *testing.T) {
 	testCases := []struct {
 		testClusterLogForwarder *ClusterLogForwarderBuilder
-		expectedError           error
+		expectedError           string
 	}{
 		{
 			testClusterLogForwarder: buildValidClusterLogForwarderBuilder(buildClusterLogForwarderClientWithDummyObject()),
-			expectedError:           nil,
+			expectedError:           "",
 		},
 		{
 			testClusterLogForwarder: buildInValidClusterLogForwarderBuilder(buildClusterLogForwarderClientWithDummyObject()),
-			expectedError:           fmt.Errorf("clusterlogforwarders.logging.openshift.io \"\" not found"),
+			expectedError:           "clusterlogforwarder 'name' cannot be empty",
 		},
 		{
 			testClusterLogForwarder: buildValidClusterLogForwarderBuilder(clients.GetTestClients(clients.TestClientParams{})),
-			expectedError:           fmt.Errorf("clusterlogforwarders.logging.openshift.io \"instance\" not found"),
+			expectedError:           "clusterlogforwarders.logging.openshift.io \"instance\" not found",
 		},
 	}
 
 	for _, testCase := range testCases {
 		clusterLogForwarderObj, err := testCase.testClusterLogForwarder.Get()
 
-		if testCase.expectedError == nil {
+		if testCase.expectedError == "" {
+			assert.Nil(t, err)
 			assert.Equal(t, testCase.testClusterLogForwarder.Definition, clusterLogForwarderObj)
 		} else {
-			assert.Equal(t, testCase.expectedError.Error(), err.Error())
+			assert.EqualError(t, err, testCase.expectedError)
 		}
 	}
 }
@@ -225,8 +226,7 @@ func TestClusterLogForwarderCreate(t *testing.T) {
 		},
 		{
 			testClusterLogForwarder: buildInValidClusterLogForwarderBuilder(buildClusterLogForwarderClientWithDummyObject()),
-			expectedError: fmt.Sprintf("ClusterLogForwarder.logging.openshift.io \"\" is invalid: %s",
-				metaDataNameErrorMgs),
+			expectedError:           "clusterlogforwarder 'name' cannot be empty",
 		},
 		{
 			testClusterLogForwarder: buildValidClusterLogForwarderBuilder(clients.GetTestClients(clients.TestClientParams{})),
@@ -290,10 +290,9 @@ func TestClusterLogForwarderUpdate(t *testing.T) {
 		},
 		{
 			testClusterLogForwarder: buildInValidClusterLogForwarderBuilder(buildClusterLogForwarderClientWithDummyObject()),
-			//nolint:lll
-			expectedError: `ClusterLogForwarder.logging.openshift.io "" is invalid: metadata.name: Required value: name is required`,
-			outputs:       newOutputs,
-			pipelines:     newPipelines,
+			expectedError:           "clusterlogforwarder 'name' cannot be empty",
+			outputs:                 newOutputs,
+			pipelines:               newPipelines,
 		},
 	}
 


### PR DESCRIPTION
The validate method of the clusterLogForwarderBuilder currently does not check for the errorMsg of the builder being set. This PR adds a check for the errorMsg and update the corresponding tests.

Following up on #727.