### PR TITLE
pod: change wait for pods healthy behavior

### DIFF
--- a/pkg/pod/list.go
+++ b/pkg/pod/list.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -274,6 +275,13 @@ func WaitForAllPodsInNamespacesHealthy(
 		}
 
 		err := podObj.WaitUntilHealthy(timeout, includeSucceeded, skipReadinessCheck, ignoreRestartPolicyNever)
+		if k8serrors.IsNotFound(err) {
+			glog.V(100).Infof("Pod %s in namespace %s no longer exists, skipping",
+				podObj.Definition.Name, podObj.Definition.Namespace)
+
+			continue
+		}
+
 		if err != nil {
 			glog.V(100).Infof("Failed to wait for all pods to be healthy due to %s", err.Error())
 

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -386,7 +386,16 @@ func (builder *Builder) WaitUntilInOneOfStatuses(statuses []corev1.PodPhase,
 		context.TODO(), time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 			updatePod, err := builder.apiClient.Pods(builder.Definition.Namespace).Get(
 				context.TODO(), builder.Definition.Name, metav1.GetOptions{})
+			if k8serrors.IsNotFound(err) {
+				glog.V(100).Infof("Pod %s in namespace %s does not exist", builder.Definition.Name, builder.Definition.Namespace)
+
+				return false, err
+			}
+
 			if err != nil {
+				glog.V(100).Infof("Failed to get pod %s in namespace %s: %v",
+					builder.Definition.Name, builder.Definition.Namespace, err)
+
 				return false, nil
 			}
 


### PR DESCRIPTION
The WaitForAllPodsInNamespacesHealthy function replaces functions in eco-gotests but behaves slightly differently, causing CI instability for cnf/ran.

Previously, the pods were listed every loop then all were checked to see if they were healthy. This means pods that get deleted during the waiting were ignored. Now, however, they cause a failure.

This PR addresses the issue by skipping pods that no longer exist during the waiting period. After all, a pod that does not exist cannot be unhealthy.