### PR TITLE
integration: add daemonset tests

### DIFF
--- a/integration/daemonset_test.go
+++ b/integration/daemonset_test.go
@@ -9,9 +9,7 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/daemonset"
 	"github.com/openshift-kni/eco-goinfra/pkg/namespace"
-	"github.com/openshift-kni/eco-goinfra/pkg/pod"
 	"github.com/stretchr/testify/assert"
-	corev1 "k8s.io/api/core/v1"
 )
 
 func TestDaemonsetCreate(t *testing.T) {
@@ -25,8 +23,8 @@ func TestDaemonsetCreate(t *testing.T) {
 	)
 
 	// Create a namespace in the cluster using the namespaces package
-	namespaceBuilder, err := namespace.NewBuilder(client, testNamespace).Create()
-	assert.Nil(t, err)
+	namespaceBuilder := namespace.NewBuilder(client, testNamespace)
+	assert.Nil(t, PreEmptiveNamespaceDeleteAndSetup(testNamespace, namespaceBuilder))
 
 	// Defer the deletion of the namespace
 	defer func() {
@@ -35,15 +33,7 @@ func TestDaemonsetCreate(t *testing.T) {
 		assert.Nil(t, err)
 	}()
 
-	testContainerBuilder := pod.NewContainerBuilder("test", containerImage, []string{"sleep", "3600"})
-	containerDefinition, err := testContainerBuilder.GetContainerCfg()
-	assert.Nil(t, err)
-
-	// Change the container default security context to something that is allowed in the test environment
-	testContainerBuilder.WithSecurityContext(&corev1.SecurityContext{
-		RunAsUser:  nil,
-		RunAsGroup: nil,
-	})
+	containerDefinition, err := CreateTestContainerDefinition("test", containerImage, []string{"sleep", "3600"})
 
 	daemonsetBuilder := daemonset.NewBuilder(client, daemonsetName, testNamespace, map[string]string{
 		"app": "test",
@@ -70,8 +60,8 @@ func TestDaemonsetDelete(t *testing.T) {
 	)
 
 	// Create a namespace in the cluster using the namespaces package
-	namespaceBuilder, err := namespace.NewBuilder(client, testNamespace).Create()
-	assert.Nil(t, err)
+	namespaceBuilder := namespace.NewBuilder(client, testNamespace)
+	assert.Nil(t, PreEmptiveNamespaceDeleteAndSetup(testNamespace, namespaceBuilder))
 
 	// Defer the deletion of the namespace
 	defer func() {
@@ -80,15 +70,7 @@ func TestDaemonsetDelete(t *testing.T) {
 		assert.Nil(t, err)
 	}()
 
-	testContainerBuilder := pod.NewContainerBuilder("test", containerImage, []string{"sleep", "3600"})
-	containerDefinition, err := testContainerBuilder.GetContainerCfg()
-	assert.Nil(t, err)
-
-	// Change the container default security context to something that is allowed in the test environment
-	testContainerBuilder.WithSecurityContext(&corev1.SecurityContext{
-		RunAsUser:  nil,
-		RunAsGroup: nil,
-	})
+	containerDefinition, err := CreateTestContainerDefinition("test", containerImage, []string{"sleep", "3600"})
 
 	daemonsetBuilder := daemonset.NewBuilder(client, daemonsetName, testNamespace, map[string]string{
 		"app": "test",

--- a/integration/daemonset_test.go
+++ b/integration/daemonset_test.go
@@ -1,0 +1,114 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/openshift-kni/eco-goinfra/pkg/clients"
+	"github.com/openshift-kni/eco-goinfra/pkg/daemonset"
+	"github.com/openshift-kni/eco-goinfra/pkg/namespace"
+	"github.com/openshift-kni/eco-goinfra/pkg/pod"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestDaemonsetCreate(t *testing.T) {
+	t.Parallel()
+	client := clients.New("")
+	assert.NotNil(t, client)
+
+	var (
+		testNamespace = "egi-daemonset-create-ns"
+		daemonsetName = "create-test"
+	)
+
+	// Create a namespace in the cluster using the namespaces package
+	namespaceBuilder, err := namespace.NewBuilder(client, testNamespace).Create()
+	assert.Nil(t, err)
+
+	// Defer the deletion of the namespace
+	defer func() {
+		// Delete the namespace
+		err := namespaceBuilder.Delete()
+		assert.Nil(t, err)
+	}()
+
+	testContainerBuilder := pod.NewContainerBuilder("test", containerImage, []string{"sleep", "3600"})
+	containerDefinition, err := testContainerBuilder.GetContainerCfg()
+	assert.Nil(t, err)
+
+	// Change the container default security context to something that is allowed in the test environment
+	testContainerBuilder.WithSecurityContext(&corev1.SecurityContext{
+		RunAsUser:  nil,
+		RunAsGroup: nil,
+	})
+
+	daemonsetBuilder := daemonset.NewBuilder(client, daemonsetName, testNamespace, map[string]string{
+		"app": "test",
+	}, *containerDefinition)
+
+	// Create a daemonset in the namespace
+	_, err = daemonsetBuilder.CreateAndWaitUntilReady(timeoutDuration)
+	assert.Nil(t, err)
+
+	// Check if the daemonset was created
+	daemonsetBuilder, err = daemonset.Pull(client, daemonsetName, testNamespace)
+	assert.Nil(t, err)
+	assert.NotNil(t, daemonsetBuilder.Object)
+}
+
+func TestDaemonsetDelete(t *testing.T) {
+	t.Parallel()
+	client := clients.New("")
+	assert.NotNil(t, client)
+
+	var (
+		testNamespace = "egi-daemonset-delete-ns"
+		daemonsetName = "delete-test"
+	)
+
+	// Create a namespace in the cluster using the namespaces package
+	namespaceBuilder, err := namespace.NewBuilder(client, testNamespace).Create()
+	assert.Nil(t, err)
+
+	// Defer the deletion of the namespace
+	defer func() {
+		// Delete the namespace
+		err := namespaceBuilder.Delete()
+		assert.Nil(t, err)
+	}()
+
+	testContainerBuilder := pod.NewContainerBuilder("test", containerImage, []string{"sleep", "3600"})
+	containerDefinition, err := testContainerBuilder.GetContainerCfg()
+	assert.Nil(t, err)
+
+	// Change the container default security context to something that is allowed in the test environment
+	testContainerBuilder.WithSecurityContext(&corev1.SecurityContext{
+		RunAsUser:  nil,
+		RunAsGroup: nil,
+	})
+
+	daemonsetBuilder := daemonset.NewBuilder(client, daemonsetName, testNamespace, map[string]string{
+		"app": "test",
+	}, *containerDefinition)
+
+	// Create a daemonset in the namespace
+	_, err = daemonsetBuilder.CreateAndWaitUntilReady(timeoutDuration)
+	assert.Nil(t, err)
+
+	// Check if the daemonset was created
+	daemonsetBuilder, err = daemonset.Pull(client, daemonsetName, testNamespace)
+	assert.Nil(t, err)
+	assert.NotNil(t, daemonsetBuilder.Object)
+
+	// Delete the daemonset
+	err = daemonsetBuilder.Delete()
+	assert.Nil(t, err)
+
+	// Check if the daemonset was deleted
+	daemonsetBuilder, err = daemonset.Pull(client, daemonsetName, testNamespace)
+	assert.NotNil(t, err)
+	assert.Nil(t, daemonsetBuilder)
+}

--- a/pkg/daemonset/daemonset.go
+++ b/pkg/daemonset/daemonset.go
@@ -321,13 +321,13 @@ func (builder *Builder) Delete() error {
 	err := builder.apiClient.Delete(
 		context.TODO(), builder.Definition.Name, metav1.DeleteOptions{})
 
-	if err != nil {
+	if err != nil && !k8serrors.IsNotFound(err) {
 		return err
 	}
 
 	builder.Object = nil
 
-	return err
+	return nil
 }
 
 // CreateAndWaitUntilReady creates a daemonset in the cluster and waits until the daemonset is available.
@@ -356,6 +356,17 @@ func (builder *Builder) CreateAndWaitUntilReady(timeout time.Duration) (*Builder
 				return false, nil
 			}
 
+			// Check if the daemonset is ready.
+			//nolint:gocritic
+			if builder.Object.Status.DesiredNumberScheduled == builder.Object.Status.CurrentNumberScheduled &&
+				builder.Object.Status.DesiredNumberScheduled == builder.Object.Status.NumberReady &&
+				builder.Object.Status.DesiredNumberScheduled == builder.Object.Status.NumberAvailable &&
+				builder.Object.Status.NumberUnavailable == 0 &&
+				builder.Object.Status.NumberReady > 0 {
+				return true, nil
+			}
+
+			// If none of the conditions above are met, evaluate the daemonset conditions.
 			for _, condition := range builder.Object.Status.Conditions {
 				if condition.Type == "Available" {
 					return condition.Status == "True", nil


### PR DESCRIPTION
- Added Create and Delete integration tests for the `daemonset` resource.
- I had to modify the `IsDaemonsetReady` to actually match what we do in the `certsuite-qe` repo [here](https://github.com/redhat-best-practices-for-k8s/certsuite-qe/blob/main/tests/globalhelper/daemonset.go#L60-L66).  For some reason, when testing, the `status` wouldn't have conditions listed and it would never come back as ready.  When this merges, I'll change our QE to use the eco-goinfra logic.
- I also added `!k8serrors.IsNotFound(err)` to the daemonset `Delete()` to better handle already "missing" daemonsets.

Related to: 
- #714 