### PR TITLE
lca: changed returned error in seedgenerator waituntilcomplete

### DIFF
--- a/pkg/lca/seedgenerator.go
+++ b/pkg/lca/seedgenerator.go
@@ -298,7 +298,7 @@ func (builder *SeedGeneratorBuilder) WaitUntilComplete(timeout time.Duration) (*
 				}
 			}
 
-			return false, fmt.Errorf("seedgenerator did not complete")
+			return false, nil
 		})
 
 	if err == nil {

--- a/pkg/lca/seedgenerator_test.go
+++ b/pkg/lca/seedgenerator_test.go
@@ -1,6 +1,7 @@
 package lca
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -309,7 +310,7 @@ func TestSeedGeneratorWaitUntilComplete(t *testing.T) {
 		status        lcasgv1.SeedGeneratorStatus
 	}{
 		{
-			expectedError: fmt.Errorf("seedgenerator did not complete"),
+			expectedError: context.DeadlineExceeded,
 			status: lcasgv1.SeedGeneratorStatus{
 				Conditions: []metav1.Condition{{Status: "True1", Type: "SeedGenCompleted", Reason: "Completed"}},
 			},


### PR DESCRIPTION
The WaitUntilComplete() function was not behaving correctly. It was not pollling until the deadline because the return of the fmt.Errorf("seedgenerator did not complete") was making the loop to stop. This PR changes the returned error when the condition is not met and updates the unit test accordingly.