### PR TITLE
Use SSH Client.Close() to close SSH connection 

### DIFF
--- a/pkg/bmc/bmc.go
+++ b/pkg/bmc/bmc.go
@@ -747,8 +747,8 @@ func (bmc *BMC) SetSystemBootOrderReferences(bootOrderReferences []string) error
 	return system.SetBoot(newBoot)
 }
 
-// CreateCLISSHClient creates a ssh Session to the host.
-func (bmc *BMC) CreateCLISSHClient() (*ssh.Client, error) {
+// createCLISSHClient creates a ssh Session to the host.
+func (bmc *BMC) createCLISSHClient() (*ssh.Client, error) {
 	if valid, err := bmc.validateSSH(); !valid {
 		return nil, err
 	}
@@ -797,7 +797,7 @@ func (bmc *BMC) RunCLICommand(
 
 	glog.V(100).Infof("Running CLI command in BMC's CLI: %s", cmd)
 
-	client, err := bmc.CreateCLISSHClient()
+	client, err := bmc.createCLISSHClient()
 	if err != nil {
 		glog.V(100).Infof("Failed to connect to CLI: %v", err)
 
@@ -899,7 +899,7 @@ func (bmc *BMC) OpenSerialConsole(openConsoleCliCmd string) (io.Reader, io.Write
 		}
 	}
 
-	client, err := bmc.CreateCLISSHClient()
+	client, err := bmc.createCLISSHClient()
 	if err != nil {
 		glog.V(100).Infof("Failed to create underlying ssh session for %v: %v", bmc.host, err)
 

--- a/pkg/bmc/bmc.go
+++ b/pkg/bmc/bmc.go
@@ -64,7 +64,7 @@ type BMC struct {
 	systemIndex       int
 	powerControlIndex int
 
-	sshSessionForSerialConsole *ssh.Session
+	sshClientForSerialConsole *ssh.Client
 
 	errorMsg string
 }
@@ -747,8 +747,8 @@ func (bmc *BMC) SetSystemBootOrderReferences(bootOrderReferences []string) error
 	return system.SetBoot(newBoot)
 }
 
-// CreateCLISSHSession creates a ssh Session to the host.
-func (bmc *BMC) CreateCLISSHSession() (*ssh.Session, error) {
+// CreateCLISSHClient creates a ssh Session to the host.
+func (bmc *BMC) CreateCLISSHClient() (*ssh.Client, error) {
 	if valid, err := bmc.validateSSH(); !valid {
 		return nil, err
 	}
@@ -782,15 +782,7 @@ func (bmc *BMC) CreateCLISSHSession() (*ssh.Session, error) {
 		return nil, fmt.Errorf("failed to connect to BMC's SSH server: %w", err)
 	}
 
-	// Create a session
-	session, err := client.NewSession()
-	if err != nil {
-		glog.V(100).Infof("Failed to create a new SSH session: %v", err)
-
-		return nil, fmt.Errorf("failed to create a new ssh session: %w", err)
-	}
-
-	return session, nil
+	return client, nil
 }
 
 // RunCLICommand runs a CLI command in the BMC's console over SSH. This method will block until the command has
@@ -805,14 +797,21 @@ func (bmc *BMC) RunCLICommand(
 
 	glog.V(100).Infof("Running CLI command in BMC's CLI: %s", cmd)
 
-	sshSession, err := bmc.CreateCLISSHSession()
+	client, err := bmc.CreateCLISSHClient()
 	if err != nil {
 		glog.V(100).Infof("Failed to connect to CLI: %v", err)
 
 		return "", "", fmt.Errorf("failed to connect to CLI: %w", err)
 	}
+	// Create a session
+	sshSession, err := client.NewSession()
+	if err != nil {
+		glog.V(100).Infof("Failed to create a new SSH session: %v", err)
 
-	defer sshSession.Close()
+		return "", "", fmt.Errorf("failed to create a new ssh session: %w", err)
+	}
+
+	defer client.Close()
 
 	var stdoutBuffer, stderrBuffer bytes.Buffer
 	if !combineOutput {
@@ -859,6 +858,8 @@ func (bmc *BMC) RunCLICommand(
 // opened in the BMC's ssh server. If openConsoleCliCmd is provided, it will be sent to the BMC's cli. Otherwise, a best
 // effort will be made to run the appropriate cli command based on the system manufacturer. This method requires both a
 // Redfish and SSH user configured.
+//
+//nolint:funlen
 func (bmc *BMC) OpenSerialConsole(openConsoleCliCmd string) (io.Reader, io.WriteCloser, error) {
 	// We use both Redfish and SSH so make sure both are valid before continuing.
 	if valid, err := bmc.validateRedfish(); !valid {
@@ -871,7 +872,7 @@ func (bmc *BMC) OpenSerialConsole(openConsoleCliCmd string) (io.Reader, io.Write
 
 	glog.V(100).Infof("Opening serial console on %v.", bmc.host)
 
-	if bmc.sshSessionForSerialConsole != nil {
+	if bmc.sshClientForSerialConsole != nil {
 		glog.V(100).Infof("There is already a serial console opened for %v's BMC. Use OpenSerialConsole() first.",
 			bmc.host)
 
@@ -898,11 +899,19 @@ func (bmc *BMC) OpenSerialConsole(openConsoleCliCmd string) (io.Reader, io.Write
 		}
 	}
 
-	sshSession, err := bmc.CreateCLISSHSession()
+	client, err := bmc.CreateCLISSHClient()
 	if err != nil {
 		glog.V(100).Infof("Failed to create underlying ssh session for %v: %v", bmc.host, err)
 
 		return nil, nil, fmt.Errorf("failed to create underlying ssh session for %v: %w", bmc.host, err)
+	}
+
+	// Create a session
+	sshSession, err := client.NewSession()
+	if err != nil {
+		glog.V(100).Infof("Failed to create a new SSH session: %v", err)
+
+		return nil, nil, fmt.Errorf("failed to create a new ssh session: %w", err)
 	}
 
 	// Pipes need to be retrieved before session.Start()
@@ -910,7 +919,7 @@ func (bmc *BMC) OpenSerialConsole(openConsoleCliCmd string) (io.Reader, io.Write
 	if err != nil {
 		glog.V(100).Infof("Failed to get stdout pipe from %v's ssh session: %v", bmc.host, err)
 
-		_ = sshSession.Close()
+		_ = client.Close()
 
 		return nil, nil, fmt.Errorf("failed to get stdout pipe from %v's ssh session: %w", bmc.host, err)
 	}
@@ -919,7 +928,7 @@ func (bmc *BMC) OpenSerialConsole(openConsoleCliCmd string) (io.Reader, io.Write
 	if err != nil {
 		glog.V(100).Infof("Failed to get stdin pipe from from %v's ssh session: %w", bmc.host, err)
 
-		_ = sshSession.Close()
+		_ = client.Close()
 
 		return nil, nil, fmt.Errorf("failed to get stdin pipe from %v's ssh session: %w", bmc.host, err)
 	}
@@ -928,15 +937,13 @@ func (bmc *BMC) OpenSerialConsole(openConsoleCliCmd string) (io.Reader, io.Write
 	if err != nil {
 		glog.V(100).Infof("Failed to start CLI command %q on %v: %v", openConsoleCliCmd, bmc.host, err)
 
-		_ = sshSession.Close()
+		_ = client.Close()
 
 		return nil, nil, fmt.Errorf(
 			"failed to start serial console with cli command %q on %v: %w", openConsoleCliCmd, bmc.host, err)
 	}
 
-	go func() { _ = sshSession.Wait() }()
-
-	bmc.sshSessionForSerialConsole = sshSession
+	bmc.sshClientForSerialConsole = client
 
 	return reader, writer, nil
 }
@@ -949,20 +956,20 @@ func (bmc *BMC) CloseSerialConsole() error {
 
 	glog.V(100).Infof("Closing serial console for %v.", bmc.host)
 
-	if bmc.sshSessionForSerialConsole == nil {
+	if bmc.sshClientForSerialConsole == nil {
 		glog.V(100).Infof("No underlying ssh session found for %v. Please use OpenSerialConsole() first.", bmc.host)
 
 		return fmt.Errorf("no underlying ssh session found for %v", bmc.host)
 	}
 
-	err := bmc.sshSessionForSerialConsole.Close()
+	err := bmc.sshClientForSerialConsole.Close()
 	if err != nil {
 		glog.V(100).Infof("Failed to close underlying ssh session for %v: %v", bmc.host, err)
 
 		return fmt.Errorf("failed to close underlying ssh session for %v: %w", bmc.host, err)
 	}
 
-	bmc.sshSessionForSerialConsole = nil
+	bmc.sshClientForSerialConsole = nil
 
 	return nil
 }
@@ -978,7 +985,7 @@ func redfishConnect(
 		Insecure: true,
 	}
 
-	ctx, cancel := context.WithTimeout(context.TODO(), sessionTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), sessionTimeout)
 
 	client, err := gofish.ConnectContext(ctx, gofishConfig)
 	if err != nil {

--- a/pkg/bmc/bmc_test.go
+++ b/pkg/bmc/bmc_test.go
@@ -615,7 +615,7 @@ func TestBMCCreateCLISSHSession(t *testing.T) {
 	// Check that the session creation fails with no SSH user.
 	expectedErrMsg := "cannot access ssh with nil user"
 
-	session, err := bmc.CreateCLISSHSession()
+	session, err := bmc.CreateCLISSHClient()
 	assert.Nil(t, session)
 	assert.EqualError(t, err, expectedErrMsg)
 
@@ -624,7 +624,7 @@ func TestBMCCreateCLISSHSession(t *testing.T) {
 
 	expectedErrMsg = "failed to connect to BMC's SSH server: dial tcp 1.2.3.4:22: i/o timeout"
 
-	session, err = bmc.CreateCLISSHSession()
+	session, err = bmc.CreateCLISSHClient()
 	assert.Nil(t, session)
 	assert.EqualError(t, err, expectedErrMsg)
 }

--- a/pkg/bmc/bmc_test.go
+++ b/pkg/bmc/bmc_test.go
@@ -615,7 +615,7 @@ func TestBMCCreateCLISSHSession(t *testing.T) {
 	// Check that the session creation fails with no SSH user.
 	expectedErrMsg := "cannot access ssh with nil user"
 
-	session, err := bmc.CreateCLISSHClient()
+	session, err := bmc.createCLISSHClient()
 	assert.Nil(t, session)
 	assert.EqualError(t, err, expectedErrMsg)
 
@@ -624,7 +624,7 @@ func TestBMCCreateCLISSHSession(t *testing.T) {
 
 	expectedErrMsg = "failed to connect to BMC's SSH server: dial tcp 1.2.3.4:22: i/o timeout"
 
-	session, err = bmc.CreateCLISSHClient()
+	session, err = bmc.createCLISSHClient()
 	assert.Nil(t, session)
 	assert.EqualError(t, err, expectedErrMsg)
 }


### PR DESCRIPTION
Previously we only delete the ssh session.Close(), the SSH client was still connected after deletion. Instead, use ssh client.Close() to fully disconnect the SSH connection.