### PR TITLE
ocm: add logs to get errors

### DIFF
--- a/pkg/ocm/placementbinding.go
+++ b/pkg/ocm/placementbinding.go
@@ -160,6 +160,9 @@ func (builder *PlacementBindingBuilder) Get() (*policiesv1.PlacementBinding, err
 	}, placementBinding)
 
 	if err != nil {
+		glog.V(100).Infof("Failed to get placementBinding %s in namespace %s: %v",
+			builder.Definition.Name, builder.Definition.Namespace, err)
+
 		return nil, err
 	}
 

--- a/pkg/ocm/placementrule.go
+++ b/pkg/ocm/placementrule.go
@@ -150,6 +150,9 @@ func (builder *PlacementRuleBuilder) Get() (*placementrulev1.PlacementRule, erro
 	}, placementRule)
 
 	if err != nil {
+		glog.V(100).Infof("Failed to get placementrule %s in namespace %s: %v",
+			builder.Definition.Name, builder.Definition.Namespace, err)
+
 		return nil, err
 	}
 

--- a/pkg/ocm/policy.go
+++ b/pkg/ocm/policy.go
@@ -163,6 +163,9 @@ func (builder *PolicyBuilder) Get() (*policiesv1.Policy, error) {
 	}, policy)
 
 	if err != nil {
+		glog.V(100).Infof("Failed to get policy %s in namespace %s: %v",
+			builder.Definition.Name, builder.Definition.Namespace, err)
+
 		return nil, err
 	}
 

--- a/pkg/ocm/policyset.go
+++ b/pkg/ocm/policyset.go
@@ -160,6 +160,9 @@ func (builder *PolicySetBuilder) Get() (*policiesv1beta1.PolicySet, error) {
 	}, policySet)
 
 	if err != nil {
+		glog.V(100).Infof("Failed to get policySet %s in namespace %s: %v",
+			builder.Definition.Name, builder.Definition.Namespace, err)
+
 		return nil, err
 	}
 


### PR DESCRIPTION
Similar to a change from #763, Exist can return true even if Get returns an error, causing Pull to succeed but Definition to be nil. By adding a log to Get, this error is no longer silent and has a more obvious root cause.