### PR TITLE
olm: added Update() method and unit test

### DIFF
--- a/pkg/olm/clusterserviceversion_test.go
+++ b/pkg/olm/clusterserviceversion_test.go
@@ -174,26 +174,39 @@ func TestClusterServiceDelete(t *testing.T) {
 
 func TestClusterServiceVersionUpdate(t *testing.T) {
 	testCases := []struct {
-		clusterServiceVersion *ClusterServiceVersionBuilder
-		expectedError         string
-		displayName           string
+		testBuilder   *ClusterServiceVersionBuilder
+		expectedError error
+		displayName   string
 	}{
 		{
-			clusterServiceVersion: buildValidClusterServiceBuilder(buildTestClientWithDummyClusterServiceObject()),
-			expectedError:         "",
-			displayName:           "newName",
+			testBuilder:   buildValidClusterServiceBuilder(buildTestClientWithDummyClusterServiceObject()),
+			expectedError: nil,
+			displayName:   "newName",
+		},
+		{
+			testBuilder: buildValidClusterServiceBuilder(
+				clients.GetTestClients(clients.TestClientParams{SchemeAttachers: testSchemes})),
+			expectedError: fmt.Errorf("cannot update non-existent ClusterServiceVersion"),
+			displayName:   "newName",
+		},
+		{
+			testBuilder:   buildInvalidClusterServiceBuilder(),
+			expectedError: fmt.Errorf("ClusterServiceVersion builder cannot have nil apiClient"),
+			displayName:   "newName",
 		},
 	}
 
 	for _, testCase := range testCases {
-		csv, _ := testCase.clusterServiceVersion.Get()
-		assert.Equal(t, csv.Spec.DisplayName, "test")
+		assert.NotEqual(t, testCase.testBuilder.Definition.Spec.DisplayName, testCase.displayName)
 
-		testCase.clusterServiceVersion.Definition.Spec.DisplayName = testCase.displayName
+		testCase.testBuilder.Definition.Spec.DisplayName = testCase.displayName
 
-		_, _ = testCase.clusterServiceVersion.Update()
-		csv, _ = testCase.clusterServiceVersion.Get()
-		assert.Equal(t, csv.Spec.DisplayName, testCase.displayName)
+		testBuilder, err := testCase.testBuilder.Update()
+		assert.Equal(t, testCase.expectedError, err)
+
+		if testCase.expectedError == nil {
+			assert.Equal(t, testBuilder.Object.Spec.DisplayName, testCase.displayName)
+		}
 	}
 }
 
@@ -304,6 +317,10 @@ func buildValidClusterServiceBuilder(apiClient *clients.Settings) *ClusterServic
 	return newClusterServiceBuilder(apiClient, "clusterservice", "test-namespace")
 }
 
+func buildInvalidClusterServiceBuilder() *ClusterServiceVersionBuilder {
+	return invalidClusterServiceBuilder("clusterservice", "test-namespace")
+}
+
 func buildTestClientWithDummyClusterServiceObject() *clients.Settings {
 	return clients.GetTestClients(clients.TestClientParams{
 		K8sMockObjects:  buildDummyClusterService(nil, ""),
@@ -363,6 +380,19 @@ func buildDummyClusterService(
 func newClusterServiceBuilder(apiClient *clients.Settings, name, namespace string) *ClusterServiceVersionBuilder {
 	return &ClusterServiceVersionBuilder{
 		apiClient: apiClient,
+		Definition: &oplmV1alpha1.ClusterServiceVersion{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Spec: oplmV1alpha1.ClusterServiceVersionSpec{
+				DisplayName: "test",
+			}}}
+}
+
+func invalidClusterServiceBuilder(name, namespace string) *ClusterServiceVersionBuilder {
+	return &ClusterServiceVersionBuilder{
+		apiClient: nil,
 		Definition: &oplmV1alpha1.ClusterServiceVersion{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,

--- a/pkg/olm/clusterserviceversion_test.go
+++ b/pkg/olm/clusterserviceversion_test.go
@@ -175,21 +175,23 @@ func TestClusterServiceDelete(t *testing.T) {
 func TestClusterServiceVersionUpdate(t *testing.T) {
 	testCases := []struct {
 		clusterServiceVersion *ClusterServiceVersionBuilder
-		expectedError     string
-		displayName string
+		expectedError         string
+		displayName           string
 	}{
 		{
 			clusterServiceVersion: buildValidClusterServiceBuilder(buildTestClientWithDummyClusterServiceObject()),
-			expectedError:     "",
-			displayName: "newName",
+			expectedError:         "",
+			displayName:           "newName",
 		},
 	}
 
 	for _, testCase := range testCases {
 		csv, _ := testCase.clusterServiceVersion.Get()
 		assert.Equal(t, csv.Spec.DisplayName, "test")
+
 		testCase.clusterServiceVersion.Definition.Spec.DisplayName = testCase.displayName
-		testCase.clusterServiceVersion.Update()
+
+		_, _ = testCase.clusterServiceVersion.Update()
 		csv, _ = testCase.clusterServiceVersion.Get()
 		assert.Equal(t, csv.Spec.DisplayName, testCase.displayName)
 	}

--- a/pkg/olm/clusterserviceversion_test.go
+++ b/pkg/olm/clusterserviceversion_test.go
@@ -172,6 +172,29 @@ func TestClusterServiceDelete(t *testing.T) {
 	}
 }
 
+func TestClusterServiceVersionUpdate(t *testing.T) {
+	testCases := []struct {
+		clusterServiceVersion *ClusterServiceVersionBuilder
+		expectedError     string
+		displayName string
+	}{
+		{
+			clusterServiceVersion: buildValidClusterServiceBuilder(buildTestClientWithDummyClusterServiceObject()),
+			expectedError:     "",
+			displayName: "newName",
+		},
+	}
+
+	for _, testCase := range testCases {
+		csv, _ := testCase.clusterServiceVersion.Get()
+		assert.Equal(t, csv.Spec.DisplayName, "test")
+		testCase.clusterServiceVersion.Definition.Spec.DisplayName = testCase.displayName
+		testCase.clusterServiceVersion.Update()
+		csv, _ = testCase.clusterServiceVersion.Get()
+		assert.Equal(t, csv.Spec.DisplayName, testCase.displayName)
+	}
+}
+
 func TestClusterServiceGetAlmExamples(t *testing.T) {
 	testCases := []struct {
 		clusterService *ClusterServiceVersionBuilder


### PR DESCRIPTION
For the ORAN tests it is necessary to be able to update a CSV. This PR adds the Update() method to the olm package and the corresponding unit test.