### PR TITLE
namespace: use corev1 client to create namespaces

### DIFF
--- a/pkg/namespace/namespace.go
+++ b/pkg/namespace/namespace.go
@@ -152,12 +152,12 @@ func (builder *Builder) Create() (*Builder, error) {
 		return builder, nil
 	}
 
-	err := builder.apiClient.Create(context.TODO(), builder.Definition)
+	var err error
+
+	builder.Object, err = builder.apiClient.Namespaces().Create(context.TODO(), builder.Definition, metav1.CreateOptions{})
 	if err != nil {
 		return builder, err
 	}
-
-	builder.Object = builder.Definition
 
 	return builder, nil
 }


### PR DESCRIPTION
- Changes namespace pkg back to using corev1 client for Create method