### PR TITLE
pod: add new health functions

### DIFF
--- a/pkg/pod/list_test.go
+++ b/pkg/pod/list_test.go
@@ -2,12 +2,14 @@ package pod
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -91,6 +93,86 @@ func TestWaitForAllPodsInNamespacesHealthy(t *testing.T) {
 			testCase.ignoreRestartPolicyNever,
 			testCase.ignoreNamespaces)
 
+		assert.Equal(t, testCase.expectedError, err)
+	}
+}
+
+func TestWaitForPodsInNamespacesHealthy(t *testing.T) {
+	testCases := []struct {
+		namespaces    []string
+		listOptions   []metav1.ListOptions
+		healthy       bool
+		failed        bool
+		client        bool
+		expectedError error
+	}{
+		{
+			namespaces:    nil,
+			listOptions:   nil,
+			healthy:       true,
+			failed:        false,
+			client:        true,
+			expectedError: nil,
+		},
+		{
+			namespaces:    nil,
+			listOptions:   nil,
+			healthy:       false,
+			failed:        true,
+			client:        true,
+			expectedError: nil,
+		},
+		{
+			namespaces:    nil,
+			listOptions:   []metav1.ListOptions{{}, {}},
+			healthy:       true,
+			failed:        false,
+			client:        true,
+			expectedError: fmt.Errorf("error: more than one ListOptions was passed"),
+		},
+		{
+			namespaces:    nil,
+			listOptions:   nil,
+			healthy:       true,
+			failed:        false,
+			client:        false,
+			expectedError: fmt.Errorf("podList 'apiClient' cannot be empty"),
+		},
+		{
+			namespaces:    nil,
+			listOptions:   nil,
+			healthy:       false,
+			failed:        false,
+			client:        true,
+			expectedError: context.DeadlineExceeded,
+		},
+		{
+			namespaces:    []string{defaultPodNsName + "-has-no-pods"},
+			listOptions:   nil,
+			healthy:       false,
+			failed:        false,
+			client:        true,
+			expectedError: nil,
+		},
+	}
+
+	for _, testCase := range testCases {
+		var testSettings *clients.Settings
+
+		if testCase.client {
+			testPod := buildDummyPod(defaultPodName, defaultPodNsName, defaultPodImage)
+			if testCase.healthy {
+				testPod = buildDummyPodWithPhaseAndCondition(corev1.PodSucceeded, corev1.PodReady, false)
+			} else if testCase.failed {
+				testPod = buildDummyPodWithPhaseAndCondition(corev1.PodFailed, corev1.PodReady, true)
+			}
+
+			testSettings = clients.GetTestClients(clients.TestClientParams{
+				K8sMockObjects: []runtime.Object{testPod},
+			})
+		}
+
+		err := WaitForPodsInNamespacesHealthy(testSettings, testCase.namespaces, time.Second, testCase.listOptions...)
 		assert.Equal(t, testCase.expectedError, err)
 	}
 }

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -306,6 +306,26 @@ func (builder *Builder) WaitUntilRunning(timeout time.Duration) error {
 	return builder.WaitUntilInStatus(corev1.PodRunning, timeout)
 }
 
+// IsHealthy returns true if and only if the pod has succeeded or is running and ready. All other cases, such as when
+// the pod does not exist or the builder is invalid, will return false.
+func (builder *Builder) IsHealthy() bool {
+	if valid, _ := builder.validate(); !valid {
+		return false
+	}
+
+	glog.V(100).Infof("Checking if pod %s in namespace %s is healthy",
+		builder.Definition.Name, builder.Definition.Namespace)
+
+	if !builder.Exists() {
+		glog.V(100).Infof("Cannot check if pod %s in namespace %s is healthy because it does not exist",
+			builder.Definition.Name, builder.Definition.Namespace)
+
+		return false
+	}
+
+	return builder.isObjectHealthy()
+}
+
 // WaitUntilHealthy waits for the duration of the defined timeout or until the pod is healthy.
 // A healthy pod is in running phase and optionally in ready condition.
 //
@@ -1307,6 +1327,32 @@ func (builder *Builder) isMountAlreadyInUseInPod(newMount corev1.VolumeMount) {
 			}
 		}
 	}
+}
+
+// isObjectHealthy returns true if and only if the pod has succeeded or is running and ready. It only verifies builder
+// and builder.Object are not nil but otherwise relies on the caller to ensure the builder is valid.
+//
+// Unlike IsHealthy, this method does not check the pod exists first, saving a request to the apiClient.
+func (builder *Builder) isObjectHealthy() bool {
+	if builder == nil || builder.Object == nil {
+		return false
+	}
+
+	if builder.Object.Status.Phase == corev1.PodSucceeded {
+		return true
+	}
+
+	if builder.Object.Status.Phase != corev1.PodRunning {
+		return false
+	}
+
+	for _, condition := range builder.Object.Status.Conditions {
+		if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+
+	return false
 }
 
 func isMountInUse(containerMounts []corev1.VolumeMount, newMount corev1.VolumeMount) bool {


### PR DESCRIPTION
This is part 1 of a 3 part effort to replace pod.WaitForAllPodsInNamespacesHealthy.

1. (This PR) Add new helpers to eco-goinfra that simplify waiting for pods healthy and list on every iteration.
2. Change the cluster.WaitForRecover function to use the new eco-goinfra helpers. Also a small change in cnf/ran/talm.
3. Remove the old helpers from eco-goinfra.

Motivation:

The old WaitForRecover function would list the pods each iteration, ensuring that pods started after calling the function will be checked as well as ignoring pods that later end up deleted. A workaround for the latter of these issues was merged in #808.

Additionally, the current pod.WaitForAllPodsInNamespacesHealthy has too many parameters and is hard to test properly. The current unit tests for it do not adequately cover all scenarios. This function only gets used in one place in eco-gotests, the aforementioned cluster.WaitForRecover, where many parameters will always be the same.

The new eco-goinfra helpers introduced in this PR will notably exclude the ignoreNamespaces option. It is a remnant of an issue specific to the cnf/ran team that no longer exists and can safely be removed to simplify the helpers further.