### PR TITLE
integration: add common funcs

### DIFF
--- a/integration/common.go
+++ b/integration/common.go
@@ -1,0 +1,50 @@
+package integration
+
+import (
+	"errors"
+	"time"
+
+	"github.com/openshift-kni/eco-goinfra/pkg/namespace"
+	"github.com/openshift-kni/eco-goinfra/pkg/pod"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// PreEmptiveNamespaceDeleteAndSetup deletes the namespace preemptively and sets it up for the test.
+func PreEmptiveNamespaceDeleteAndSetup(namespace string, namespaceBuilder *namespace.Builder) error {
+	if namespaceBuilder == nil {
+		return errors.New("namespaceBuilder is nil")
+	}
+
+	// Preemptively delete the namespace before the test.
+	err := namespaceBuilder.DeleteAndWait(time.Duration(30) * time.Second)
+	if err != nil {
+		return err
+	}
+
+	// Create the namespace
+	_, err = namespaceBuilder.Create()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// CreateTestContainerDefinition creates a container definition for the test.
+func CreateTestContainerDefinition(containerName string, containerImage string,
+	command []string) (*corev1.Container, error) {
+	testContainerBuilder := pod.NewContainerBuilder(containerName, containerImage, command)
+
+	// Change the container default security context to something that is allowed in the test environment
+	testContainerBuilder.WithSecurityContext(&corev1.SecurityContext{
+		RunAsUser:  nil,
+		RunAsGroup: nil,
+	})
+
+	containerDefinition, err := testContainerBuilder.GetContainerCfg()
+	if err != nil {
+		return nil, err
+	}
+
+	return containerDefinition, nil
+}

--- a/integration/deployment_test.go
+++ b/integration/deployment_test.go
@@ -32,17 +32,9 @@ func TestDeploymentCreate(t *testing.T) {
 		deploymentName = "create-test"
 	)
 
-	// Create a namespace in the cluster using the namespaces package
+	// Setup namespace for the test
 	namespaceBuilder := namespace.NewBuilder(client, testNamespace)
-	assert.NotNil(t, namespaceBuilder)
-
-	// Preemptively delete the namespace before the test
-	err := namespaceBuilder.DeleteAndWait(time.Duration(30) * time.Second)
-	assert.Nil(t, err)
-
-	// Create the namespace
-	namespaceBuilder, err = namespaceBuilder.Create()
-	assert.Nil(t, err)
+	assert.Nil(t, PreEmptiveNamespaceDeleteAndSetup(testNamespace, namespaceBuilder))
 
 	// Defer the deletion of the namespace
 	defer func() {
@@ -51,15 +43,8 @@ func TestDeploymentCreate(t *testing.T) {
 		assert.Nil(t, err)
 	}()
 
-	testContainerBuilder := pod.NewContainerBuilder("test", containerImage, []string{"sleep", "3600"})
-	containerDefinition, err := testContainerBuilder.GetContainerCfg()
+	containerDefinition, err := CreateTestContainerDefinition("test", containerImage, []string{"sleep", "3600"})
 	assert.Nil(t, err)
-
-	// Change the container default security context to something that is allowed in the test environment
-	testContainerBuilder.WithSecurityContext(&corev1.SecurityContext{
-		RunAsUser:  nil,
-		RunAsGroup: nil,
-	})
 
 	deploymentBuilder := deployment.NewBuilder(client, deploymentName, testNamespace, map[string]string{
 		"app": "test",
@@ -87,14 +72,7 @@ func TestDeploymentDelete(t *testing.T) {
 
 	// Create a namespace in the cluster using the namespaces package
 	namespaceBuilder := namespace.NewBuilder(client, testNamespace)
-	assert.NotNil(t, namespaceBuilder)
-
-	// Preemptively delete the namespace before the test
-	err := namespaceBuilder.DeleteAndWait(time.Duration(30) * time.Second)
-	assert.Nil(t, err)
-
-	// Create the namespace
-	namespaceBuilder, err = namespaceBuilder.Create()
+	assert.Nil(t, PreEmptiveNamespaceDeleteAndSetup(testNamespace, namespaceBuilder))
 
 	// Defer the deletion of the namespace
 	defer func() {
@@ -103,15 +81,8 @@ func TestDeploymentDelete(t *testing.T) {
 		assert.Nil(t, err)
 	}()
 
-	testContainerBuilder := pod.NewContainerBuilder("test", containerImage, []string{"sleep", "3600"})
-	containerDefinition, err := testContainerBuilder.GetContainerCfg()
+	containerDefinition, err := CreateTestContainerDefinition("test", containerImage, []string{"sleep", "3600"})
 	assert.Nil(t, err)
-
-	// Change the container default security context to something that is allowed in the test environment
-	testContainerBuilder.WithSecurityContext(&corev1.SecurityContext{
-		RunAsUser:  nil,
-		RunAsGroup: nil,
-	})
 
 	deploymentBuilder := deployment.NewBuilder(client, deploymentName, testNamespace, map[string]string{
 		"app": "test",


### PR DESCRIPTION
Adds an `integration/common.go` with two funcs:
- CreateTestContainerDefinition()
- PreEmptiveNamespaceDeleteAndSetup()

Stuff that is "shared" between our various integration tests can be placed here to add more code re-use.