### PR TITLE
ci: prevent forks from running nightly crons

### DIFF
--- a/.github/workflows/sync-libs.yaml
+++ b/.github/workflows/sync-libs.yaml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   sync-libs:
+    if: github.repository_owner == 'openshift-kni'
     permissions:
       contents: write  # for peter-evans/create-pull-request to create branch
       pull-requests: write  # for peter-evans/create-pull-request to create a PR


### PR DESCRIPTION
Resolves: https://github.com/openshift-kni/eco-goinfra/issues/959

If any more `cron` related jobs (eg. #942) get added, they will also need the conditional statement.