### PR TITLE
performanceprofile: adjust return consistency

### DIFF
--- a/pkg/nto/performanceprofile.go
+++ b/pkg/nto/performanceprofile.go
@@ -165,6 +165,8 @@ func (builder *Builder) WithHugePages(hugePageSize string, hugePages []v2.HugePa
 			hugePageSize, allowedHugePageSize)
 
 		builder.errorMsg = fmt.Sprintf("'hugePageSize' argument is not in allowed list: %v", allowedHugePageSize)
+
+		return builder
 	}
 
 	if len(hugePages) == 0 {
@@ -534,13 +536,13 @@ func (builder *Builder) validate() (bool, error) {
 	if builder.Definition == nil {
 		glog.V(100).Infof("The %s is undefined", resourceCRD)
 
-		builder.errorMsg = msg.UndefinedCrdObjectErrString(resourceCRD)
+		return false, fmt.Errorf(msg.UndefinedCrdObjectErrString(resourceCRD))
 	}
 
 	if builder.apiClient == nil {
 		glog.V(100).Infof("The %s builder apiclient is nil", resourceCRD)
 
-		builder.errorMsg = fmt.Sprintf("%s builder cannot have nil apiClient", resourceCRD)
+		return false, fmt.Errorf("%s builder cannot have nil apiClient", resourceCRD)
 	}
 
 	if builder.errorMsg != "" {


### PR DESCRIPTION
Follow up to: https://github.com/openshift-kni/eco-goinfra/pull/851

The `performanceprofile` file was missed from #355.