### PR TITLE
oran: add Node resource and unit tests 

### DIFF
--- a/pkg/oran/node.go
+++ b/pkg/oran/node.go
@@ -1,0 +1,147 @@
+package oran
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/golang/glog"
+	"github.com/openshift-kni/eco-goinfra/pkg/clients"
+	"github.com/openshift-kni/eco-goinfra/pkg/msg"
+	hardwaremanagementv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// NodeBuilder provides a struct to inferface with Node resources on a specific cluster.
+type NodeBuilder struct {
+	// Definition of the Node used to create the resource.
+	Definition *hardwaremanagementv1alpha1.Node
+	// Object of the Node as it is on the cluster.
+	Object *hardwaremanagementv1alpha1.Node
+	// apiClient used to interact with the cluster.
+	apiClient runtimeclient.Client
+	// errorMsg used to store latest error message from functions that do not return errors.
+	errorMsg string
+}
+
+// PullNode pulls an existing Node into a NodeBuilder struct.
+func PullNode(apiClient *clients.Settings, name, nsname string) (*NodeBuilder, error) {
+	glog.V(100).Infof("Pulling existing Node %s in namespace %s from cluster", name, nsname)
+
+	if apiClient == nil {
+		glog.V(100).Infof("The apiClient of the Node is nil")
+
+		return nil, fmt.Errorf("node 'apiClient' cannot be nil")
+	}
+
+	err := apiClient.AttachScheme(hardwaremanagementv1alpha1.AddToScheme)
+	if err != nil {
+		glog.V(100).Infof("Failed to add hardwaremanagement v1alpha1 scheme to client schemes: %v", err)
+
+		return nil, err
+	}
+
+	builder := &NodeBuilder{
+		apiClient: apiClient.Client,
+		Definition: &hardwaremanagementv1alpha1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: nsname,
+			},
+		},
+	}
+
+	if name == "" {
+		glog.V(100).Info("The name of the Node is empty")
+
+		return nil, fmt.Errorf("node 'name' cannot be empty")
+	}
+
+	if nsname == "" {
+		glog.V(100).Info("The nsname of the Node is empty")
+
+		return nil, fmt.Errorf("node 'nsname' cannot be empty")
+	}
+
+	if !builder.Exists() {
+		glog.V(100).Info("The Node %s does not exist in namespace %s", name, nsname)
+
+		return nil, fmt.Errorf("node object %s does not exist in namespace %s", name, nsname)
+	}
+
+	builder.Definition = builder.Object
+
+	return builder, nil
+}
+
+// Get returns the Node object if found.
+func (builder *NodeBuilder) Get() (*hardwaremanagementv1alpha1.Node, error) {
+	if valid, err := builder.validate(); !valid {
+		return nil, err
+	}
+
+	glog.V(100).Infof("Getting Node object %s in namespace %s",
+		builder.Definition.Name, builder.Definition.Namespace)
+
+	node := &hardwaremanagementv1alpha1.Node{}
+	err := builder.apiClient.Get(context.TODO(), runtimeclient.ObjectKey{
+		Name:      builder.Definition.Name,
+		Namespace: builder.Definition.Namespace,
+	}, node)
+
+	if err != nil {
+		glog.V(100).Infof("Failed to get Node object %s in namespace %s: %v",
+			builder.Definition.Name, builder.Definition.Namespace, err)
+
+		return nil, err
+	}
+
+	return node, nil
+}
+
+// Exists checks whether this Node exists on the cluster.
+func (builder *NodeBuilder) Exists() bool {
+	if valid, _ := builder.validate(); !valid {
+		return false
+	}
+
+	glog.V(100).Infof("Checking if Node %s exists in namespace %s",
+		builder.Definition.Name, builder.Definition.Namespace)
+
+	var err error
+	builder.Object, err = builder.Get()
+
+	return err == nil || !k8serrors.IsNotFound(err)
+}
+
+// validate checks that the builder, definition, and apiClient are properly initialized and there is no errorMsg.
+func (builder *NodeBuilder) validate() (bool, error) {
+	resourceCRD := "node"
+
+	if builder == nil {
+		glog.V(100).Infof("The %s builder is uninitialized", resourceCRD)
+
+		return false, fmt.Errorf("error: received nil %s builder", resourceCRD)
+	}
+
+	if builder.Definition == nil {
+		glog.V(100).Infof("The %s is uninitialized", resourceCRD)
+
+		return false, fmt.Errorf(msg.UndefinedCrdObjectErrString(resourceCRD))
+	}
+
+	if builder.apiClient == nil {
+		glog.V(100).Infof("The %s builder apiClient is nil", resourceCRD)
+
+		return false, fmt.Errorf("%s builder cannot have nil apiClient", resourceCRD)
+	}
+
+	if builder.errorMsg != "" {
+		glog.V(100).Infof("The %s builder has error message %s", resourceCRD, builder.errorMsg)
+
+		return false, fmt.Errorf(builder.errorMsg)
+	}
+
+	return true, nil
+}

