### PR TITLE
pod: remove default GracePeriod

### DIFF
--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -1280,9 +1280,6 @@ func getDefinition(name, nsName string) *corev1.Pod {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: nsName},
-		Spec: corev1.PodSpec{
-			TerminationGracePeriodSeconds: ptr.To(int64(0)),
-		},
 	}
 }
 


### PR DESCRIPTION
[PR](https://github.com/openshift-kni/eco-goinfra/pull/891) ensures grace-period is not set to while terminating pod. But kubernetes uses GracePeriod defined in Pod Spec. However, `TerminationGracePeriodSeconds` in PodSpec is being set to 0 for all new pods defined with `NewBuilder` unless explicitly updated with `WithTerminationGracePeriodSeconds`

Hence, removing grace-period=0 in default pod definition.