### PR TITLE
integration: add configmap test

### DIFF
--- a/integration/common.go
+++ b/integration/common.go
@@ -1,0 +1,50 @@
+package integration
+
+import (
+	"errors"
+	"time"
+
+	"github.com/openshift-kni/eco-goinfra/pkg/namespace"
+	"github.com/openshift-kni/eco-goinfra/pkg/pod"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// PreEmptiveNamespaceDeleteAndSetup deletes the namespace preemptively and sets it up for the test.
+func PreEmptiveNamespaceDeleteAndSetup(namespace string, namespaceBuilder *namespace.Builder) error {
+	if namespaceBuilder == nil {
+		return errors.New("namespaceBuilder is nil")
+	}
+
+	// Preemptively delete the namespace before the test.
+	err := namespaceBuilder.DeleteAndWait(time.Duration(30) * time.Second)
+	if err != nil {
+		return err
+	}
+
+	// Create the namespace
+	_, err = namespaceBuilder.Create()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// CreateTestContainerDefinition creates a container definition for the test.
+func CreateTestContainerDefinition(containerName string, containerImage string,
+	command []string) (*corev1.Container, error) {
+	testContainerBuilder := pod.NewContainerBuilder(containerName, containerImage, command)
+
+	// Change the container default security context to something that is allowed in the test environment
+	testContainerBuilder.WithSecurityContext(&corev1.SecurityContext{
+		RunAsUser:  nil,
+		RunAsGroup: nil,
+	})
+
+	containerDefinition, err := testContainerBuilder.GetContainerCfg()
+	if err != nil {
+		return nil, err
+	}
+
+	return containerDefinition, nil
+}

--- a/integration/configmap_test.go
+++ b/integration/configmap_test.go
@@ -1,0 +1,105 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/openshift-kni/eco-goinfra/pkg/clients"
+	"github.com/openshift-kni/eco-goinfra/pkg/configmap"
+	"github.com/openshift-kni/eco-goinfra/pkg/namespace"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigmapCreate(t *testing.T) {
+	t.Parallel()
+	client := clients.New("")
+	assert.NotNil(t, client)
+
+	var (
+		testNamespace = "egi-configmap-create-ns"
+		configmapName = "create-test"
+	)
+
+	// Create a namespace in the cluster using the namespaces package
+	namespaceBuilder := namespace.NewBuilder(client, testNamespace)
+	assert.NotNil(t, namespaceBuilder)
+
+	// Preemptively delete the namespace before the test
+	err := namespaceBuilder.DeleteAndWait(time.Duration(30) * time.Second)
+	assert.Nil(t, err)
+
+	// Create the namespace
+	namespaceBuilder, err = namespaceBuilder.Create()
+	assert.Nil(t, err)
+
+	// Defer the deletion of the namespace
+	defer func() {
+		// Delete the namespace
+		err := namespaceBuilder.Delete()
+		assert.Nil(t, err)
+	}()
+
+	configmapBuilder := configmap.NewBuilder(client, configmapName, testNamespace)
+
+	// Create a configmap in the namespace
+	_, err = configmapBuilder.Create()
+	assert.Nil(t, err)
+
+	// Check if the configmap was created
+	configmapBuilder, err = configmap.Pull(client, configmapName, testNamespace)
+	assert.Nil(t, err)
+	assert.NotNil(t, configmapBuilder.Object)
+}
+
+func TestConfigmapDelete(t *testing.T) {
+	t.Parallel()
+	client := clients.New("")
+	assert.NotNil(t, client)
+
+	var (
+		testNamespace = "egi-configmap-delete-ns"
+		configmapName = "delete-test"
+	)
+
+	// Create a namespace in the cluster using the namespaces package
+	namespaceBuilder := namespace.NewBuilder(client, testNamespace)
+	assert.NotNil(t, namespaceBuilder)
+
+	// Preemptively delete the namespace before the test
+	err := namespaceBuilder.DeleteAndWait(time.Duration(30) * time.Second)
+	assert.Nil(t, err)
+
+	// Create the namespace
+	namespaceBuilder, err = namespaceBuilder.Create()
+	assert.Nil(t, err)
+
+	// Defer the deletion of the namespace
+	defer func() {
+		// Delete the namespace
+		err := namespaceBuilder.Delete()
+		assert.Nil(t, err)
+	}()
+
+	configmapBuilder := configmap.NewBuilder(client, configmapName, testNamespace)
+
+	// Create a configmap in the namespace
+	_, err = configmapBuilder.Create()
+	assert.Nil(t, err)
+
+	// Check if the configmap was created
+	configmapBuilder, err = configmap.Pull(client, configmapName, testNamespace)
+	assert.Nil(t, err)
+	assert.NotNil(t, configmapBuilder.Object)
+
+	// Delete the configmap
+	err = configmapBuilder.Delete()
+	assert.Nil(t, err)
+
+	// Check if the configmap was deleted
+	configmapBuilder, err = configmap.Pull(client, configmapName, testNamespace)
+	assert.NotNil(t, err)
+	assert.Nil(t, configmapBuilder)
+}

--- a/integration/configmap_test.go
+++ b/integration/configmap_test.go
@@ -5,7 +5,6 @@ package integration
 
 import (
 	"testing"
-	"time"
 
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/configmap"
@@ -25,15 +24,7 @@ func TestConfigmapCreate(t *testing.T) {
 
 	// Create a namespace in the cluster using the namespaces package
 	namespaceBuilder := namespace.NewBuilder(client, testNamespace)
-	assert.NotNil(t, namespaceBuilder)
-
-	// Preemptively delete the namespace before the test
-	err := namespaceBuilder.DeleteAndWait(time.Duration(30) * time.Second)
-	assert.Nil(t, err)
-
-	// Create the namespace
-	namespaceBuilder, err = namespaceBuilder.Create()
-	assert.Nil(t, err)
+	assert.Nil(t, PreEmptiveNamespaceDeleteAndSetup(testNamespace, namespaceBuilder))
 
 	// Defer the deletion of the namespace
 	defer func() {
@@ -45,7 +36,7 @@ func TestConfigmapCreate(t *testing.T) {
 	configmapBuilder := configmap.NewBuilder(client, configmapName, testNamespace)
 
 	// Create a configmap in the namespace
-	_, err = configmapBuilder.Create()
+	_, err := configmapBuilder.Create()
 	assert.Nil(t, err)
 
 	// Check if the configmap was created
@@ -66,15 +57,7 @@ func TestConfigmapDelete(t *testing.T) {
 
 	// Create a namespace in the cluster using the namespaces package
 	namespaceBuilder := namespace.NewBuilder(client, testNamespace)
-	assert.NotNil(t, namespaceBuilder)
-
-	// Preemptively delete the namespace before the test
-	err := namespaceBuilder.DeleteAndWait(time.Duration(30) * time.Second)
-	assert.Nil(t, err)
-
-	// Create the namespace
-	namespaceBuilder, err = namespaceBuilder.Create()
-	assert.Nil(t, err)
+	assert.Nil(t, PreEmptiveNamespaceDeleteAndSetup(testNamespace, namespaceBuilder))
 
 	// Defer the deletion of the namespace
 	defer func() {
@@ -86,7 +69,7 @@ func TestConfigmapDelete(t *testing.T) {
 	configmapBuilder := configmap.NewBuilder(client, configmapName, testNamespace)
 
 	// Create a configmap in the namespace
-	_, err = configmapBuilder.Create()
+	_, err := configmapBuilder.Create()
 	assert.Nil(t, err)
 
 	// Check if the configmap was created

--- a/integration/deployment_test.go
+++ b/integration/deployment_test.go
@@ -32,17 +32,9 @@ func TestDeploymentCreate(t *testing.T) {
 		deploymentName = "create-test"
 	)
 
-	// Create a namespace in the cluster using the namespaces package
+	// Setup namespace for the test
 	namespaceBuilder := namespace.NewBuilder(client, testNamespace)
-	assert.NotNil(t, namespaceBuilder)
-
-	// Preemptively delete the namespace before the test
-	err := namespaceBuilder.DeleteAndWait(time.Duration(30) * time.Second)
-	assert.Nil(t, err)
-
-	// Create the namespace
-	namespaceBuilder, err = namespaceBuilder.Create()
-	assert.Nil(t, err)
+	assert.Nil(t, PreEmptiveNamespaceDeleteAndSetup(testNamespace, namespaceBuilder))
 
 	// Defer the deletion of the namespace
 	defer func() {
@@ -51,15 +43,8 @@ func TestDeploymentCreate(t *testing.T) {
 		assert.Nil(t, err)
 	}()
 
-	testContainerBuilder := pod.NewContainerBuilder("test", containerImage, []string{"sleep", "3600"})
-	containerDefinition, err := testContainerBuilder.GetContainerCfg()
+	containerDefinition, err := CreateTestContainerDefinition("test", containerImage, []string{"sleep", "3600"})
 	assert.Nil(t, err)
-
-	// Change the container default security context to something that is allowed in the test environment
-	testContainerBuilder.WithSecurityContext(&corev1.SecurityContext{
-		RunAsUser:  nil,
-		RunAsGroup: nil,
-	})
 
 	deploymentBuilder := deployment.NewBuilder(client, deploymentName, testNamespace, map[string]string{
 		"app": "test",
@@ -87,18 +72,7 @@ func TestDeploymentDelete(t *testing.T) {
 
 	// Create a namespace in the cluster using the namespaces package
 	namespaceBuilder := namespace.NewBuilder(client, testNamespace)
-	assert.NotNil(t, namespaceBuilder)
-
-	// Preemptively delete the namespace before the test
-	err := namespaceBuilder.DeleteAndWait(time.Duration(30) * time.Second)
-	assert.Nil(t, err)
-
-	// Create the namespace
-	namespaceBuilder, err = namespaceBuilder.Create()
-	assert.Nil(t, err)
-
-	// Create the namespace
-	namespaceBuilder, err = namespaceBuilder.Create()
+	assert.Nil(t, PreEmptiveNamespaceDeleteAndSetup(testNamespace, namespaceBuilder))
 
 	// Defer the deletion of the namespace
 	defer func() {
@@ -107,15 +81,8 @@ func TestDeploymentDelete(t *testing.T) {
 		assert.Nil(t, err)
 	}()
 
-	testContainerBuilder := pod.NewContainerBuilder("test", containerImage, []string{"sleep", "3600"})
-	containerDefinition, err := testContainerBuilder.GetContainerCfg()
+	containerDefinition, err := CreateTestContainerDefinition("test", containerImage, []string{"sleep", "3600"})
 	assert.Nil(t, err)
-
-	// Change the container default security context to something that is allowed in the test environment
-	testContainerBuilder.WithSecurityContext(&corev1.SecurityContext{
-		RunAsUser:  nil,
-		RunAsGroup: nil,
-	})
 
 	deploymentBuilder := deployment.NewBuilder(client, deploymentName, testNamespace, map[string]string{
 		"app": "test",

--- a/integration/deployment_test.go
+++ b/integration/deployment_test.go
@@ -95,6 +95,10 @@ func TestDeploymentDelete(t *testing.T) {
 
 	// Create the namespace
 	namespaceBuilder, err = namespaceBuilder.Create()
+	assert.Nil(t, err)
+
+	// Create the namespace
+	namespaceBuilder, err = namespaceBuilder.Create()
 
 	// Defer the deletion of the namespace
 	defer func() {
@@ -153,6 +157,10 @@ func TestDeploymentWithReplicas(t *testing.T) {
 
 	// Preemptively delete the namespace before the test
 	err := namespaceBuilder.DeleteAndWait(time.Duration(30) * time.Second)
+	assert.Nil(t, err)
+
+	// Create the namespace
+	namespaceBuilder, err = namespaceBuilder.Create()
 	assert.Nil(t, err)
 
 	// Create the namespace


### PR DESCRIPTION
- Add tests for `configmap` package.
- I also had to modify the `deployment` package to better handle running in parallel.  I made a separate PR to adjust it [here](https://github.com/openshift-kni/eco-goinfra/pull/951).

Related to: https://github.com/openshift-kni/eco-goinfra/pull/714