### PR TITLE
bmc: added bootfromcd function

### DIFF
--- a/pkg/bmc/testdata/redfish_v1_system_virtual_media.json
+++ b/pkg/bmc/testdata/redfish_v1_system_virtual_media.json
@@ -1,0 +1,16 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#VirtualMediaCollection.VirtualMediaCollection",
+    "@odata.type": "#VirtualMediaCollection.VirtualMediaCollection",
+    "@odata.id": "/redfish/v1/Systems/System.Embedded.1/VirtualMedia",
+    "Description": "Collection of VirtualMedia",
+    "Members": [
+      {
+        "@odata.id": "/redfish/v1/Systems/System.Embedded.1/VirtualMedia/1"
+      },
+      {
+        "@odata.id": "/redfish/v1/Systems/System.Embedded.1/VirtualMedia/2"
+      }
+    ],
+    "Members@odata.count": 2,
+    "Name": "VirtualMedia Collection"
+  }

--- a/pkg/bmc/testdata/redfish_v1_system_virtual_media_1.json
+++ b/pkg/bmc/testdata/redfish_v1_system_virtual_media_1.json
@@ -1,0 +1,19 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#VirtualMedia.VirtualMedia",
+  "@odata.id": "/redfish/v1/Systems/System.Embedded.1/VirtualMedia/1",
+  "@odata.type": "#VirtualMedia.v1_6_1.VirtualMedia",
+  "VirtualMediaEnabled": true,
+  "VirtualMediaReference": "1",
+  "ID": "1",
+  "Image": "",
+  "Inserted": false,
+  "MediaTypes": ["CD", "DVD", "USBStick"],
+  "Actions": {
+      "#VirtualMedia.EjectMedia": {
+        "target": "/redfish/v1/Systems/System.Embedded.1/VirtualMedia/2/Actions/VirtualMedia.EjectMedia"
+      },
+      "#VirtualMedia.InsertMedia": {
+        "target": "/redfish/v1/Systems/System.Embedded.1/VirtualMedia/2/Actions/VirtualMedia.InsertMedia"
+      }
+    }
+}

--- a/pkg/bmc/testdata/redfish_v1_system_virtual_media_2.json
+++ b/pkg/bmc/testdata/redfish_v1_system_virtual_media_2.json
@@ -1,0 +1,11 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#VirtualMedia.VirtualMedia",
+  "@odata.id": "/redfish/v1/Systems/System.Embedded.1/VirtualMedia/2",
+  "@odata.type": "#VirtualMedia.v1_6_1.VirtualMedia",
+  "VirtualMediaEnabled": true,
+  "VirtualMediaReference": "2",
+  "ID": "2",
+  "Image": "",
+  "Inserted": false,
+  "MediaTypes": ["CD", "DVD", "USBStick"]
+}


### PR DESCRIPTION
This PR adds a function to the bmc package to boot from CD only once. This functionality is required for the ORAN system tests based on the IBI-based provisioning. 