### PR TITLE
deployment: adjust return consistency

### DIFF
--- a/pkg/deployment/deployment.go
+++ b/pkg/deployment/deployment.go
@@ -43,7 +43,7 @@ func NewBuilder(
 			"name: %s, namespace: %s, labels: %s, containerSpec %v",
 		name, nsname, labels, containerSpec)
 
-	builder := Builder{
+	builder := &Builder{
 		apiClient: apiClient.AppsV1Interface,
 		Definition: &appsv1.Deployment{
 			Spec: appsv1.DeploymentSpec{
@@ -70,7 +70,7 @@ func NewBuilder(
 
 		builder.errorMsg = "deployment 'name' cannot be empty"
 
-		return &builder
+		return builder
 	}
 
 	if nsname == "" {
@@ -78,7 +78,7 @@ func NewBuilder(
 
 		builder.errorMsg = "deployment 'namespace' cannot be empty"
 
-		return &builder
+		return builder
 	}
 
 	if len(labels) == 0 {
@@ -86,10 +86,10 @@ func NewBuilder(
 
 		builder.errorMsg = "deployment 'labels' cannot be empty"
 
-		return &builder
+		return builder
 	}
 
-	return &builder
+	return builder
 }
 
 // Pull loads an existing deployment into Builder struct.
@@ -103,7 +103,7 @@ func Pull(apiClient *clients.Settings, name, nsname string) (*Builder, error) {
 
 	glog.V(100).Infof("Pulling existing deployment name: %s under namespace: %s", name, nsname)
 
-	builder := Builder{
+	builder := &Builder{
 		apiClient: apiClient.AppsV1Interface,
 		Definition: &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
@@ -131,7 +131,7 @@ func Pull(apiClient *clients.Settings, name, nsname string) (*Builder, error) {
 
 	builder.Definition = builder.Object
 
-	return &builder, nil
+	return builder, nil
 }
 
 // WithNodeSelector applies a nodeSelector to the deployment definition.


### PR DESCRIPTION
Broken out from: https://github.com/openshift-kni/eco-goinfra/pull/355

No actual returns added here, mostly just changing the references to the pointer.  I find it more consistent to declare variables as a pointer initially then to return a pointer to an object at the end of a function.