### PR TITLE
sync: update label job if condition

### DIFF
--- a/.github/workflows/sync-libs.yaml
+++ b/.github/workflows/sync-libs.yaml
@@ -61,7 +61,7 @@ jobs:
     
   label:
     needs: [sync-libs, makefile, gotests, integration]
-    if: ${{ needs.sync-libs.result == 'success' && needs.sync-libs.outputs.pr-url }}
+    if: ${{ !cancelled() && needs.sync-libs.result == 'success' && needs.sync-libs.outputs.pr-url }}
 
     name: Label created PR
 


### PR DESCRIPTION
By default, GitHub actions will apply a `success()` condition to the if unless there is another status check function used. Since the label function is meant to run even if previous steps failed, we need to use a status check function to replace the default success condition. This PR adds a `!cancelled()` condition to address that and prevent issues where the job runs even if dependencies have been cancelled.