--- a/pkg/oran/node_test.go
+++ b/pkg/oran/node_test.go
@@ -1,0 +1,171 @@
+package oran
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/openshift-kni/eco-goinfra/pkg/clients"
+	hardwaremanagementv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+const (
+	defaultNodeName      = "test-node"
+	defaultNodeNamespace = "test-namespace"
+)
+
+func TestPullNode(t *testing.T) {
+	testCases := []struct {
+		name                string
+		nsname              string
+		addToRuntimeObjects bool
+		client              bool
+		expectedError       error
+	}{
+		{
+			name:                defaultNodeName,
+			nsname:              defaultNodeNamespace,
+			addToRuntimeObjects: true,
+			client:              true,
+			expectedError:       nil,
+		},
+		{
+			name:                "",
+			nsname:              defaultNodeNamespace,
+			addToRuntimeObjects: true,
+			client:              true,
+			expectedError:       fmt.Errorf("node 'name' cannot be empty"),
+		},
+		{
+			name:                defaultNodeName,
+			nsname:              "",
+			addToRuntimeObjects: true,
+			client:              true,
+			expectedError:       fmt.Errorf("node 'nsname' cannot be empty"),
+		},
+		{
+			name:                defaultNodeName,
+			nsname:              defaultNodeNamespace,
+			addToRuntimeObjects: false,
+			client:              true,
+			expectedError: fmt.Errorf(
+				"node object %s does not exist in namespace %s", defaultNodeName, defaultNodeNamespace),
+		},
+		{
+			name:                defaultNodeName,
+			nsname:              defaultNodeNamespace,
+			addToRuntimeObjects: true,
+			client:              false,
+			expectedError:       fmt.Errorf("node 'apiClient' cannot be nil"),
+		},
+	}
+
+	for _, testCase := range testCases {
+		var (
+			runtimeObjects []runtime.Object
+			testSettings   *clients.Settings
+		)
+
+		if testCase.addToRuntimeObjects {
+			runtimeObjects = append(runtimeObjects, buildDummyNode(defaultNodeName, defaultNodeNamespace))
+		}
+
+		if testCase.client {
+			testSettings = clients.GetTestClients(clients.TestClientParams{
+				K8sMockObjects:  runtimeObjects,
+				SchemeAttachers: hardwaremanagementTestSchemes,
+			})
+		}
+
+		testBuilder, err := PullNode(testSettings, testCase.name, testCase.nsname)
+		assert.Equal(t, testCase.expectedError, err)
+
+		if testCase.expectedError == nil {
+			assert.Equal(t, testCase.name, testBuilder.Definition.Name)
+			assert.Equal(t, testCase.nsname, testBuilder.Definition.Namespace)
+		}
+	}
+}
+
+func TestNodeGet(t *testing.T) {
+	testCases := []struct {
+		testBuilder   *NodeBuilder
+		expectedError string
+	}{
+		{
+			testBuilder:   buildValidNodeTestBuilder(buildTestClientWithDummyNode()),
+			expectedError: "",
+		},
+		{
+			testBuilder: buildValidNodeTestBuilder(clients.GetTestClients(clients.TestClientParams{})),
+			expectedError: fmt.Sprintf(
+				"nodes.o2ims-hardwaremanagement.oran.openshift.io \"%s\" not found", defaultNodeName),
+		},
+	}
+
+	for _, testCase := range testCases {
+		node, err := testCase.testBuilder.Get()
+
+		if testCase.expectedError == "" {
+			assert.Nil(t, err)
+			assert.Equal(t, testCase.testBuilder.Definition.Name, node.Name)
+			assert.Equal(t, testCase.testBuilder.Definition.Namespace, node.Namespace)
+		} else {
+			assert.EqualError(t, err, testCase.expectedError)
+		}
+	}
+}
+
+func TestNodeExists(t *testing.T) {
+	testCases := []struct {
+		testBuilder *NodeBuilder
+		exists      bool
+	}{
+		{
+			testBuilder: buildValidNodeTestBuilder(buildTestClientWithDummyNode()),
+			exists:      true,
+		},
+		{
+			testBuilder: buildValidNodeTestBuilder(clients.GetTestClients(clients.TestClientParams{})),
+			exists:      false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		exists := testCase.testBuilder.Exists()
+		assert.Equal(t, testCase.exists, exists)
+	}
+}
+
+// buildDummyNode returns a Node with the provided name and nsname.
+func buildDummyNode(name, nsname string) *hardwaremanagementv1alpha1.Node {
+	return &hardwaremanagementv1alpha1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: nsname,
+		},
+	}
+}
+
+// buildTestClientWithDummyNode returns an apiClient with the correct schemes and a Node with default name and
+// namespace.
+func buildTestClientWithDummyNode() *clients.Settings {
+	return clients.GetTestClients(clients.TestClientParams{
+		K8sMockObjects: []runtime.Object{
+			buildDummyNode(defaultNodeName, defaultNodeNamespace),
+		},
+		SchemeAttachers: hardwaremanagementTestSchemes,
+	})
+}
+
+// buildValidNodeTestBuilder returns a valid NodeBuilder with all defaults and the provided apiClient.
+func buildValidNodeTestBuilder(apiClient *clients.Settings) *NodeBuilder {
+	_ = apiClient.AttachScheme(hardwaremanagementv1alpha1.AddToScheme)
+
+	return &NodeBuilder{
+		Definition: buildDummyNode(defaultNodeName, defaultNodeNamespace),
+		apiClient:  apiClient,
+	}
+}

