### PR TITLE
replicaset: adjust delete return

### DIFF
--- a/pkg/replicaset/replicaset.go
+++ b/pkg/replicaset/replicaset.go
@@ -309,6 +309,11 @@ func (builder *Builder) Delete() error {
 		builder.Definition.Name, builder.Definition.Namespace)
 
 	if !builder.Exists() {
+		glog.V(100).Infof("ReplicaSet %s in namespaces %s does not exist",
+			builder.Definition.Name, builder.Definition.Namespace)
+
+		builder.Object = nil
+
 		return nil
 	}
 


### PR DESCRIPTION
Adjusts the delete function to also set the Object to nil when the replicaset does not exist. Similar to #379.