### PR TITLE
metallb: fix bgppeer test after syncing types

### DIFF
--- a/pkg/metallb/bgppeer_test.go
+++ b/pkg/metallb/bgppeer_test.go
@@ -244,7 +244,7 @@ func TestBGPPeerWithHoldTime(t *testing.T) {
 		assert.Equal(t, testCase.expectedError, bgpPeerBuilder.errorMsg)
 
 		if testCase.expectedError == "" {
-			assert.Equal(t, testCase.holdTime, bgpPeerBuilder.Definition.Spec.HoldTime)
+			assert.Equal(t, testCase.holdTime, *bgpPeerBuilder.Definition.Spec.HoldTime)
 		}
 	}
 }
@@ -275,7 +275,7 @@ func TestBGPPeerWithKeepalive(t *testing.T) {
 		assert.Equal(t, testCase.expectedError, bgpPeerBuilder.errorMsg)
 
 		if testCase.expectedError == "" {
-			assert.Equal(t, testCase.keepalive, bgpPeerBuilder.Definition.Spec.KeepaliveTime)
+			assert.Equal(t, testCase.keepalive, *bgpPeerBuilder.Definition.Spec.KeepaliveTime)
 		}
 	}
 }


### PR DESCRIPTION
Follow up to #881 that fixes the unit test failure. It seems like the unit tests ran when the PR base was main, which has this change, then got merged into release-4.17 without it, causing the failure.