### PR TITLE
oran: added ClusterTemplate resource and unit tests

### DIFF
--- a/pkg/oran/clustertemplate.go
+++ b/pkg/oran/clustertemplate.go
@@ -1,0 +1,213 @@
+package oran
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/openshift-kni/eco-goinfra/pkg/clients"
+	"github.com/openshift-kni/eco-goinfra/pkg/msg"
+	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ClusterTemplateBuilder provides a struct to inferface with ClusterTemplate resources on a specific cluster.
+type ClusterTemplateBuilder struct {
+	// Definition of the ClusterTemplate used to create the resource.
+	Definition *provisioningv1alpha1.ClusterTemplate
+	// Object of the ClusterTemplate as it is on the cluster.
+	Object *provisioningv1alpha1.ClusterTemplate
+	// apiClient used to interact with the cluster.
+	apiClient runtimeclient.Client
+	// errorMsg used to store latest error message from functions that do not return errors.
+	errorMsg string
+}
+
+// PullClusterTemplate pulls an existing ClusterTemplate into a ClusterTemplateBuilder struct.
+func PullClusterTemplate(apiClient *clients.Settings, name, nsname string) (*ClusterTemplateBuilder, error) {
+	glog.V(100).Infof("Pulling existing ClusterTemplate %s in namespace %s from cluster", name, nsname)
+
+	if apiClient == nil {
+		glog.V(100).Infof("The apiClient of the ClusterTemplate is nil")
+
+		return nil, fmt.Errorf("clusterTemplate 'apiClient' cannot be nil")
+	}
+
+	err := apiClient.AttachScheme(provisioningv1alpha1.AddToScheme)
+	if err != nil {
+		glog.V(100).Infof("Failed to add provisioning v1alpha1 scheme to client schemes: %v", err)
+
+		return nil, err
+	}
+
+	builder := &ClusterTemplateBuilder{
+		apiClient: apiClient.Client,
+		Definition: &provisioningv1alpha1.ClusterTemplate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: nsname,
+			},
+		},
+	}
+
+	if name == "" {
+		glog.V(100).Info("The name of the ClusterTemplate is empty")
+
+		return nil, fmt.Errorf("clusterTemplate 'name' cannot be empty")
+	}
+
+	if nsname == "" {
+		glog.V(100).Info("The nsname of the ClusterTemplate is empty")
+
+		return nil, fmt.Errorf("clusterTemplate 'nsname' cannot be empty")
+	}
+
+	if !builder.Exists() {
+		glog.V(100).Info("The ClusterTemplate %s does not exist in namespace %s", name, nsname)
+
+		return nil, fmt.Errorf("clusterTemplate object %s does not exist in namespace %s", name, nsname)
+	}
+
+	builder.Definition = builder.Object
+
+	return builder, nil
+}
+
+// Get returns the ClusterTemplate object if found.
+func (builder *ClusterTemplateBuilder) Get() (*provisioningv1alpha1.ClusterTemplate, error) {
+	if valid, err := builder.validate(); !valid {
+		return nil, err
+	}
+
+	glog.V(100).Infof("Getting ClusterTemplate object %s in namespace %s",
+		builder.Definition.Name, builder.Definition.Namespace)
+
+	clusterTemplate := &provisioningv1alpha1.ClusterTemplate{}
+	err := builder.apiClient.Get(context.TODO(), runtimeclient.ObjectKey{
+		Name:      builder.Definition.Name,
+		Namespace: builder.Definition.Namespace,
+	}, clusterTemplate)
+
+	if err != nil {
+		glog.V(100).Infof("Failed to get ClusterTemplate object %s in namespace %s: %v",
+			builder.Definition.Name, builder.Definition.Namespace, err)
+
+		return nil, err
+	}
+
+	return clusterTemplate, nil
+}
+
+// Exists checks whether this ClusterTemplate exists on the cluster.
+func (builder *ClusterTemplateBuilder) Exists() bool {
+	if valid, _ := builder.validate(); !valid {
+		return false
+	}
+
+	glog.V(100).Infof("Checking if ClusterTemplate %s exists in namespace %s",
+		builder.Definition.Name, builder.Definition.Namespace)
+
+	var err error
+	builder.Object, err = builder.Get()
+
+	return err == nil || !k8serrors.IsNotFound(err)
+}
+
+// WaitForCondition waits up to the provided timeout for a condition matching expected. It checks only the Type, Status,
+// Reason, and Message fields. For the message, it matches if the message contains the expected. Zero fields in the
+// expected condition are ignored.
+func (builder *ClusterTemplateBuilder) WaitForCondition(
+	expected metav1.Condition, timeout time.Duration) (*ClusterTemplateBuilder, error) {
+	if valid, err := builder.validate(); !valid {
+		return nil, err
+	}
+
+	glog.V(100).Infof("Waiting up to %s until ClusterTemplate %s in namespace %s has condition %v",
+		timeout, builder.Definition.Name, builder.Definition.Namespace, expected)
+
+	if !builder.Exists() {
+		glog.V(100).Infof("ClusterTemplate %s does not exist in namespace %s",
+			builder.Definition.Name, builder.Definition.Namespace)
+
+		return nil, fmt.Errorf("cannot wait for non-existent ClusterTemplate")
+	}
+
+	err := wait.PollUntilContextTimeout(
+		context.TODO(), 3*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+			var err error
+			builder.Object, err = builder.Get()
+
+			if err != nil {
+				glog.V(100).Infof("Failed to get ClusterTemplate %s in namespace %s: %v",
+					builder.Definition.Name, builder.Definition.Namespace, err)
+
+				return false, nil
+			}
+
+			builder.Definition = builder.Object
+
+			for _, condition := range builder.Object.Status.Conditions {
+				if expected.Type != "" && condition.Type != expected.Type {
+					continue
+				}
+
+				if expected.Status != "" && condition.Status != expected.Status {
+					continue
+				}
+
+				if expected.Reason != "" && condition.Reason != expected.Reason {
+					continue
+				}
+
+				if expected.Message != "" && !strings.Contains(condition.Message, expected.Message) {
+					continue
+				}
+
+				return true, nil
+			}
+
+			return false, nil
+		})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return builder, nil
+}
+
+// validate checks that the builder, definition, and apiClient are properly initialized and there is no errorMsg.
+func (builder *ClusterTemplateBuilder) validate() (bool, error) {
+	resourceCRD := "clusterTemplate"
+
+	if builder == nil {
+		glog.V(100).Infof("The %s builder is uninitialized", resourceCRD)
+
+		return false, fmt.Errorf("error: received nil %s builder", resourceCRD)
+	}
+
+	if builder.Definition == nil {
+		glog.V(100).Infof("The %s is uninitialized", resourceCRD)
+
+		return false, fmt.Errorf(msg.UndefinedCrdObjectErrString(resourceCRD))
+	}
+
+	if builder.apiClient == nil {
+		glog.V(100).Infof("The %s builder apiClient is nil", resourceCRD)
+
+		return false, fmt.Errorf("%s builder cannot have nil apiClient", resourceCRD)
+	}
+
+	if builder.errorMsg != "" {
+		glog.V(100).Infof("The %s builder has error message %s", resourceCRD, builder.errorMsg)
+
+		return false, fmt.Errorf(builder.errorMsg)
+	}
+
+	return true, nil
+}

