### PR TITLE
imageregistry: update to use scheme attachers

### DIFF
--- a/pkg/clients/clients.go
+++ b/pkg/clients/clients.go
@@ -291,8 +291,6 @@ func GetModifiableTestClients(tcp TestClientParams) (*Settings, *fakeRuntimeClie
 			genericClientObjects = append(genericClientObjects, v)
 		case *operatorv1.Console:
 			genericClientObjects = append(genericClientObjects, v)
-		case *imageregistryV1.Config:
-			genericClientObjects = append(genericClientObjects, v)
 		case *configV1.ClusterOperator:
 			genericClientObjects = append(genericClientObjects, v)
 		case *agentInstallV1Beta1.AgentServiceConfig:

--- a/pkg/imageregistry/imageregistry.go
+++ b/pkg/imageregistry/imageregistry.go
@@ -33,16 +33,19 @@ type Builder struct {
 
 // Pull retrieves an existing imageRegistry object from the cluster.
 func Pull(apiClient *clients.Settings, imageRegistryObjName string) (*Builder, error) {
+	glog.V(100).Infof("Pulling existing imageRegistry Config %s", imageRegistryObjName)
+
 	if apiClient == nil {
 		glog.V(100).Infof("The apiClient is empty")
 
 		return nil, fmt.Errorf("imageRegistry Config 'apiClient' cannot be empty")
 	}
 
-	if imageRegistryObjName == "" {
-		glog.V(100).Infof("The name of the imageRegistry is empty")
+	err := apiClient.AttachScheme(imageregistryv1.Install)
+	if err != nil {
+		glog.V(100).Infof("Failed to attach imageregistry v1 scheme: %v", err)
 
-		return nil, fmt.Errorf("imageRegistry 'imageRegistryObjName' cannot be empty")
+		return nil, err
 	}
 
 	glog.V(100).Infof(
@@ -55,6 +58,12 @@ func Pull(apiClient *clients.Settings, imageRegistryObjName string) (*Builder, e
 				Name: imageRegistryObjName,
 			},
 		},
+	}
+
+	if imageRegistryObjName == "" {
+		glog.V(100).Infof("The name of the imageRegistry is empty")
+
+		return nil, fmt.Errorf("imageRegistry 'imageRegistryObjName' cannot be empty")
 	}
 
 	if !builder.Exists() {


### PR DESCRIPTION
Although the imageregistry package has been updated to use the controller-runtime client already, it still uses the switch statement in the clients package to add objects rather than AttachScheme like other packages. This PR updates the package and removes the case from the clients package.