### PR TITLE
pod: fix ci failure from too short time out

### DIFF
--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -245,7 +245,7 @@ func TestPodDelete(t *testing.T) {
 
 func TestPodDeleteAndWait(t *testing.T) {
 	testPodDeleteHelper(t, func(builder *Builder) (*Builder, error) {
-		return builder.DeleteAndWait(time.Second)
+		return builder.DeleteAndWait(2 * time.Second)
 	})
 }
 


### PR DESCRIPTION
Similar to #744 except it covers the DeleteAndWait test, which internally uses WaitUntilDeleted and therefore needs to have its timeout extended to 2 seconds for the same reason.