### PR TITLE
PoC: Add nightly OCP integration test

### DIFF
--- a/.github/workflows/eco-gotests-integration.yml
+++ b/.github/workflows/eco-gotests-integration.yml
@@ -17,15 +17,15 @@ jobs:
       ECO_GOTESTS_REPO: openshift-kni/eco-gotests
 
     steps:
-      - name: Set up Go 1.23
-        if: ${{ !contains(github.event.*.labels.*.name, 'ignore-dep-check') }}
-        uses: actions/setup-go@v5
-        with:
-          go-version: 1.23.6
-
       - name: Check out the eco-goinfra code
         if: ${{ !contains(github.event.*.labels.*.name, 'ignore-dep-check') }}
         uses: actions/checkout@v4
+
+      - name: Set up Go
+        if: ${{ !contains(github.event.*.labels.*.name, 'ignore-dep-check') }}
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
 
       - name: Check out the eco-gotests code
         if: ${{ !contains(github.event.*.labels.*.name, 'ignore-dep-check') }}

--- a/.github/workflows/integration-testing-nightly.yml
+++ b/.github/workflows/integration-testing-nightly.yml
@@ -1,0 +1,61 @@
+name: Integration Testing
+
+on:
+  workflow_dispatch:
+  # Triggers the workflow every day
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  integration-k8s:
+    if: github.repository_owner == 'openshift-kni'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, ubuntu-22.04-arm]
+    env:
+      SHELL: /bin/bash
+      KUBECONFIG: '/home/runner/.kube/config'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Setup cluster (k8s)
+        uses: palmsoftware/quick-k8s@v0.0.21
+
+      - name: Run integration tests
+        run: make integration-test
+
+  integration-ocp:
+    if: github.repository_owner == 'openshift-kni'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-22.04]
+    env:
+      SHELL: /bin/bash
+      KUBECONFIG: '/home/runner/.kube/config'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Setup cluster (ocp)
+        uses: palmsoftware/quick-ocp@v0.0.6
+        with:
+          ocpPullSecret: $OCP_PULL_SECRET
+          bundleCache: true
+        env:
+          OCP_PULL_SECRET: ${{ secrets.OCP_PULL_SECRET }}
+
+      - name: Run integration tests
+        run: make integration-test

--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -20,10 +20,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Go 1.23
+      - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23.5
+          go-version-file: go.mod
 
       - name: Setup cluster (k8s)
         uses: palmsoftware/quick-k8s@v0.0.21

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -19,12 +19,12 @@ jobs:
       SHELL: /bin/bash
 
     steps:
-      - name: Set up Go 1.23
+      - uses: actions/checkout@v4
+      
+      - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23.6
-
-      - uses: actions/checkout@v4
+          go-version-file: go.mod
 
       - name: Run lint
         run: make lint
@@ -35,12 +35,12 @@ jobs:
       SHELL: /bin/bash
 
     steps:
-      - name: Set up Go 1.23
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23.6
-
-      - uses: actions/checkout@v4
+          go-version-file: go.mod
 
       - name: Run unit tests
         run: make test

--- a/.github/workflows/sync-libs.yaml
+++ b/.github/workflows/sync-libs.yaml
@@ -25,10 +25,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Go 1.23
+      - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23.6
+          go-version-file: go.mod
 
       - name: Run sync script
         run: make lib-sync


### PR DESCRIPTION
Adds a nightly YAML for triggering both k8s and OCP runs nightly (not tied to any PR).

This runs the exact `make integration-test` path, but against OCP in a nightly fashion.

Brings in changes from:
- #937 
- #961 