--- a/pkg/oran/clustertemplate_test.go
+++ b/pkg/oran/clustertemplate_test.go
@@ -1,0 +1,230 @@
+package oran
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/openshift-kni/eco-goinfra/pkg/clients"
+	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+const (
+	defaultClusterTemplateName      = "test-cluster-template"
+	defaultClusterTemplateNamespace = "test-namespace"
+)
+
+var defaultClusterTemplateCondition = metav1.Condition{
+	Type:   string(provisioningv1alpha1.CTconditionTypes.Validated),
+	Reason: string(provisioningv1alpha1.CTconditionReasons.Completed),
+	Status: metav1.ConditionTrue,
+}
+
+func TestPullClusterTemplate(t *testing.T) {
+	testCases := []struct {
+		name                string
+		nsname              string
+		addToRuntimeObjects bool
+		client              bool
+		expectedError       error
+	}{
+		{
+			name:                defaultClusterTemplateName,
+			nsname:              defaultClusterTemplateNamespace,
+			addToRuntimeObjects: true,
+			client:              true,
+			expectedError:       nil,
+		},
+		{
+			name:                "",
+			nsname:              defaultClusterTemplateNamespace,
+			addToRuntimeObjects: true,
+			client:              true,
+			expectedError:       fmt.Errorf("clusterTemplate 'name' cannot be empty"),
+		},
+		{
+			name:                defaultClusterTemplateName,
+			nsname:              "",
+			addToRuntimeObjects: true,
+			client:              true,
+			expectedError:       fmt.Errorf("clusterTemplate 'nsname' cannot be empty"),
+		},
+		{
+			name:                defaultClusterTemplateName,
+			nsname:              defaultClusterTemplateNamespace,
+			addToRuntimeObjects: false,
+			client:              true,
+			expectedError: fmt.Errorf("clusterTemplate object %s does not exist in namespace %s",
+				defaultClusterTemplateName, defaultClusterTemplateNamespace),
+		},
+		{
+			name:                defaultClusterTemplateName,
+			nsname:              defaultClusterTemplateNamespace,
+			addToRuntimeObjects: true,
+			client:              false,
+			expectedError:       fmt.Errorf("clusterTemplate 'apiClient' cannot be nil"),
+		},
+	}
+
+	for _, testCase := range testCases {
+		var (
+			runtimeObjects []runtime.Object
+			testSettings   *clients.Settings
+		)
+
+		if testCase.addToRuntimeObjects {
+			runtimeObjects = append(runtimeObjects,
+				buildDummyClusterTemplate(defaultClusterTemplateName, defaultClusterTemplateNamespace))
+		}
+
+		if testCase.client {
+			testSettings = clients.GetTestClients(clients.TestClientParams{
+				K8sMockObjects:  runtimeObjects,
+				SchemeAttachers: provisioningTestSchemes,
+			})
+		}
+
+		testBuilder, err := PullClusterTemplate(testSettings, testCase.name, testCase.nsname)
+		assert.Equal(t, testCase.expectedError, err)
+
+		if testCase.expectedError == nil {
+			assert.Equal(t, testCase.name, testBuilder.Definition.Name)
+			assert.Equal(t, testCase.nsname, testBuilder.Definition.Namespace)
+		}
+	}
+}
+
+func TestClusterTemplateGet(t *testing.T) {
+	testCases := []struct {
+		testBuilder   *ClusterTemplateBuilder
+		expectedError string
+	}{
+		{
+			testBuilder:   buildValidClusterTemplateTestBuilder(buildTestClientWithDummyClusterTemplate()),
+			expectedError: "",
+		},
+		{
+			testBuilder: buildValidClusterTemplateTestBuilder(clients.GetTestClients(clients.TestClientParams{})),
+			expectedError: fmt.Sprintf(
+				"clustertemplates.o2ims.provisioning.oran.org \"%s\" not found", defaultClusterTemplateName),
+		},
+	}
+
+	for _, testCase := range testCases {
+		clusterTemplate, err := testCase.testBuilder.Get()
+
+		if testCase.expectedError == "" {
+			assert.Nil(t, err)
+			assert.Equal(t, testCase.testBuilder.Definition.Name, clusterTemplate.Name)
+			assert.Equal(t, testCase.testBuilder.Definition.Namespace, clusterTemplate.Namespace)
+		} else {
+			assert.EqualError(t, err, testCase.expectedError)
+		}
+	}
+}
+
+func TestClusterTemplateExists(t *testing.T) {
+	testCases := []struct {
+		testBuilder *ClusterTemplateBuilder
+		exists      bool
+	}{
+		{
+			testBuilder: buildValidClusterTemplateTestBuilder(buildTestClientWithDummyClusterTemplate()),
+			exists:      true,
+		},
+		{
+			testBuilder: buildValidClusterTemplateTestBuilder(clients.GetTestClients(clients.TestClientParams{})),
+			exists:      false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		exists := testCase.testBuilder.Exists()
+		assert.Equal(t, testCase.exists, exists)
+	}
+}
+
+func TestClusterTemplateWaitForCondition(t *testing.T) {
+	testCases := []struct {
+		conditionMet  bool
+		exists        bool
+		expectedError error
+	}{
+		{
+			conditionMet:  true,
+			exists:        true,
+			expectedError: nil,
+		},
+		{
+			conditionMet:  false,
+			exists:        true,
+			expectedError: context.DeadlineExceeded,
+		},
+		{
+			conditionMet:  true,
+			exists:        false,
+			expectedError: fmt.Errorf("cannot wait for non-existent ClusterTemplate"),
+		},
+	}
+
+	for _, testCase := range testCases {
+		var runtimeObjects []runtime.Object
+
+		if testCase.exists {
+			clusterTemplate := buildDummyClusterTemplate(defaultClusterTemplateName, defaultClusterTemplateNamespace)
+
+			if testCase.conditionMet {
+				clusterTemplate.Status.Conditions = append(clusterTemplate.Status.Conditions, defaultClusterTemplateCondition)
+			}
+
+			runtimeObjects = append(runtimeObjects, clusterTemplate)
+		}
+
+		testSettings := clients.GetTestClients(clients.TestClientParams{
+			K8sMockObjects:  runtimeObjects,
+			SchemeAttachers: provisioningTestSchemes,
+		})
+		testBuilder := buildValidClusterTemplateTestBuilder(testSettings)
+
+		_, err := testBuilder.WaitForCondition(defaultClusterTemplateCondition, time.Second)
+		assert.Equal(t, testCase.expectedError, err)
+	}
+}
+
+// buildDummyClusterTemplate returns a ClusterTemplate with the provided name and nsname.
+//
+//nolint:unparam
+func buildDummyClusterTemplate(name, nsname string) *provisioningv1alpha1.ClusterTemplate {
+	return &provisioningv1alpha1.ClusterTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: nsname,
+		},
+	}
+}
+
+// buildTestClientWithDummyClusterTemplate returns an apiClient with the correct schemes and a ClusterTemplate with
+// default name and namespace.
+func buildTestClientWithDummyClusterTemplate() *clients.Settings {
+	return clients.GetTestClients(clients.TestClientParams{
+		K8sMockObjects: []runtime.Object{
+			buildDummyClusterTemplate(defaultClusterTemplateName, defaultClusterTemplateNamespace),
+		},
+		SchemeAttachers: provisioningTestSchemes,
+	})
+}
+
+// buildValidClusterTemplateTestBuilder returns a valid ClusterTemplateBuilder with all defaults and the provided
+// apiClient.
+func buildValidClusterTemplateTestBuilder(apiClient *clients.Settings) *ClusterTemplateBuilder {
+	_ = apiClient.AttachScheme(provisioningv1alpha1.AddToScheme)
+
+	return &ClusterTemplateBuilder{
+		Definition: buildDummyClusterTemplate(defaultClusterTemplateName, defaultClusterTemplateNamespace),
+		apiClient:  apiClient,
+	}
+}

