### PR TITLE
sync: fix ocs sync for go 1.24

### DIFF
--- a/internal/sync/configs/ocs-config.yaml
+++ b/internal/sync/configs/ocs-config.yaml
@@ -82,6 +82,10 @@
   replace_imports:
     - old: '"github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"'
       new: '"github.com/openshift-kni/eco-goinfra/pkg/schemes/ocs/k8s.cni.cncf.io/v1"'
+    # Since replace_imports does not actually check for imports, just does a
+    # find and replace, we can use it to fix this vet error in go 1.24+.
+    - old: "fmt.Errorf(fmt.Sprintf(\"Failed to parse: one or more items did not match comma-delimited format (must consist of lower case alphanumeric characters). Must start and end with an alphanumeric character), mismatch @ '%v'\", allItems[i]))"
+      new: "fmt.Errorf(\"Failed to parse: one or more items did not match comma-delimited format (must consist of lower case alphanumeric characters). Must start and end with an alphanumeric character), mismatch @ '%v'\", allItems[i])"
 
 - name: noobaa-operator
   sync: true

--- a/pkg/schemes/ocs/nadutils/net-attach-def.go
+++ b/pkg/schemes/ocs/nadutils/net-attach-def.go
@@ -371,7 +371,7 @@ func parsePodNetworkObjectText(podnetwork string) (string, string, string, error
 	for i := range allItems {
 		matched, _ := regexp.MatchString("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$", allItems[i])
 		if !matched && len([]rune(allItems[i])) > 0 {
-			return "", "", "", fmt.Errorf(fmt.Sprintf("Failed to parse: one or more items did not match comma-delimited format (must consist of lower case alphanumeric characters). Must start and end with an alphanumeric character), mismatch @ '%v'", allItems[i]))
+			return "", "", "", fmt.Errorf("Failed to parse: one or more items did not match comma-delimited format (must consist of lower case alphanumeric characters). Must start and end with an alphanumeric character), mismatch @ '%v'", allItems[i])
 		}
 	}
 


### PR DESCRIPTION
Go 1.24 changes the way vet works and this causes our CI to break with the ocs nadutils schemes. This PR uses the replace_imports feature of the sync to correct the single line where this error occurs without affecting functionality.