--- a/pkg/oran/nodelist.go
+++ b/pkg/oran/nodelist.go
@@ -1,0 +1,67 @@
+package oran
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/golang/glog"
+	"github.com/openshift-kni/eco-goinfra/pkg/clients"
+	hardwaremanagementv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ListNodes returns a list of Nodes in all namespaces, using the provided options.
+func ListNodes(apiClient *clients.Settings, options ...runtimeclient.ListOptions) ([]*NodeBuilder, error) {
+	if apiClient == nil {
+		glog.V(100).Info("Nodes 'apiClient' parameter cannot be nil")
+
+		return nil, fmt.Errorf("failed to list nodes, 'apiClient' parameter is nil")
+	}
+
+	err := apiClient.AttachScheme(hardwaremanagementv1alpha1.AddToScheme)
+	if err != nil {
+		glog.V(100).Info("Failed to add hardwaremanagement v1alpha1 scheme to client schemes")
+
+		return nil, err
+	}
+
+	logMessage := "Listing Nodes in all namespaces"
+	passedOptions := runtimeclient.ListOptions{}
+
+	if len(options) > 1 {
+		glog.V(100).Info("Nodes 'options' parameter must be empty or single-valued")
+
+		return nil, fmt.Errorf("error: more than one ListOptions was passed")
+	}
+
+	if len(options) == 1 {
+		passedOptions = options[0]
+		logMessage += fmt.Sprintf(" with the options %v", passedOptions)
+	}
+
+	glog.V(100).Info(logMessage)
+
+	nodeList := new(hardwaremanagementv1alpha1.NodeList)
+	err = apiClient.Client.List(context.TODO(), nodeList, &passedOptions)
+
+	if err != nil {
+		glog.V(100).Infof("Failed to list Nodes in all namespaces due to %v", err)
+
+		return nil, err
+	}
+
+	var nodeObjects []*NodeBuilder
+
+	for _, node := range nodeList.Items {
+		copiedNode := node
+		nodeBuilder := &NodeBuilder{
+			apiClient:  apiClient.Client,
+			Object:     &copiedNode,
+			Definition: &copiedNode,
+		}
+
+		nodeObjects = append(nodeObjects, nodeBuilder)
+	}
+
+	return nodeObjects, nil
+}

--- a/pkg/oran/nodelist_test.go
+++ b/pkg/oran/nodelist_test.go
@@ -1,0 +1,63 @@
+package oran
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/openshift-kni/eco-goinfra/pkg/clients"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/labels"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestListNodes(t *testing.T) {
+	testCases := []struct {
+		nodes         []*NodeBuilder
+		listOptions   []runtimeclient.ListOptions
+		client        bool
+		expectedError error
+	}{
+		{
+			nodes:         []*NodeBuilder{buildValidNodeTestBuilder(buildTestClientWithDummyNode())},
+			listOptions:   nil,
+			client:        true,
+			expectedError: nil,
+		},
+		{
+			nodes:         []*NodeBuilder{buildValidNodeTestBuilder(buildTestClientWithDummyNode())},
+			listOptions:   []runtimeclient.ListOptions{{LabelSelector: labels.NewSelector()}},
+			client:        true,
+			expectedError: nil,
+		},
+		{
+			nodes: []*NodeBuilder{buildValidNodeTestBuilder(buildTestClientWithDummyNode())},
+			listOptions: []runtimeclient.ListOptions{
+				{LabelSelector: labels.NewSelector()},
+				{LabelSelector: labels.NewSelector()},
+			},
+			client:        true,
+			expectedError: fmt.Errorf("error: more than one ListOptions was passed"),
+		},
+		{
+			nodes:         []*NodeBuilder{buildValidNodeTestBuilder(buildTestClientWithDummyNode())},
+			listOptions:   nil,
+			client:        false,
+			expectedError: fmt.Errorf("failed to list nodes, 'apiClient' parameter is nil"),
+		},
+	}
+
+	for _, testCase := range testCases {
+		var testSettings *clients.Settings
+
+		if testCase.client {
+			testSettings = buildTestClientWithDummyNode()
+		}
+
+		builders, err := ListNodes(testSettings, testCase.listOptions...)
+		assert.Equal(t, testCase.expectedError, err)
+
+		if testCase.expectedError == nil && len(testCase.listOptions) == 0 {
+			assert.Equal(t, len(testCase.nodes), len(builders))
+		}
+	}
+}


### PR DESCRIPTION
Depends-on: #901 

This PR adds the Node resource and its unit tests to the oran package. Like with the NodePool resource, this PR only implements the read only methods since the operator should handle the actual modifications.