--- a/pkg/oran/clustertemplatelist.go
+++ b/pkg/oran/clustertemplatelist.go
@@ -1,0 +1,68 @@
+package oran
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/golang/glog"
+	"github.com/openshift-kni/eco-goinfra/pkg/clients"
+	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ListClusterTemplates returns a list of ClusterTemplates in all namespaces, using the provided options.
+func ListClusterTemplates(
+	apiClient *clients.Settings, options ...runtimeclient.ListOptions) ([]*ClusterTemplateBuilder, error) {
+	if apiClient == nil {
+		glog.V(100).Info("ClusterTemplates 'apiClient' parameter cannot be nil")
+
+		return nil, fmt.Errorf("failed to list clusterTemplates, 'apiClient' parameter is nil")
+	}
+
+	err := apiClient.AttachScheme(provisioningv1alpha1.AddToScheme)
+	if err != nil {
+		glog.V(100).Info("Failed to add provisioning v1alpha1 scheme to client schemes")
+
+		return nil, err
+	}
+
+	logMessage := "Listing ClusterTemplates in all namespaces"
+	passedOptions := runtimeclient.ListOptions{}
+
+	if len(options) > 1 {
+		glog.V(100).Info("ClusterTemplates 'options' parameter must be empty or single-valued")
+
+		return nil, fmt.Errorf("error: more than one ListOptions was passed")
+	}
+
+	if len(options) == 1 {
+		passedOptions = options[0]
+		logMessage += fmt.Sprintf(" with the options %v", passedOptions)
+	}
+
+	glog.V(100).Info(logMessage)
+
+	clusterTemplateList := new(provisioningv1alpha1.ClusterTemplateList)
+	err = apiClient.Client.List(context.TODO(), clusterTemplateList, &passedOptions)
+
+	if err != nil {
+		glog.V(100).Infof("Failed to list ClusterTemplates in all namespaces due to %v", err)
+
+		return nil, err
+	}
+
+	var clusterTemplateObjects []*ClusterTemplateBuilder
+
+	for _, clusterTemplate := range clusterTemplateList.Items {
+		copiedClusterTemplate := clusterTemplate
+		clusterTemplateBuilder := &ClusterTemplateBuilder{
+			apiClient:  apiClient.Client,
+			Object:     &copiedClusterTemplate,
+			Definition: &copiedClusterTemplate,
+		}
+
+		clusterTemplateObjects = append(clusterTemplateObjects, clusterTemplateBuilder)
+	}
+
+	return clusterTemplateObjects, nil
+}

