### PR TITLE
deps: Remove `openshift/api` replace directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/openshift-kni/oran-hwmgr-plugin/api/hwmgr-plugin v0.0.0-20250128160241-57fbcf565b32
 	github.com/openshift-kni/oran-o2ims/api/hardwaremanagement v0.0.0-20250129205116-6838db628c2b
 	github.com/openshift-kni/oran-o2ims/api/provisioning v0.0.0-20250123151805-c935b06062f9
-	github.com/openshift/api v3.9.1-0.20191111211345-a27ff30ebf09+incompatible
+	github.com/openshift/api v0.0.0-20241210155609-29859d55727b // release-4.18
 	github.com/openshift/client-go v0.0.0-20241107164952-923091dd2b1a
 	github.com/openshift/cluster-logging-operator v0.0.0-20241003210634-afb65cea19d1 // release-5.9
 	github.com/openshift/cluster-nfd-operator v0.0.0-20250116132220-e601a6278a42 // release-4.18
@@ -216,7 +216,6 @@ require (
 replace (
 	github.com/imdario/mergo => github.com/imdario/mergo v0.3.16
 	github.com/k8snetworkplumbingwg/sriov-network-operator => github.com/openshift/sriov-network-operator v0.0.0-20250102160645-f496851fbd0d // release-4.18
-	github.com/openshift/api => github.com/openshift/api v0.0.0-20241210155609-29859d55727b // release-4.18
 	github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1
 	k8s.io/client-go => k8s.io/client-go v0.31.5
 )

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -497,7 +497,7 @@ github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1
 # github.com/openshift-kni/oran-o2ims/api/provisioning v0.0.0-20250123151805-c935b06062f9
 ## explicit; go 1.22.0
 github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1
-# github.com/openshift/api v3.9.1-0.20191111211345-a27ff30ebf09+incompatible => github.com/openshift/api v0.0.0-20241210155609-29859d55727b
+# github.com/openshift/api v0.0.0-20241210155609-29859d55727b
 ## explicit; go 1.22.0
 github.com/openshift/api
 github.com/openshift/api/annotations
@@ -1685,6 +1685,5 @@ sigs.k8s.io/yaml/goyaml.v2
 sigs.k8s.io/yaml/goyaml.v3
 # github.com/imdario/mergo => github.com/imdario/mergo v0.3.16
 # github.com/k8snetworkplumbingwg/sriov-network-operator => github.com/openshift/sriov-network-operator v0.0.0-20250102160645-f496851fbd0d
-# github.com/openshift/api => github.com/openshift/api v0.0.0-20241210155609-29859d55727b
 # github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1
 # k8s.io/client-go => k8s.io/client-go v0.31.5


### PR DESCRIPTION
Using the `replace` directive causes trouble in dependant projects that need to generate installable binaries [1].

Also, there is no point in depending on an invalid version:
```
$ go get github.com/openshift/api@v3.9.1-0.20191111211345-a27ff30ebf09+incompatible
go: github.com/openshift/api@v3.9.1-0.20191111211345-a27ff30ebf09+incompatible: invalid pseudo-version: preceding tag (v3.9.0) not found
```

[1] https://github.com/golang/go/issues/44840

Please, note that this PR does not bring any real dependency changes, as `vendor/` directory go files are not affected.