### PR TITLE
network: add unit tests and switch to go client

### DIFF
--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -10,6 +10,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -23,15 +24,28 @@ type ConfigBuilder struct {
 	// Created network object.
 	Object *configv1.Network
 	// api client to interact with the cluster.
-	apiClient *clients.Settings
+	apiClient runtimeclient.Client
 }
 
 // PullConfig loads an existing network into ConfigBuilder struct.
 func PullConfig(apiClient *clients.Settings) (*ConfigBuilder, error) {
-	glog.V(100).Infof("Pulling existing network name: %s", clusterNetworkName)
+	glog.V(100).Infof("Pulling existing network.config name: %s", clusterNetworkName)
 
-	builder := ConfigBuilder{
-		apiClient: apiClient,
+	if apiClient == nil {
+		glog.V(100).Info("The network.configapiClient is nil")
+
+		return nil, fmt.Errorf("network.config 'apiClient' cannot be nil")
+	}
+
+	err := apiClient.AttachScheme(configv1.Install)
+	if err != nil {
+		glog.V(100).Info("Failed to add config v1 scheme to client schemes")
+
+		return nil, err
+	}
+
+	builder := &ConfigBuilder{
+		apiClient: apiClient.Client,
 		Definition: &configv1.Network{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: clusterNetworkName,
@@ -40,12 +54,34 @@ func PullConfig(apiClient *clients.Settings) (*ConfigBuilder, error) {
 	}
 
 	if !builder.Exists() {
-		return nil, fmt.Errorf("network object %s does not exist", clusterNetworkName)
+		glog.V(100).Infof("network.config %s does not exist", clusterNetworkName)
+
+		return nil, fmt.Errorf("network.config object %s does not exist", clusterNetworkName)
 	}
 
 	builder.Definition = builder.Object
 
-	return &builder, nil
+	return builder, nil
+}
+
+// Get returns the network object from the cluster if it exists.
+func (builder *ConfigBuilder) Get() (*configv1.Network, error) {
+	if valid, err := builder.validate(); !valid {
+		return nil, err
+	}
+
+	glog.V(100).Infof("Getting network.config object %s", builder.Definition.Name)
+
+	network := &configv1.Network{}
+	err := builder.apiClient.Get(context.TODO(), runtimeclient.ObjectKey{Name: builder.Definition.Name}, network)
+
+	if err != nil {
+		glog.V(100).Infof("Failed to get network.config object %s: %v", builder.Definition.Name, err)
+
+		return nil, err
+	}
+
+	return network, err
 }
 
 // Exists checks whether the given network exists.
@@ -54,13 +90,10 @@ func (builder *ConfigBuilder) Exists() bool {
 		return false
 	}
 
-	glog.V(100).Infof(
-		"Checking if network %s exists",
-		builder.Definition.Name)
+	glog.V(100).Infof("Checking if network.config %s exists", builder.Definition.Name)
 
 	var err error
-	builder.Object, err = builder.apiClient.ConfigV1Interface.Networks().Get(
-		context.TODO(), builder.Definition.Name, metav1.GetOptions{})
+	builder.Object, err = builder.Get()
 
 	return err == nil || !k8serrors.IsNotFound(err)
 }
@@ -68,7 +101,7 @@ func (builder *ConfigBuilder) Exists() bool {
 // validate will check that the builder and builder definition are properly initialized before
 // accessing any member fields.
 func (builder *ConfigBuilder) validate() (bool, error) {
-	resourceCRD := "Network.Config"
+	resourceCRD := "network.config"
 
 	if builder == nil {
 		glog.V(100).Infof("The %s builder is uninitialized", resourceCRD)

--- a/pkg/network/network_test.go
+++ b/pkg/network/network_test.go
@@ -1,1 +1,198 @@
 package network
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/openshift-kni/eco-goinfra/pkg/clients"
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var configTestSchemes = []clients.SchemeAttacher{
+	configv1.Install,
+}
+
+func TestPullConfig(t *testing.T) {
+	testCases := []struct {
+		addToRuntimeObjects bool
+		client              bool
+		expectedError       error
+	}{
+		{
+			addToRuntimeObjects: true,
+			client:              true,
+			expectedError:       nil,
+		},
+		{
+			addToRuntimeObjects: false,
+			client:              true,
+			expectedError:       fmt.Errorf("network.config object %s does not exist", clusterNetworkName),
+		},
+		{
+			addToRuntimeObjects: true,
+			client:              false,
+			expectedError:       fmt.Errorf("network.config 'apiClient' cannot be nil"),
+		},
+	}
+
+	for _, testCase := range testCases {
+		var (
+			runtimeObjects []runtime.Object
+			testSettings   *clients.Settings
+		)
+
+		if testCase.addToRuntimeObjects {
+			runtimeObjects = append(runtimeObjects, buildDummyNetwork())
+		}
+
+		if testCase.client {
+			testSettings = clients.GetTestClients(clients.TestClientParams{
+				K8sMockObjects:  runtimeObjects,
+				SchemeAttachers: configTestSchemes,
+			})
+		}
+
+		testbBuilder, err := PullConfig(testSettings)
+		assert.Equal(t, testCase.expectedError, err)
+
+		if testCase.expectedError == nil {
+			assert.Equal(t, clusterNetworkName, testbBuilder.Definition.Name)
+		}
+	}
+}
+
+func TestConfigGet(t *testing.T) {
+	testCases := []struct {
+		testBuilder   *ConfigBuilder
+		expectedError string
+	}{
+		{
+			testBuilder:   newConfigBuilder(buildTestClientWithDummyNetwork()),
+			expectedError: "",
+		},
+		{
+			testBuilder:   newConfigBuilder(clients.GetTestClients(clients.TestClientParams{})),
+			expectedError: "networks.config.openshift.io \"cluster\" not found",
+		},
+	}
+
+	for _, testCase := range testCases {
+		network, err := testCase.testBuilder.Get()
+
+		if testCase.expectedError == "" {
+			assert.Nil(t, err)
+			assert.Equal(t, clusterNetworkName, network.Name)
+		} else {
+			assert.EqualError(t, err, testCase.expectedError)
+		}
+	}
+}
+
+func TestConfigExists(t *testing.T) {
+	testCases := []struct {
+		testBuilder *ConfigBuilder
+		exists      bool
+	}{
+		{
+			testBuilder: newConfigBuilder(buildTestClientWithDummyNetwork()),
+			exists:      true,
+		},
+		{
+			testBuilder: newConfigBuilder(clients.GetTestClients(clients.TestClientParams{})),
+			exists:      false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		exists := testCase.testBuilder.Exists()
+		assert.Equal(t, testCase.exists, exists)
+	}
+}
+
+func TestConfigValidate(t *testing.T) {
+	testCases := []struct {
+		builderNil    bool
+		definitionNil bool
+		apiClientNil  bool
+		expectedError error
+	}{
+		{
+			builderNil:    false,
+			definitionNil: false,
+			apiClientNil:  false,
+			expectedError: nil,
+		},
+		{
+			builderNil:    true,
+			definitionNil: false,
+			apiClientNil:  false,
+			expectedError: fmt.Errorf("error: received nil network.config builder"),
+		},
+		{
+			builderNil:    false,
+			definitionNil: true,
+			apiClientNil:  false,
+			expectedError: fmt.Errorf("can not redefine the undefined network.config"),
+		},
+		{
+			builderNil:    false,
+			definitionNil: false,
+			apiClientNil:  true,
+			expectedError: fmt.Errorf("network.config builder cannot have nil apiClient"),
+		},
+	}
+
+	for _, testCase := range testCases {
+		networkBuilder := newConfigBuilder(clients.GetTestClients(clients.TestClientParams{}))
+
+		if testCase.builderNil {
+			networkBuilder = nil
+		}
+
+		if testCase.definitionNil {
+			networkBuilder.Definition = nil
+		}
+
+		if testCase.apiClientNil {
+			networkBuilder.apiClient = nil
+		}
+
+		valid, err := networkBuilder.validate()
+
+		if testCase.expectedError != nil {
+			assert.False(t, valid)
+			assert.Equal(t, testCase.expectedError, err)
+		} else {
+			assert.True(t, valid)
+			assert.Nil(t, err)
+		}
+	}
+}
+
+// buildDummyNetwork builds a dummy network object. It uses the clusterNetworkName.
+func buildDummyNetwork() *configv1.Network {
+	return &configv1.Network{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: clusterNetworkName,
+		},
+	}
+}
+
+func buildTestClientWithDummyNetwork() *clients.Settings {
+	return clients.GetTestClients(clients.TestClientParams{
+		K8sMockObjects: []runtime.Object{
+			buildDummyNetwork(),
+		},
+		SchemeAttachers: configTestSchemes,
+	})
+}
+
+func newConfigBuilder(apiClient *clients.Settings) *ConfigBuilder {
+	return &ConfigBuilder{
+		apiClient:  apiClient.Client,
+		Definition: buildDummyNetwork(),
+	}
+}


### PR DESCRIPTION
* Add unit tests for network.go in the network package.
* Switch network.go to use the runtime client and add the Get method.