### PR TITLE
namespace: edit CleanObjects

### DIFF
--- a/pkg/namespace/namespace.go
+++ b/pkg/namespace/namespace.go
@@ -310,7 +310,7 @@ func (builder *Builder) CleanObjects(cleanTimeout time.Duration, objects ...sche
 				objList, err := builder.apiClient.Resource(resource).Namespace(builder.Definition.Name).List(
 					context.TODO(), metav1.ListOptions{})
 
-				if err != nil || len(objList.Items) > 1 {
+				if err != nil || len(objList.Items) > 0 {
 					// avoid timeout due to default automatically created openshift
 					// configmaps: kube-root-ca.crt openshift-service-ca.crt
 					if resource.Resource == "configmaps" {


### PR DESCRIPTION
CleanObjects is not working when there is only 1 pod/resource in terminating state