### PR TITLE
Import consistency

### DIFF
--- a/pkg/assisted/agentclusterinstall.go
+++ b/pkg/assisted/agentclusterinstall.go
@@ -14,7 +14,7 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
 	hiveextV1Beta1 "github.com/openshift-kni/eco-goinfra/pkg/schemes/assisted/api/hiveextension/v1beta1"
-	v1 "github.com/openshift-kni/eco-goinfra/pkg/schemes/assisted/hive/api/v1"
+	hivev1 "github.com/openshift-kni/eco-goinfra/pkg/schemes/assisted/hive/api/v1"
 	"github.com/openshift-kni/eco-goinfra/pkg/schemes/assisted/models"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -243,7 +243,7 @@ func (builder *AgentClusterInstallBuilder) WithImageSet(imageSet string) *AgentC
 		return builder
 	}
 
-	builder.Definition.Spec.ImageSetRef = &v1.ClusterImageSetReference{Name: imageSet}
+	builder.Definition.Spec.ImageSetRef = &hivev1.ClusterImageSetReference{Name: imageSet}
 
 	return builder
 }
@@ -404,7 +404,7 @@ func (builder *AgentClusterInstallBuilder) WithOptions(
 
 // WaitForConditionMessage waits the specified timeout for the given condition to report the specified message.
 func (builder *AgentClusterInstallBuilder) WaitForConditionMessage(
-	conditionType v1.ClusterInstallConditionType, message string, timeout time.Duration) error {
+	conditionType hivev1.ClusterInstallConditionType, message string, timeout time.Duration) error {
 	return wait.PollUntilContextTimeout(
 		context.TODO(), retryInterval, timeout, true, func(ctx context.Context) (bool, error) {
 			condition, err := builder.getCondition(conditionType)
@@ -418,7 +418,7 @@ func (builder *AgentClusterInstallBuilder) WaitForConditionMessage(
 
 // WaitForConditionStatus waits the specified timeout for the given condition to report the specified status.
 func (builder *AgentClusterInstallBuilder) WaitForConditionStatus(
-	conditionType v1.ClusterInstallConditionType, status corev1.ConditionStatus, timeout time.Duration) error {
+	conditionType hivev1.ClusterInstallConditionType, status corev1.ConditionStatus, timeout time.Duration) error {
 	return wait.PollUntilContextTimeout(
 		context.TODO(), retryInterval, timeout, true, func(ctx context.Context) (bool, error) {
 			condition, err := builder.getCondition(conditionType)
@@ -432,7 +432,7 @@ func (builder *AgentClusterInstallBuilder) WaitForConditionStatus(
 
 // WaitForConditionReason waits the specified timeout for the given condition to report the specified reason.
 func (builder *AgentClusterInstallBuilder) WaitForConditionReason(
-	conditionType v1.ClusterInstallConditionType, reason string, timeout time.Duration) error {
+	conditionType hivev1.ClusterInstallConditionType, reason string, timeout time.Duration) error {
 	return wait.PollUntilContextTimeout(
 		context.TODO(), retryInterval, timeout, true, func(ctx context.Context) (bool, error) {
 			condition, err := builder.getCondition(conditionType)
@@ -695,7 +695,7 @@ func (builder *AgentClusterInstallBuilder) Exists() bool {
 
 // getCondition returns the agentclusterinstall condition discovered based on specified conditionType.
 func (builder *AgentClusterInstallBuilder) getCondition(
-	conditionType v1.ClusterInstallConditionType) (*v1.ClusterInstallCondition, error) {
+	conditionType hivev1.ClusterInstallConditionType) (*hivev1.ClusterInstallCondition, error) {
 	if valid, err := builder.validate(); !valid {
 		return nil, err
 	}

--- a/pkg/assisted/agentclusterinstall_test.go
+++ b/pkg/assisted/agentclusterinstall_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	hiveextV1Beta1 "github.com/openshift-kni/eco-goinfra/pkg/schemes/assisted/api/hiveextension/v1beta1"
-	v1 "github.com/openshift-kni/eco-goinfra/pkg/schemes/assisted/hive/api/v1"
+	hivev1 "github.com/openshift-kni/eco-goinfra/pkg/schemes/assisted/hive/api/v1"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -887,12 +887,12 @@ func TestAgentClusterInstallWaitForStateInfo(t *testing.T) {
 func TestAgentClusterInstallWaitForConditionMessage(t *testing.T) {
 	testCases := []struct {
 		status        hiveextV1Beta1.AgentClusterInstallStatus
-		conditionType v1.ClusterInstallConditionType
+		conditionType hivev1.ClusterInstallConditionType
 		message       string
 	}{
 		{
 			status: hiveextV1Beta1.AgentClusterInstallStatus{
-				Conditions: []v1.ClusterInstallCondition{
+				Conditions: []hivev1.ClusterInstallCondition{
 					{
 						Type:    "Stopped",
 						Status:  corev1.ConditionTrue,
@@ -906,7 +906,7 @@ func TestAgentClusterInstallWaitForConditionMessage(t *testing.T) {
 		},
 		{
 			status: hiveextV1Beta1.AgentClusterInstallStatus{
-				Conditions: []v1.ClusterInstallCondition{
+				Conditions: []hivev1.ClusterInstallCondition{
 					{
 						Type:    "SpecSynced",
 						Status:  corev1.ConditionTrue,
@@ -940,12 +940,12 @@ func TestAgentClusterInstallWaitForConditionMessage(t *testing.T) {
 func TestAgentClusterInstallWaitForConditionStatus(t *testing.T) {
 	testCases := []struct {
 		status          hiveextV1Beta1.AgentClusterInstallStatus
-		conditionType   v1.ClusterInstallConditionType
+		conditionType   hivev1.ClusterInstallConditionType
 		conditionStatus corev1.ConditionStatus
 	}{
 		{
 			status: hiveextV1Beta1.AgentClusterInstallStatus{
-				Conditions: []v1.ClusterInstallCondition{
+				Conditions: []hivev1.ClusterInstallCondition{
 					{
 						Type:    "Stopped",
 						Status:  corev1.ConditionTrue,
@@ -959,7 +959,7 @@ func TestAgentClusterInstallWaitForConditionStatus(t *testing.T) {
 		},
 		{
 			status: hiveextV1Beta1.AgentClusterInstallStatus{
-				Conditions: []v1.ClusterInstallCondition{
+				Conditions: []hivev1.ClusterInstallCondition{
 					{
 						Type:    "Failed",
 						Status:  corev1.ConditionFalse,
@@ -993,12 +993,12 @@ func TestAgentClusterInstallWaitForConditionStatus(t *testing.T) {
 func TestAgentClusterInstallWaitForConditionReason(t *testing.T) {
 	testCases := []struct {
 		status        hiveextV1Beta1.AgentClusterInstallStatus
-		conditionType v1.ClusterInstallConditionType
+		conditionType hivev1.ClusterInstallConditionType
 		reason        string
 	}{
 		{
 			status: hiveextV1Beta1.AgentClusterInstallStatus{
-				Conditions: []v1.ClusterInstallCondition{
+				Conditions: []hivev1.ClusterInstallCondition{
 					{
 						Type:    "Stopped",
 						Status:  corev1.ConditionTrue,
@@ -1012,7 +1012,7 @@ func TestAgentClusterInstallWaitForConditionReason(t *testing.T) {
 		},
 		{
 			status: hiveextV1Beta1.AgentClusterInstallStatus{
-				Conditions: []v1.ClusterInstallCondition{
+				Conditions: []hivev1.ClusterInstallCondition{
 					{
 						Type:    "Failed",
 						Status:  corev1.ConditionFalse,

--- a/pkg/kmm/containers_test.go
+++ b/pkg/kmm/containers_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
 	"github.com/stretchr/testify/assert"
@@ -129,7 +129,7 @@ func TestModuleLoaderContainerWithImagePullPolicy(t *testing.T) {
 		assert.Equal(t, testCase.expectedError, testBuilder.errorMsg)
 
 		if testCase.expectedError == "" {
-			assert.Equal(t, v1.PullPolicy(testCase.imagePolicy), testBuilder.definition.ImagePullPolicy)
+			assert.Equal(t, corev1.PullPolicy(testCase.imagePolicy), testBuilder.definition.ImagePullPolicy)
 		}
 	}
 }

--- a/pkg/networkpolicy/multinetegressrule_test.go
+++ b/pkg/networkpolicy/multinetegressrule_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -31,12 +31,12 @@ func TestEgressWithPortAndProtocol(t *testing.T) {
 
 func TestEgressWithProtocol(t *testing.T) {
 	testCases := []struct {
-		protocol      v1.Protocol
+		protocol      corev1.Protocol
 		expectedError string
 	}{
-		{protocol: v1.ProtocolTCP, expectedError: ""},
-		{protocol: v1.ProtocolUDP, expectedError: ""},
-		{protocol: v1.ProtocolSCTP, expectedError: ""},
+		{protocol: corev1.ProtocolTCP, expectedError: ""},
+		{protocol: corev1.ProtocolUDP, expectedError: ""},
+		{protocol: corev1.ProtocolSCTP, expectedError: ""},
 		{protocol: "dummy", expectedError: "invalid protocol argument. Allowed protocols: TCP, UDP & SCTP"},
 	}
 	for _, testCase := range testCases {

--- a/pkg/networkpolicy/multinetingressrule_test.go
+++ b/pkg/networkpolicy/multinetingressrule_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -31,12 +31,12 @@ func TestIngressWithPortAndProtocol(t *testing.T) {
 
 func TestIngressWithProtocol(t *testing.T) {
 	testCases := []struct {
-		protocol      v1.Protocol
+		protocol      corev1.Protocol
 		expectedError string
 	}{
-		{protocol: v1.ProtocolTCP, expectedError: ""},
-		{protocol: v1.ProtocolUDP, expectedError: ""},
-		{protocol: v1.ProtocolSCTP, expectedError: ""},
+		{protocol: corev1.ProtocolTCP, expectedError: ""},
+		{protocol: corev1.ProtocolUDP, expectedError: ""},
+		{protocol: corev1.ProtocolSCTP, expectedError: ""},
 		{protocol: "dummy", expectedError: "invalid protocol argument. Allowed protocols: TCP, UDP & SCTP"},
 	}
 	for _, testCase := range testCases {

--- a/pkg/nmstate/policy_test.go
+++ b/pkg/nmstate/policy_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v2"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -569,7 +569,7 @@ func buildDummyPolicyObject() []runtime.Object {
 			Conditions: shared.ConditionList{
 				shared.Condition{
 					Type:   shared.NodeNetworkStateConditionAvailable,
-					Status: v1.ConditionTrue,
+					Status: corev1.ConditionTrue,
 				},
 			},
 		},

--- a/pkg/oadp/dataprotectionapplication_test.go
+++ b/pkg/oadp/dataprotectionapplication_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	oadpv1alpha1 "github.com/openshift-kni/eco-goinfra/pkg/schemes/oadp/api/v1alpha1"
-	v1 "github.com/openshift-kni/eco-goinfra/pkg/schemes/oadp/velero/api/v1"
+	velerov1 "github.com/openshift-kni/eco-goinfra/pkg/schemes/oadp/velero/api/v1"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -263,10 +263,10 @@ func TestDPAWithBackupLocation(t *testing.T) {
 	}{
 		{
 			backupLocation: oadpv1alpha1.BackupLocation{
-				Velero: &v1.BackupStorageLocationSpec{
+				Velero: &velerov1.BackupStorageLocationSpec{
 					Provider: "aws",
-					StorageType: v1.StorageType{
-						ObjectStorage: &v1.ObjectStorageLocation{
+					StorageType: velerov1.StorageType{
+						ObjectStorage: &velerov1.ObjectStorageLocation{
 							Bucket: "test-bucket",
 							Prefix: "backup",
 						},
@@ -568,10 +568,10 @@ func generateDataProtectionApplication() *oadpv1alpha1.DataProtectionApplication
 			},
 			BackupLocations: []oadpv1alpha1.BackupLocation{
 				{
-					Velero: &v1.BackupStorageLocationSpec{
+					Velero: &velerov1.BackupStorageLocationSpec{
 						Provider: "aws",
-						StorageType: v1.StorageType{
-							ObjectStorage: &v1.ObjectStorageLocation{
+						StorageType: velerov1.StorageType{
+							ObjectStorage: &velerov1.ObjectStorageLocation{
 								Bucket: "test-bucket",
 								Prefix: "backup",
 							},

--- a/pkg/olm/operatorgroup_test.go
+++ b/pkg/olm/operatorgroup_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
-	v1 "github.com/openshift-kni/eco-goinfra/pkg/schemes/olm/operators/v1"
+	operatorsv1 "github.com/openshift-kni/eco-goinfra/pkg/schemes/olm/operators/v1"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -13,7 +13,7 @@ import (
 
 var (
 	operatorTestSchemes = []clients.SchemeAttacher{
-		v1.AddToScheme,
+		operatorsv1.AddToScheme,
 	}
 )
 
@@ -74,13 +74,13 @@ func TestNewOperatorGroupBuilder(t *testing.T) {
 }
 
 func TestPullIOperatorGroup(t *testing.T) {
-	operatorGroup := func(name, namespace string) *v1.OperatorGroup {
-		return &v1.OperatorGroup{
+	operatorGroup := func(name, namespace string) *operatorsv1.OperatorGroup {
+		return &operatorsv1.OperatorGroup{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: namespace,
 			},
-			Spec: v1.OperatorGroupSpec{
+			Spec: operatorsv1.OperatorGroupSpec{
 				ServiceAccountName: "test",
 			},
 		}
@@ -330,11 +330,11 @@ func buildOperatorGroupTestClientWithDummyObject() *clients.Settings {
 }
 
 func buildDummyOperatorGroup() []runtime.Object {
-	return append([]runtime.Object{}, &v1.OperatorGroup{
+	return append([]runtime.Object{}, &operatorsv1.OperatorGroup{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "operatorgroup",
 			Namespace: "test-namespace",
 		},
-		Spec: v1.OperatorGroupSpec{},
+		Spec: operatorsv1.OperatorGroupSpec{},
 	})
 }


### PR DESCRIPTION
Makes sure that imports are using a more descriptive name than `v1`.

Note: This does not touch the `schemes` folder that are copies of other code.

Similar to:
- #239 
- #387 
- #694 
- #711 