--- a/pkg/oran/clustertemplatelist_test.go
+++ b/pkg/oran/clustertemplatelist_test.go
@@ -1,0 +1,71 @@
+package oran
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/openshift-kni/eco-goinfra/pkg/clients"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/labels"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestListClusterTemplates(t *testing.T) {
+	testCases := []struct {
+		clusterTemplates []*ClusterTemplateBuilder
+		listOptions      []runtimeclient.ListOptions
+		client           bool
+		expectedError    error
+	}{
+		{
+			clusterTemplates: []*ClusterTemplateBuilder{
+				buildValidClusterTemplateTestBuilder(buildTestClientWithDummyClusterTemplate()),
+			},
+			listOptions:   nil,
+			client:        true,
+			expectedError: nil,
+		},
+		{
+			clusterTemplates: []*ClusterTemplateBuilder{
+				buildValidClusterTemplateTestBuilder(buildTestClientWithDummyClusterTemplate()),
+			},
+			listOptions:   []runtimeclient.ListOptions{{LabelSelector: labels.NewSelector()}},
+			client:        true,
+			expectedError: nil,
+		},
+		{
+			clusterTemplates: []*ClusterTemplateBuilder{
+				buildValidClusterTemplateTestBuilder(buildTestClientWithDummyClusterTemplate()),
+			},
+			listOptions: []runtimeclient.ListOptions{
+				{LabelSelector: labels.NewSelector()},
+				{LabelSelector: labels.NewSelector()},
+			},
+			client:        true,
+			expectedError: fmt.Errorf("error: more than one ListOptions was passed"),
+		},
+		{
+			clusterTemplates: []*ClusterTemplateBuilder{
+				buildValidClusterTemplateTestBuilder(buildTestClientWithDummyClusterTemplate()),
+			},
+			listOptions:   nil,
+			client:        false,
+			expectedError: fmt.Errorf("failed to list clusterTemplates, 'apiClient' parameter is nil"),
+		},
+	}
+
+	for _, testCase := range testCases {
+		var testSettings *clients.Settings
+
+		if testCase.client {
+			testSettings = buildTestClientWithDummyClusterTemplate()
+		}
+
+		builders, err := ListClusterTemplates(testSettings, testCase.listOptions...)
+		assert.Equal(t, testCase.expectedError, err)
+
+		if testCase.expectedError == nil && len(testCase.listOptions) == 0 {
+			assert.Equal(t, len(testCase.clusterTemplates), len(builders))
+		}
+	}
+}


### PR DESCRIPTION
This PR adds the ClusterTemplate resource and its unit tests to the oran package. Like with the NodePool and Node resources, this is meant to be read only and therefore has only the Pull, Get, and Exists methods.