### PR TITLE
ci: remove script call; update golangci-lint

### DIFF
--- a/.github/workflows/integration-testing-nightly.yml
+++ b/.github/workflows/integration-testing-nightly.yml
@@ -28,9 +28,6 @@ jobs:
       - name: Setup cluster (k8s)
         uses: palmsoftware/quick-k8s@v0.0.24
 
-      - name: Wait for pods to be ready
-        run: ./scripts/wait-for-pods.sh
-
       - name: Run integration tests
         uses: nick-fields/retry@v3
         with:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -89,6 +89,12 @@ linters:
             - github.com/stmcginnis/gofish
             - github.com/prometheus-operator/prometheus-operator
             - github.com/google/uuid
+            - gopkg.in/yaml.v2
+            - gopkg.in/yaml.v3
+            - golang.org/x/crypto/ssh
+            - golang.org/x/exp/slices
+            - gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/types
+            - golang.org/x/net/context
     funlen:
       lines: 90
       statements: 40
@@ -105,9 +111,10 @@ linters:
             - disableStutteringCheck
     staticcheck:
       checks:
-        - -SA1006
-        - ST1001
         - all
+        - -SA1006
+        - -ST1000
+        - ST1001
     wsl:
       strict-append: false
   exclusions:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,95 +1,12 @@
+version: "2"
 run:
   go: "1.24"
-  timeout: 15m0s
-  fast: false
-#  modules-download-mode: readonly
-
-linters-settings:
-  depguard:
-    rules:
-      main:
-        allow:
-          - "k8s.io/apimachinery"
-          - "k8s.io/api"
-          - "k8s.io/kubectl/pkg/drain"
-          - "k8s.io/kubelet"
-          - "k8s.io/utils"
-          - "k8s.io/client-go"
-          - "github.com/Masterminds/semver/v3"
-          - "github.com/onsi/ginkgo"
-          - "github.com/openshift"
-          - "github.com/nmstate/kubernetes-nmstate"
-          - "github.com/k8snetworkplumbingwg"
-          - "github.com/metallb/metallb-operator"
-          - "github.com/metal3-io/baremetal-operator"
-          - "github.com/operator-framework/operator-lifecycle-manager"
-          - "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressservice/v1"
-          - "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1"
-          - "github.com/grafana-operator/grafana-operator"
-          - "github.com/kedacore/keda-olm-operator/apis/keda/v1alpha1"
-          - "github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
-          - "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
-          - "github.com/grafana/loki/operator/apis/loki/v1"
-          - "github.com/NVIDIA/gpu-operator/"
-          - "github.com/operator-framework/api"
-          - "github.com/argoproj-labs/argocd-operator/api"
-          - "github.com/golang/glog"
-          - "github.com/rh-ecosystem-edge/kernel-module-management/"
-          - "maistra.io/api/"
-          - "open-cluster-management.io/governance-policy-propagator/api"
-          - "open-cluster-management.io/governance-policy-propagator/api/v1beta1"
-          - "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/placementrule/v1"
-          - "open-cluster-management.io/api"
-          - "github.com/stolostron/klusterlet-addon-controller/pkg/apis"
-          - "sigs.k8s.io/controller-runtime"
-          - "github.com/stretchr/testify"
-          - $gostd
-          - "github.com/stretchr/testify"
-          - "github.com/vmware-tanzu/velero"
-          - "github.com/kelseyhightower/envconfig"
-          - "github.com/red-hat-storage/ocs-operator"
-          - "github.com/red-hat-storage/odf-operator"
-          - "github.com/stmcginnis/gofish"
-          - "github.com/prometheus-operator/prometheus-operator"
-          - "github.com/google/uuid"
-  govet:
-    disable:
-      - printf
-  revive:
-    rules:
-      - name: indent-error-flow
-      - name: var-naming
-      - name: increment-decrement
-      - name: exported
-        arguments:
-          - disableStutteringCheck
-  wsl:
-    strict-append: false
-  gofmt:
-    simplify: true
-  funlen:
-    lines: 90
-    statements: 40
-  unused:
-    check-exported: true
-  staticcheck:
-    # https://staticcheck.io/docs/options#checks
-    checks:
-      - all
-      - "-SA1006"
-  stylecheck:
-    # https://staticcheck.io/docs/options#checks
-    checks:
-      - all
-      - ST1001
-
 linters:
   enable:
     - asciicheck
     - bidichk
     - depguard
     - durationcheck
-    - errcheck
     - errname
     - errorlint
     - exhaustive
@@ -102,52 +19,123 @@ linters:
     - gocyclo
     - godot
     - godox
-    - gofmt
     - goheader
-    - goimports
     - gomodguard
     - goprintffuncname
-    - gosimple
-    - govet
     - importas
-    - ineffassign
     - ireturn
     - lll
     - makezero
     - misspell
     - nakedret
     - nilnil
+    - nlreturn
     - nolintlint
     - predeclared
     - promlinter
     - revive
     - staticcheck
-    - stylecheck
     - thelper
-    - typecheck
     - unconvert
     - unparam
-    - unused
     - usetesting
     - varnamelen
     - wsl
-    - nlreturn
-
-output:
-  formats: colored-line-number
-issues:
-  exclude-dirs-use-default: true
-  exclude-dirs:
-    - pkg/schemes
-  include:
-    - EXC0002 # disable excluding of issues about comments from golint
-    - EXC0012  # EXC0012 revive: Annoying issue about not having a comment. The rare codebase has such comments
-    - EXC0014  # EXC0014 revive: Annoying issue about not having a comment. The rare codebase has such comments
-  exclude-rules:
-    #- # Exclude some linters from running on tests files.
-    - path: 'pkg/polarion'
-      linters:
-        - exhaustive
-
-
-
+  settings:
+    depguard:
+      rules:
+        main:
+          allow:
+            - k8s.io/apimachinery
+            - k8s.io/api
+            - k8s.io/kubectl/pkg/drain
+            - k8s.io/kubelet
+            - k8s.io/utils
+            - k8s.io/client-go
+            - github.com/Masterminds/semver/v3
+            - github.com/onsi/ginkgo
+            - github.com/openshift
+            - github.com/nmstate/kubernetes-nmstate
+            - github.com/k8snetworkplumbingwg
+            - github.com/metallb/metallb-operator
+            - github.com/metal3-io/baremetal-operator
+            - github.com/operator-framework/operator-lifecycle-manager
+            - github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressservice/v1
+            - github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1
+            - github.com/grafana-operator/grafana-operator
+            - github.com/kedacore/keda-olm-operator/apis/keda/v1alpha1
+            - github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1
+            - github.com/kedacore/keda/v2/apis/keda/v1alpha1
+            - github.com/grafana/loki/operator/apis/loki/v1
+            - github.com/NVIDIA/gpu-operator/
+            - github.com/operator-framework/api
+            - github.com/argoproj-labs/argocd-operator/api
+            - github.com/golang/glog
+            - github.com/rh-ecosystem-edge/kernel-module-management/
+            - maistra.io/api/
+            - open-cluster-management.io/governance-policy-propagator/api
+            - open-cluster-management.io/governance-policy-propagator/api/v1beta1
+            - open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/placementrule/v1
+            - open-cluster-management.io/api
+            - github.com/stolostron/klusterlet-addon-controller/pkg/apis
+            - sigs.k8s.io/controller-runtime
+            - github.com/stretchr/testify
+            - $gostd
+            - github.com/stretchr/testify
+            - github.com/vmware-tanzu/velero
+            - github.com/kelseyhightower/envconfig
+            - github.com/red-hat-storage/ocs-operator
+            - github.com/red-hat-storage/odf-operator
+            - github.com/stmcginnis/gofish
+            - github.com/prometheus-operator/prometheus-operator
+            - github.com/google/uuid
+    funlen:
+      lines: 90
+      statements: 40
+    govet:
+      disable:
+        - printf
+    revive:
+      rules:
+        - name: indent-error-flow
+        - name: var-naming
+        - name: increment-decrement
+        - name: exported
+          arguments:
+            - disableStutteringCheck
+    staticcheck:
+      checks:
+        - -SA1006
+        - ST1001
+        - all
+    wsl:
+      strict-append: false
+  exclusions:
+    generated: lax
+    presets:
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - exhaustive
+        path: pkg/polarion
+    paths:
+      - pkg/schemes
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    gofmt:
+      simplify: true
+  exclusions:
+    generated: lax
+    paths:
+      - pkg/schemes
+      - third_party$
+      - builtin$
+      - examples$

--- a/integration/common.go
+++ b/integration/common.go
@@ -1,3 +1,4 @@
+// Package integration provides common functions for integration tests.
 package integration
 
 import (

--- a/pkg/assisted/agent.go
+++ b/pkg/assisted/agent.go
@@ -300,7 +300,7 @@ func (builder *agentBuilder) Update() (*agentBuilder, error) {
 		glog.V(100).Infof("agent %s in namespace %s does not exist",
 			builder.Definition.Name, builder.Definition.Namespace)
 
-		return nil, fmt.Errorf(nonExistentMsg)
+		return nil, fmt.Errorf("%s", nonExistentMsg)
 	}
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)

--- a/pkg/certificate/signingrequestlist.go
+++ b/pkg/certificate/signingrequestlist.go
@@ -47,7 +47,7 @@ func ListSigningRequests(
 	glog.V(100).Info(logMessage)
 
 	csrList := new(certificatesv1.CertificateSigningRequestList)
-	err = apiClient.Client.List(context.TODO(), csrList, &passedOptions)
+	err = apiClient.List(context.TODO(), csrList, &passedOptions)
 
 	if err != nil {
 		glog.V(100).Infof("Failed to list CertificateSigningRequests: %v", err)

--- a/pkg/cgu/cgulist.go
+++ b/pkg/cgu/cgulist.go
@@ -42,7 +42,7 @@ func ListInAllNamespaces(apiClient *clients.Settings, options ...client.ListOpti
 	glog.V(100).Infof(logMessage)
 
 	cguList := &v1alpha1.ClusterGroupUpgradeList{}
-	err = apiClient.Client.List(context.TODO(), cguList, &passedOptions)
+	err = apiClient.List(context.TODO(), cguList, &passedOptions)
 
 	if err != nil {
 		glog.V(100).Infof("Failed to list all CGUs in all namespaces due to %s", err.Error())

--- a/pkg/deployment/deployment.go
+++ b/pkg/deployment/deployment.go
@@ -206,7 +206,7 @@ func (builder *Builder) WithSecondaryNetwork(networks []*multus.NetworkSelection
 		return builder
 	}
 
-	builder.Definition.Spec.Template.ObjectMeta.Annotations = map[string]string{
+	builder.Definition.Spec.Template.Annotations = map[string]string{
 		"k8s.v1.cni.cncf.io/networks": string(netAnnotation)}
 
 	return builder

--- a/pkg/deployment/deployment_test.go
+++ b/pkg/deployment/deployment_test.go
@@ -248,7 +248,7 @@ func TestWithHugePages(t *testing.T) {
 	// Assert the volumes are added to the spec
 	assert.Equal(t, "hugepages", testBuilder.Definition.Spec.Template.Spec.Volumes[0].Name)
 	assert.Equal(t, corev1.StorageMedium("HugePages"),
-		testBuilder.Definition.Spec.Template.Spec.Volumes[0].VolumeSource.EmptyDir.Medium)
+		testBuilder.Definition.Spec.Template.Spec.Volumes[0].EmptyDir.Medium)
 
 	// Assert the container is updated with the volume mount
 	assert.Equal(t, "hugepages", testBuilder.Definition.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name)

--- a/pkg/egressip/egressip_test.go
+++ b/pkg/egressip/egressip_test.go
@@ -339,7 +339,7 @@ func TestEgressIPGet(t *testing.T) {
 			assert.Equal(t, testCase.expectedError.Error(), err.Error())
 			assert.Empty(t, testEgressIP)
 		} else {
-			assert.Equal(t, defaultEgressIPName, testEgressIP.ObjectMeta.Name)
+			assert.Equal(t, defaultEgressIPName, testEgressIP.Name)
 		}
 	}
 }

--- a/pkg/egressservice/egressservice_test.go
+++ b/pkg/egressservice/egressservice_test.go
@@ -330,8 +330,8 @@ func TestGet(t *testing.T) {
 			assert.Equal(t, testCase.expectedError.Error(), err.Error())
 			assert.Empty(t, testEgressService)
 		} else {
-			assert.Equal(t, testCase.name, testEgressService.ObjectMeta.Name)
-			assert.Equal(t, testCase.nsname, testEgressService.ObjectMeta.Namespace)
+			assert.Equal(t, testCase.name, testEgressService.Name)
+			assert.Equal(t, testCase.nsname, testEgressService.Namespace)
 			assert.Equal(t, testCase.sourceIPBy, string(testEgressService.Spec.SourceIPBy))
 		}
 	}

--- a/pkg/lca/imagebasedupgrade.go
+++ b/pkg/lca/imagebasedupgrade.go
@@ -137,7 +137,7 @@ func (builder *ImageBasedUpgradeBuilder) Update() (*ImageBasedUpgradeBuilder, er
 					return false, err
 				}
 
-				if ibu.ObjectMeta.Generation == ibu.Status.ObservedGeneration {
+				if ibu.Generation == ibu.Status.ObservedGeneration {
 					builder.Object = ibu
 
 					return true, nil

--- a/pkg/machine/machineset.go
+++ b/pkg/machine/machineset.go
@@ -495,23 +495,23 @@ func createNewWorkerMachineSetFromCopy(
 	}
 
 	glog.V(100).Infof("Renaming copied SetBuilder to: %s",
-		copiedSetBuilder.Definition.ObjectMeta.Name)
+		copiedSetBuilder.Definition.Name)
 
 	// replace dots in name with dashes.  Cannot have dots or underscores in machineSet name, must also be lower case
-	copiedSetBuilder.Definition.ObjectMeta.Name = fmt.Sprintf("%v-%v",
+	copiedSetBuilder.Definition.Name = fmt.Sprintf("%v-%v",
 		copiedSetBuilder.Definition.Name,
 		strings.ToLower(regexp.MustCompile(`[\.|\_]`).ReplaceAllString(instanceType, "-")))
 
 	glog.V(100).Infof("Updating copied MachineSet name in metadata, selector and template parameters")
 
-	copiedSetBuilder.Definition.ObjectMeta.UID = ""
-	copiedSetBuilder.Definition.ObjectMeta.ResourceVersion = ""
+	copiedSetBuilder.Definition.UID = ""
+	copiedSetBuilder.Definition.ResourceVersion = ""
 
 	// change spec labels
 	copiedSetBuilder.Definition.Spec.Selector.MatchLabels["machine.openshift.io/cluster-api-machineset"] =
-		copiedSetBuilder.Definition.ObjectMeta.Name
-	copiedSetBuilder.Definition.Spec.Template.ObjectMeta.Labels["machine.openshift.io/cluster-api-machineset"] =
-		copiedSetBuilder.Definition.ObjectMeta.Name
+		copiedSetBuilder.Definition.Name
+	copiedSetBuilder.Definition.Spec.Template.Labels["machine.openshift.io/cluster-api-machineset"] =
+		copiedSetBuilder.Definition.Name
 
 	glog.V(100).Infof("Updating copied MachineSet replicas value to: %v", replicas)
 	copiedSetBuilder.Definition.Spec.Replicas = &replicas

--- a/pkg/machine/machinesetlist.go
+++ b/pkg/machine/machinesetlist.go
@@ -62,7 +62,7 @@ func ListWorkerMachineSets(
 			Definition: &copiedMachineSet,
 		}
 
-		if val, ok := SetBuilder.Definition.Spec.Template.ObjectMeta.Labels[workerLabel]; ok && val == "worker" {
+		if val, ok := SetBuilder.Definition.Spec.Template.Labels[workerLabel]; ok && val == "worker" {
 			machineSetObjects = append(machineSetObjects, SetBuilder)
 		}
 	}

--- a/pkg/mco/machineconfiglist.go
+++ b/pkg/mco/machineconfiglist.go
@@ -42,7 +42,7 @@ func ListMC(apiClient *clients.Settings, options ...runtimeclient.ListOptions) (
 	glog.V(100).Infof(logMessage)
 
 	mcList := new(mcv1.MachineConfigList)
-	err = apiClient.Client.List(context.TODO(), mcList, &passedOptions)
+	err = apiClient.List(context.TODO(), mcList, &passedOptions)
 
 	if err != nil {
 		glog.V(100).Info("Failed to list MC objects due to %s", err.Error())

--- a/pkg/mco/mcp.go
+++ b/pkg/mco/mcp.go
@@ -322,7 +322,7 @@ func (builder *MCPBuilder) WaitToBeStableFor(stableDuration time.Duration, timeo
 						builder.Object.Status.DegradedMachineCount != 0 {
 						glog.V(100).Infof("MachineConfigPool: %v degraded and has a mismatch in "+
 							"machineCount: %v "+"vs machineCountUpdated: "+"%v vs readyMachineCount: %v and "+
-							"degradedMachineCount is : %v \n", builder.Object.ObjectMeta.Name,
+							"degradedMachineCount is : %v \n", builder.Object.Name,
 							builder.Object.Status.MachineCount, builder.Object.Status.UpdatedMachineCount,
 							builder.Object.Status.ReadyMachineCount, builder.Object.Status.DegradedMachineCount)
 

--- a/pkg/mco/mcplist.go
+++ b/pkg/mco/mcplist.go
@@ -45,7 +45,7 @@ func ListMCP(apiClient *clients.Settings, options ...runtimeclient.ListOptions) 
 	glog.V(100).Infof(logMessage)
 
 	mcpList := new(mcv1.MachineConfigPoolList)
-	err = apiClient.Client.List(context.TODO(), mcpList, &passedOptions)
+	err = apiClient.List(context.TODO(), mcpList, &passedOptions)
 
 	if err != nil {
 		glog.V(100).Infof("Failed to list MCP objects due to %s", err.Error())
@@ -142,7 +142,7 @@ func ListMCPWaitToBeStableFor(
 
 							glog.V(100).Infof("MachineConfigPool: %v degraded and has a mismatch in "+
 								"machineCount: %v "+"vs machineCountUpdated: "+"%v vs readyMachineCount: %v and "+
-								"degradedMachineCount is : %v \n", mcp.Object.ObjectMeta.Name,
+								"degradedMachineCount is : %v \n", mcp.Object.Name,
 								mcp.Object.Status.MachineCount, mcp.Object.Status.UpdatedMachineCount,
 								mcp.Object.Status.ReadyMachineCount, mcp.Object.Status.DegradedMachineCount)
 

--- a/pkg/metallb/adresspool_test.go
+++ b/pkg/metallb/adresspool_test.go
@@ -265,7 +265,7 @@ func TestIPAddressPoolUpdate(t *testing.T) {
 		assert.Nil(t, testCase.testIPAddressPool.Definition.Spec.AutoAssign)
 		assert.Nil(t, nil, testCase.testIPAddressPool.Object)
 		testCase.testIPAddressPool.WithAutoAssign(true)
-		testCase.testIPAddressPool.Definition.ObjectMeta.ResourceVersion = "999"
+		testCase.testIPAddressPool.Definition.ResourceVersion = "999"
 		_, err := testCase.testIPAddressPool.Update(false)
 		assert.Equal(t, testCase.expectedError, err)
 

--- a/pkg/metallb/bfdprofile_test.go
+++ b/pkg/metallb/bfdprofile_test.go
@@ -259,7 +259,7 @@ func TestBFDProfileUpdate(t *testing.T) {
 		assert.Nil(t, testCase.testBFDProfile.Definition.Spec.EchoMode)
 		assert.Nil(t, nil, testCase.testBFDProfile.Object)
 		testCase.testBFDProfile.WithEchoMode(true)
-		testCase.testBFDProfile.Definition.ObjectMeta.ResourceVersion = "999"
+		testCase.testBFDProfile.Definition.ResourceVersion = "999"
 		_, err := testCase.testBFDProfile.Update(false)
 		assert.Equal(t, testCase.expectedError, err)
 

--- a/pkg/metallb/bgpadvertisement_test.go
+++ b/pkg/metallb/bgpadvertisement_test.go
@@ -258,7 +258,7 @@ func TestBGPAdvertisementUpdate(t *testing.T) {
 		assert.Nil(t, testCase.testBGPAdvertisement.Definition.Spec.IPAddressPools)
 		assert.Nil(t, nil, testCase.testBGPAdvertisement.Object)
 		testCase.testBGPAdvertisement.WithIPAddressPools(testCase.ipAddressPool)
-		testCase.testBGPAdvertisement.Definition.ObjectMeta.ResourceVersion = "999"
+		testCase.testBGPAdvertisement.Definition.ResourceVersion = "999"
 		_, err := testCase.testBGPAdvertisement.Update(false)
 		assert.Equal(t, testCase.expectedError, err)
 

--- a/pkg/metallb/l2advertisement_test.go
+++ b/pkg/metallb/l2advertisement_test.go
@@ -265,7 +265,7 @@ func TestL2AdvertisementUpdate(t *testing.T) {
 		assert.Nil(t, testCase.testL2Advertisement.Definition.Spec.IPAddressPools)
 		assert.Nil(t, nil, testCase.testL2Advertisement.Object)
 		testCase.testL2Advertisement.WithIPAddressPools(testCase.addressPool)
-		testCase.testL2Advertisement.Definition.ObjectMeta.ResourceVersion = "999"
+		testCase.testL2Advertisement.Definition.ResourceVersion = "999"
 		_, err := testCase.testL2Advertisement.Update(false)
 		assert.Equal(t, testCase.expectedError, err)
 

--- a/pkg/metallb/metallb.go
+++ b/pkg/metallb/metallb.go
@@ -240,7 +240,7 @@ func (builder *Builder) Update(force bool) (*Builder, error) {
 	)
 
 	builder.Definition.ResourceVersion = builder.Object.ResourceVersion
-	builder.Definition.ObjectMeta.ResourceVersion = builder.Object.ObjectMeta.ResourceVersion
+	builder.Definition.ResourceVersion = builder.Object.ResourceVersion
 
 	err := builder.apiClient.Update(context.TODO(), builder.Definition)
 

--- a/pkg/nad/builder_test.go
+++ b/pkg/nad/builder_test.go
@@ -304,7 +304,7 @@ func TestNADUpdate(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Nil(t, nil, testCase.testNetwork.Object)
 		testCase.testNetwork.WithMasterPlugin(masterPlugin)
-		testCase.testNetwork.Definition.ObjectMeta.ResourceVersion = "999"
+		testCase.testNetwork.Definition.ResourceVersion = "999"
 		netBuilder, err := testCase.testNetwork.Update()
 		assert.Equal(t, testCase.expectedError, err)
 

--- a/pkg/namespace/namespace.go
+++ b/pkg/namespace/namespace.go
@@ -354,8 +354,8 @@ func (builder *Builder) hasOnlyDefaultConfigMaps(objList *unstructured.Unstructu
 	}
 
 	// return false if existing configmaps are NOT default pre-deployed openshift configmaps
-	if !(slices.Contains(existingConfigMaps, "kube-root-ca.crt") &&
-		slices.Contains(existingConfigMaps, "openshift-service-ca.crt")) {
+	if !slices.Contains(existingConfigMaps, "kube-root-ca.crt") ||
+		!slices.Contains(existingConfigMaps, "openshift-service-ca.crt") {
 		return false, err
 	}
 

--- a/pkg/network/operator.go
+++ b/pkg/network/operator.go
@@ -212,7 +212,7 @@ func (builder *OperatorBuilder) WaitUntilInCondition(
 				return false, fmt.Errorf("network.operator object %s does not exist", builder.Definition.Name)
 			}
 
-			for _, c := range builder.Object.Status.OperatorStatus.Conditions {
+			for _, c := range builder.Object.Status.Conditions {
 				if c.Type == condition && c.Status == status {
 					return true, nil
 				}

--- a/pkg/network/operator_test.go
+++ b/pkg/network/operator_test.go
@@ -175,7 +175,7 @@ func TestOperatorWaitUntilInCondition(t *testing.T) {
 			networkOperator := buildDummyNetworkOperator()
 
 			if testCase.inCondition {
-				networkOperator.Status.OperatorStatus.Conditions = []operatorv1.OperatorCondition{{
+				networkOperator.Status.Conditions = []operatorv1.OperatorCondition{{
 					Type:   operatorv1.OperatorStatusTypeAvailable,
 					Status: operatorv1.ConditionTrue,
 				}}

--- a/pkg/networkpolicy/multinetegressrule.go
+++ b/pkg/networkpolicy/multinetegressrule.go
@@ -67,7 +67,7 @@ func (builder *EgressRuleBuilder) WithProtocol(protocol corev1.Protocol) *Egress
 
 	glog.V(100).Infof("Adding protocol %s to EgressRule", protocol)
 
-	if !(protocol == corev1.ProtocolTCP || protocol == corev1.ProtocolUDP || protocol == corev1.ProtocolSCTP) {
+	if protocol != corev1.ProtocolTCP && protocol != corev1.ProtocolUDP && protocol != corev1.ProtocolSCTP {
 		glog.V(100).Infof("invalid protocol argument. Allowed protocols: TCP, UDP & SCTP ")
 
 		builder.errorMsg = "invalid protocol argument. Allowed protocols: TCP, UDP & SCTP"

--- a/pkg/networkpolicy/multinetingressrule.go
+++ b/pkg/networkpolicy/multinetingressrule.go
@@ -66,7 +66,7 @@ func (builder *IngressRuleBuilder) WithProtocol(protocol corev1.Protocol) *Ingre
 
 	glog.V(100).Infof("Adding protocol %s to IngressRule", protocol)
 
-	if !(protocol == corev1.ProtocolTCP || protocol == corev1.ProtocolUDP || protocol == corev1.ProtocolSCTP) {
+	if protocol != corev1.ProtocolTCP && protocol != corev1.ProtocolUDP && protocol != corev1.ProtocolSCTP {
 		glog.V(100).Infof("invalid protocol argument")
 
 		builder.errorMsg = "invalid protocol argument. Allowed protocols: TCP, UDP & SCTP"

--- a/pkg/networkpolicy/multinetworkpolicy_test.go
+++ b/pkg/networkpolicy/multinetworkpolicy_test.go
@@ -285,7 +285,7 @@ func TestMultiNetworkPolicyUpdate(t *testing.T) {
 			testBuilder.Definition.Spec.PodSelector = metav1.LabelSelector{MatchLabels: map[string]string{"test": "test"}}
 		}
 
-		testBuilder.Definition.ObjectMeta.ResourceVersion = "999"
+		testBuilder.Definition.ResourceVersion = "999"
 		builder, err := testBuilder.Update()
 
 		if testCase.expectedError {

--- a/pkg/networkpolicy/networkpolicy_test.go
+++ b/pkg/networkpolicy/networkpolicy_test.go
@@ -405,7 +405,7 @@ func TestNetworkPolicyUpdate(t *testing.T) {
 		// Set some arbitrary values to update
 		testBuilder.Definition.Labels = map[string]string{"test": "test"}
 
-		testBuilder.Definition.ObjectMeta.ResourceVersion = "999"
+		testBuilder.Definition.ResourceVersion = "999"
 		builder, err := testBuilder.Update()
 
 		if testCase.expectedError {

--- a/pkg/nfd/nodefeaturediscovery_test.go
+++ b/pkg/nfd/nodefeaturediscovery_test.go
@@ -287,7 +287,7 @@ func TestNFDUpdate(t *testing.T) {
 		assert.Empty(t, testCase.nfd.Definition.Spec.LabelWhiteList)
 		assert.Nil(t, nil, testCase.nfd.Object)
 		testCase.nfd.Definition.Spec.LabelWhiteList = testCase.labelList
-		testCase.nfd.Definition.ObjectMeta.ResourceVersion = "999"
+		testCase.nfd.Definition.ResourceVersion = "999"
 		_, err := testCase.nfd.Update(false)
 		assert.Equal(t, testCase.expectedError, err)
 

--- a/pkg/nmstate/nmstate_test.go
+++ b/pkg/nmstate/nmstate_test.go
@@ -263,7 +263,7 @@ func TestNMStateUpdate(t *testing.T) {
 		assert.Empty(t, testCase.testNMState.Definition.Spec.NodeSelector)
 		assert.Nil(t, nil, testCase.testNMState.Object)
 		testCase.testNMState.Definition.Spec.NodeSelector = map[string]string{"test": "test"}
-		testCase.testNMState.Definition.ObjectMeta.ResourceVersion = "999"
+		testCase.testNMState.Definition.ResourceVersion = "999"
 		nmStateBuilder, err := testCase.testNMState.Update(testCase.forceFlag)
 		assert.Equal(t, testCase.expectedError, err)
 

--- a/pkg/nmstate/policy_test.go
+++ b/pkg/nmstate/policy_test.go
@@ -211,7 +211,7 @@ func TestPolicyUpdate(t *testing.T) {
 		testCase.testNMStatePolicy.Definition.Spec.NodeSelector = map[string]string{"test2": "test2"}
 
 		if !testCase.forceFlag {
-			testCase.testNMStatePolicy.Definition.ObjectMeta.ResourceVersion = "999"
+			testCase.testNMStatePolicy.Definition.ResourceVersion = "999"
 		}
 
 		nmStatePolicyBuilder, err := testCase.testNMStatePolicy.Update(testCase.forceFlag)

--- a/pkg/nmstate/policylist.go
+++ b/pkg/nmstate/policylist.go
@@ -42,7 +42,7 @@ func ListPolicy(apiClient *clients.Settings, options ...goclient.ListOptions) ([
 	glog.V(100).Infof(logMessage)
 
 	policyList := &nmstateV1.NodeNetworkConfigurationPolicyList{}
-	err = apiClient.Client.List(context.TODO(), policyList, &passedOptions)
+	err = apiClient.List(context.TODO(), policyList, &passedOptions)
 
 	if err != nil {
 		glog.V(100).Infof("Failed to list NodeNetworkConfigurationPolicy due to %s", err.Error())

--- a/pkg/nto/performanceprofile.go
+++ b/pkg/nto/performanceprofile.go
@@ -344,7 +344,7 @@ func (builder *Builder) WithAnnotations(annotations map[string]string) *Builder 
 		return builder
 	}
 
-	builder.Definition.ObjectMeta.Annotations = annotations
+	builder.Definition.Annotations = annotations
 
 	return builder
 }

--- a/pkg/nto/performanceprofile_test.go
+++ b/pkg/nto/performanceprofile_test.go
@@ -648,7 +648,7 @@ func TestPerformanceProfileWithAnnotations(t *testing.T) {
 			assert.Equal(t, testCase.expectedErrorText, result.errorMsg)
 		} else {
 			assert.NotNil(t, result)
-			assert.Equal(t, testCase.testAnnotations, result.Definition.ObjectMeta.Annotations)
+			assert.Equal(t, testCase.testAnnotations, result.Definition.Annotations)
 		}
 	}
 }

--- a/pkg/nvidiagpu/clusterpolicy_test.go
+++ b/pkg/nvidiagpu/clusterpolicy_test.go
@@ -287,7 +287,7 @@ func TestNvidiaGPUUpdate(t *testing.T) {
 		assert.Nil(t, testCase.clusterPolicy.Definition.Spec.CDI.Enabled)
 		assert.Nil(t, nil, testCase.clusterPolicy.Object)
 		testCase.clusterPolicy.Definition.Spec.CDI.Enabled = &testCase.cdiEnabled
-		testCase.clusterPolicy.Definition.ObjectMeta.ResourceVersion = "999"
+		testCase.clusterPolicy.Definition.ResourceVersion = "999"
 		_, err := testCase.clusterPolicy.Update(false)
 		assert.Equal(t, testCase.expectedError, err)
 

--- a/pkg/ocm/placementbindingList.go
+++ b/pkg/ocm/placementbindingList.go
@@ -44,7 +44,7 @@ func ListPlacementBindingsInAllNamespaces(apiClient *clients.Settings,
 	glog.V(100).Infof(logMessage)
 
 	placementBindingList := new(policiesv1.PlacementBindingList)
-	err = apiClient.Client.List(context.TODO(), placementBindingList, &passedOptions)
+	err = apiClient.List(context.TODO(), placementBindingList, &passedOptions)
 
 	if err != nil {
 		glog.V(100).Infof("Failed to list all placementBindings in all namespaces due to %s", err.Error())

--- a/pkg/ocm/placementrulelist.go
+++ b/pkg/ocm/placementrulelist.go
@@ -44,7 +44,7 @@ func ListPlacementrulesInAllNamespaces(apiClient *clients.Settings,
 	glog.V(100).Infof(logMessage)
 
 	placementRuleList := new(placementrulev1.PlacementRuleList)
-	err = apiClient.Client.List(context.TODO(), placementRuleList, &passedOptions)
+	err = apiClient.List(context.TODO(), placementRuleList, &passedOptions)
 
 	if err != nil {
 		glog.V(100).Infof("Failed to list all placementrules in all namespaces due to %s", err.Error())

--- a/pkg/ocm/policylist.go
+++ b/pkg/ocm/policylist.go
@@ -46,7 +46,7 @@ func ListPoliciesInAllNamespaces(apiClient *clients.Settings,
 	glog.V(100).Infof(logMessage)
 
 	policyList := new(policiesv1.PolicyList)
-	err = apiClient.Client.List(context.TODO(), policyList, &passedOptions)
+	err = apiClient.List(context.TODO(), policyList, &passedOptions)
 
 	if err != nil {
 		glog.V(100).Infof("Failed to list all policies in all namespaces due to %s", err.Error())

--- a/pkg/ocm/policysetlist.go
+++ b/pkg/ocm/policysetlist.go
@@ -44,7 +44,7 @@ func ListPolicieSetsInAllNamespaces(apiClient *clients.Settings,
 	glog.V(100).Infof(logMessage)
 
 	policySetList := new(policiesv1beta1.PolicySetList)
-	err = apiClient.Client.List(context.TODO(), policySetList, &passedOptions)
+	err = apiClient.List(context.TODO(), policySetList, &passedOptions)
 
 	if err != nil {
 		glog.V(100).Infof("Failed to list all policySets in all namespaces due to %s", err.Error())

--- a/pkg/olm/catalogsource_test.go
+++ b/pkg/olm/catalogsource_test.go
@@ -306,7 +306,7 @@ func TestCatalogSourceUpdate(t *testing.T) {
 		assert.Empty(t, testCase.catalogSource.Definition.Spec.Address)
 		assert.Nil(t, nil, testCase.catalogSource.Object)
 		testCase.catalogSource.Definition.Spec.Address = testCase.address
-		testCase.catalogSource.Definition.ObjectMeta.ResourceVersion = "999"
+		testCase.catalogSource.Definition.ResourceVersion = "999"
 		_, err := testCase.catalogSource.Update(false)
 		assert.Equal(t, testCase.expectedError, err)
 

--- a/pkg/olm/clusterserviceversion.go
+++ b/pkg/olm/clusterserviceversion.go
@@ -185,7 +185,7 @@ func (builder *ClusterServiceVersionBuilder) GetAlmExamples() (string, error) {
 	almExamples := "alm-examples"
 
 	if builder.Exists() {
-		annotations := builder.Object.ObjectMeta.GetAnnotations()
+		annotations := builder.Object.GetAnnotations()
 
 		if example, ok := annotations[almExamples]; ok {
 			return example, nil

--- a/pkg/olm/installplan_test.go
+++ b/pkg/olm/installplan_test.go
@@ -299,7 +299,7 @@ func TestInstallPlanUpdate(t *testing.T) {
 		assert.Empty(t, testCase.installPlan.Definition.Spec.CatalogSourceNamespace)
 		assert.Nil(t, nil, testCase.installPlan.Object)
 		testCase.installPlan.Definition.Spec.CatalogSourceNamespace = testCase.catalogSourceNamespace
-		testCase.installPlan.Definition.ObjectMeta.ResourceVersion = "999"
+		testCase.installPlan.Definition.ResourceVersion = "999"
 		_, err := testCase.installPlan.Update()
 		assert.Equal(t, testCase.expectedError, err)
 

--- a/pkg/olm/operatorgroup_test.go
+++ b/pkg/olm/operatorgroup_test.go
@@ -304,7 +304,7 @@ func TestOperatorGroupUpdate(t *testing.T) {
 		assert.Empty(t, testCase.operatorGroup.Definition.Spec.ServiceAccountName)
 		assert.Nil(t, nil, testCase.operatorGroup.Object)
 		testCase.operatorGroup.Definition.Spec.ServiceAccountName = testCase.serviceAccount
-		testCase.operatorGroup.Definition.ObjectMeta.ResourceVersion = "999"
+		testCase.operatorGroup.Definition.ResourceVersion = "999"
 		_, err := testCase.operatorGroup.Update()
 		assert.Equal(t, testCase.expectedError, err)
 

--- a/pkg/olm/subscription.go
+++ b/pkg/olm/subscription.go
@@ -154,7 +154,7 @@ func (builder *SubscriptionBuilder) WithInstallPlanApproval(
 	glog.V(100).Infof("Defining Subscription builder object with "+
 		"installPlanApproval: %s", installPlanApproval)
 
-	if !(installPlanApproval == "Automatic" || installPlanApproval == "Manual") {
+	if installPlanApproval != "Automatic" && installPlanApproval != "Manual" {
 		glog.V(100).Infof("The InstallPlanApproval of the Subscription must be either \"Automatic\" " +
 			"or \"Manual\"")
 

--- a/pkg/olm/subscription_test.go
+++ b/pkg/olm/subscription_test.go
@@ -301,7 +301,7 @@ func TestSubscriptionUpdate(t *testing.T) {
 		assert.Empty(t, testCase.subscription.Definition.Spec.StartingCSV)
 		assert.Nil(t, nil, testCase.subscription.Object)
 		testCase.subscription.Definition.Spec.StartingCSV = testCase.startingCSV
-		testCase.subscription.Definition.ObjectMeta.ResourceVersion = "999"
+		testCase.subscription.Definition.ResourceVersion = "999"
 		_, err := testCase.subscription.Update()
 		assert.Equal(t, testCase.expectedError, err)
 

--- a/pkg/oran/clustertemplatelist.go
+++ b/pkg/oran/clustertemplatelist.go
@@ -43,7 +43,7 @@ func ListClusterTemplates(
 	glog.V(100).Info(logMessage)
 
 	clusterTemplateList := new(provisioningv1alpha1.ClusterTemplateList)
-	err = apiClient.Client.List(context.TODO(), clusterTemplateList, &passedOptions)
+	err = apiClient.List(context.TODO(), clusterTemplateList, &passedOptions)
 
 	if err != nil {
 		glog.V(100).Infof("Failed to list ClusterTemplates in all namespaces due to %v", err)

--- a/pkg/oran/hardwaremanagerlist.go
+++ b/pkg/oran/hardwaremanagerlist.go
@@ -43,7 +43,7 @@ func ListHardwareManagers(
 	glog.V(100).Info(logMessage)
 
 	hwmgrList := new(pluginv1alpha1.HardwareManagerList)
-	err = apiClient.Client.List(context.TODO(), hwmgrList, &passedOptions)
+	err = apiClient.List(context.TODO(), hwmgrList, &passedOptions)
 
 	if err != nil {
 		glog.V(100).Infof("Failed to list HardwareManagers in all namespaces due to %v", err)

--- a/pkg/oran/nodelist.go
+++ b/pkg/oran/nodelist.go
@@ -42,7 +42,7 @@ func ListNodes(apiClient *clients.Settings, options ...runtimeclient.ListOptions
 	glog.V(100).Info(logMessage)
 
 	nodeList := new(hardwaremanagementv1alpha1.NodeList)
-	err = apiClient.Client.List(context.TODO(), nodeList, &passedOptions)
+	err = apiClient.List(context.TODO(), nodeList, &passedOptions)
 
 	if err != nil {
 		glog.V(100).Infof("Failed to list Nodes in all namespaces due to %v", err)

--- a/pkg/oran/nodepoollist.go
+++ b/pkg/oran/nodepoollist.go
@@ -42,7 +42,7 @@ func ListNodePools(apiClient *clients.Settings, options ...runtimeclient.ListOpt
 	glog.V(100).Info(logMessage)
 
 	nodePoolList := new(hardwaremanagementv1alpha1.NodePoolList)
-	err = apiClient.Client.List(context.TODO(), nodePoolList, &passedOptions)
+	err = apiClient.List(context.TODO(), nodePoolList, &passedOptions)
 
 	if err != nil {
 		glog.V(100).Infof("Failed to list NodePools in all namespaces due to %v", err)

--- a/pkg/rbac/clusterrole_test.go
+++ b/pkg/rbac/clusterrole_test.go
@@ -258,7 +258,7 @@ func TestClusterRoleUpdate(t *testing.T) {
 		assert.Empty(t, testCase.testClusterRole.Definition.Labels)
 		assert.Nil(t, nil, testCase.testClusterRole.Object)
 		testCase.testClusterRole.Definition.Labels = map[string]string{"test": "test"}
-		testCase.testClusterRole.Definition.ObjectMeta.ResourceVersion = "999"
+		testCase.testClusterRole.Definition.ResourceVersion = "999"
 		roleBuilder, err := testCase.testClusterRole.Update()
 		assert.Equal(t, testCase.expectedError, err)
 

--- a/pkg/rbac/role_test.go
+++ b/pkg/rbac/role_test.go
@@ -290,7 +290,7 @@ func TestRoleUpdate(t *testing.T) {
 		assert.Empty(t, testCase.testRole.Definition.Labels)
 		assert.Nil(t, nil, testCase.testRole.Object)
 		testCase.testRole.Definition.Labels = map[string]string{"test": "test"}
-		testCase.testRole.Definition.ObjectMeta.ResourceVersion = "999"
+		testCase.testRole.Definition.ResourceVersion = "999"
 		roleBuilder, err := testCase.testRole.Update()
 		assert.Equal(t, testCase.expectedError, err)
 

--- a/pkg/scc/scc_test.go
+++ b/pkg/scc/scc_test.go
@@ -274,7 +274,7 @@ func TestSCCUpdate(t *testing.T) {
 		assert.Empty(t, testCase.scc.Definition.Users)
 		assert.Nil(t, nil, testCase.scc.Object)
 		testCase.scc.Definition.Users = testCase.users
-		testCase.scc.Definition.ObjectMeta.ResourceVersion = "999"
+		testCase.scc.Definition.ResourceVersion = "999"
 		_, err := testCase.scc.Update()
 		assert.Equal(t, testCase.expectedError, err)
 

--- a/pkg/servicemesh/controlplane_test.go
+++ b/pkg/servicemesh/controlplane_test.go
@@ -288,7 +288,7 @@ func TestControlPlaneUpdate(t *testing.T) {
 			assert.Equal(t, testCase.expectedError, err.Error())
 		} else {
 			assert.Equal(t, testCase.addonEnablement,
-				*testCase.testControlPlane.Definition.Spec.Addons.Grafana.Enablement.Enabled)
+				*testCase.testControlPlane.Definition.Spec.Addons.Grafana.Enabled)
 		}
 	}
 }
@@ -317,10 +317,10 @@ func TestControlPlaneWithAllAddonsDisabled(t *testing.T) {
 			}
 		} else {
 			assert.NotNil(t, result)
-			assert.Equal(t, testCase.testControlPlane, *result.Definition.Spec.Addons.Prometheus.Enablement.Enabled)
-			assert.Equal(t, testCase.testControlPlane, *result.Definition.Spec.Addons.Grafana.Enablement.Enabled)
-			assert.Equal(t, testCase.testControlPlane, *result.Definition.Spec.Addons.Kiali.Enablement.Enabled)
-			assert.Equal(t, testCase.testControlPlane, *result.Definition.Spec.Addons.ThreeScale.Enablement.Enabled)
+			assert.Equal(t, testCase.testControlPlane, *result.Definition.Spec.Addons.Prometheus.Enabled)
+			assert.Equal(t, testCase.testControlPlane, *result.Definition.Spec.Addons.Grafana.Enabled)
+			assert.Equal(t, testCase.testControlPlane, *result.Definition.Spec.Addons.Kiali.Enabled)
+			assert.Equal(t, testCase.testControlPlane, *result.Definition.Spec.Addons.ThreeScale.Enabled)
 		}
 	}
 }
@@ -397,7 +397,7 @@ func TestControlPlaneWithGrafanaAddon(t *testing.T) {
 			}
 		} else {
 			assert.NotNil(t, result)
-			assert.Equal(t, testCase.testEnablement, *result.Definition.Spec.Addons.Grafana.Enablement.Enabled)
+			assert.Equal(t, testCase.testEnablement, *result.Definition.Spec.Addons.Grafana.Enabled)
 
 			if testCase.testEnablement {
 				assert.Equal(t, testCase.testInstall, result.Definition.Spec.Addons.Grafana.Install)
@@ -582,7 +582,7 @@ func TestControlPlaneWithKialiAddon(t *testing.T) {
 			}
 		} else {
 			assert.NotNil(t, result)
-			assert.Equal(t, testCase.testEnablement, *result.Definition.Spec.Addons.Kiali.Enablement.Enabled)
+			assert.Equal(t, testCase.testEnablement, *result.Definition.Spec.Addons.Kiali.Enabled)
 
 			if testCase.testEnablement {
 				assert.Equal(t, testCase.testInstall, result.Definition.Spec.Addons.Kiali.Install)
@@ -727,7 +727,7 @@ func TestControlPlaneWithPrometheusAddon(t *testing.T) {
 			}
 		} else {
 			assert.NotNil(t, result)
-			assert.Equal(t, testCase.testEnablement, *result.Definition.Spec.Addons.Prometheus.Enablement.Enabled)
+			assert.Equal(t, testCase.testEnablement, *result.Definition.Spec.Addons.Prometheus.Enabled)
 
 			if testCase.testEnablement {
 				assert.Equal(t, testCase.testScrape, *result.Definition.Spec.Addons.Prometheus.Scrape)
@@ -769,7 +769,7 @@ func TestControlPlaneWithGatewaysEnablement(t *testing.T) {
 			}
 		} else {
 			assert.NotNil(t, result)
-			assert.Equal(t, testCase.testEnablement, *result.Definition.Spec.Gateways.Enablement.Enabled)
+			assert.Equal(t, testCase.testEnablement, *result.Definition.Spec.Gateways.Enabled)
 		}
 	}
 }

--- a/pkg/sriov/network_test.go
+++ b/pkg/sriov/network_test.go
@@ -694,7 +694,7 @@ func TestUpdate(t *testing.T) {
 		assert.Equal(t, "", testCase.testNetwork.Definition.Spec.IPAM)
 		assert.Nil(t, nil, testCase.testNetwork.Object)
 		testCase.testNetwork.WithStaticIpam()
-		testCase.testNetwork.Definition.ObjectMeta.ResourceVersion = "999"
+		testCase.testNetwork.Definition.ResourceVersion = "999"
 		netBuilder, err := testCase.testNetwork.Update(false)
 		assert.Equal(t, testCase.expectedError, err)
 		assert.Equal(t, `{ "type": "static" }`, testCase.testNetwork.Object.Spec.IPAM)

--- a/pkg/sriov/operatorconfig_test.go
+++ b/pkg/sriov/operatorconfig_test.go
@@ -361,7 +361,7 @@ func TestOperatorConfigUpdate(t *testing.T) {
 			testCase.webhook = true
 		}
 
-		operatorConfigBuilder.Definition.ObjectMeta.ResourceVersion = "999"
+		operatorConfigBuilder.Definition.ResourceVersion = "999"
 		operatorConfigBuilder, err = operatorConfigBuilder.WithOperatorWebhook(testCase.webhook).Update()
 		assert.Equal(t, nil, err)
 		assert.Equal(t, testCase.webhook, testCase.testOperatorConfig.Object.Spec.EnableOperatorWebhook)

--- a/pkg/sriov/poolconfig_test.go
+++ b/pkg/sriov/poolconfig_test.go
@@ -168,7 +168,7 @@ func TestPoolConfigUpdate(t *testing.T) {
 		assert.Equal(t, int32(2), poolConfigBuilder.Definition.Spec.MaxUnavailable.IntVal)
 		testCase.testPoolConfig.WithMaxUnavailable(intstr.FromString("100%"))
 
-		poolConfigBuilder.Definition.ObjectMeta.ResourceVersion = "999"
+		poolConfigBuilder.Definition.ResourceVersion = "999"
 		poolConfigBuilder, err = poolConfigBuilder.Update()
 		assert.Nil(t, err)
 		assert.Equal(t, "100%", poolConfigBuilder.Object.Spec.MaxUnavailable.StrVal)

--- a/pkg/velero/backup.go
+++ b/pkg/velero/backup.go
@@ -139,11 +139,11 @@ func (builder *BackupBuilder) WithStorageLocation(location string) *BackupBuilde
 		return builder
 	}
 
-	if builder.Definition.ObjectMeta.Labels == nil {
-		builder.Definition.ObjectMeta.Labels = make(map[string]string)
+	if builder.Definition.Labels == nil {
+		builder.Definition.Labels = make(map[string]string)
 	}
 
-	builder.Definition.ObjectMeta.Labels["velero.io/storage-location"] = location
+	builder.Definition.Labels["velero.io/storage-location"] = location
 
 	return builder
 }

--- a/pkg/velero/backupstoragelocation_test.go
+++ b/pkg/velero/backupstoragelocation_test.go
@@ -430,7 +430,7 @@ func TestBackupStorageLocationUpdate(t *testing.T) {
 
 		testBuilder.Definition.Spec.Provider = "testProvider"
 
-		testBuilder.Definition.ObjectMeta.ResourceVersion = "999"
+		testBuilder.Definition.ResourceVersion = "999"
 		bsl, err := testBuilder.Update()
 		assert.Equal(t, testCase.expectedError, err)
 

--- a/pkg/velero/backupstoragelocationlist.go
+++ b/pkg/velero/backupstoragelocationlist.go
@@ -47,7 +47,7 @@ func ListBackupStorageLocationBuilder(
 	glog.V(100).Infof(logMessage)
 
 	bslList := &velerov1.BackupStorageLocationList{}
-	err = apiClient.Client.List(context.TODO(), bslList, &passedOptions)
+	err = apiClient.List(context.TODO(), bslList, &passedOptions)
 
 	if err != nil {
 		glog.V(100).Infof("Failed to list backupstoragelocations in the nsname %s due to %s", nsname, err.Error())

--- a/pkg/velero/restore.go
+++ b/pkg/velero/restore.go
@@ -150,11 +150,11 @@ func (builder *RestoreBuilder) WithStorageLocation(location string) *RestoreBuil
 		return builder
 	}
 
-	if builder.Definition.ObjectMeta.Labels == nil {
-		builder.Definition.ObjectMeta.Labels = make(map[string]string)
+	if builder.Definition.Labels == nil {
+		builder.Definition.Labels = make(map[string]string)
 	}
 
-	builder.Definition.ObjectMeta.Labels["velero.io/storage-location"] = location
+	builder.Definition.Labels["velero.io/storage-location"] = location
 
 	return builder
 }

--- a/scripts/golangci-lint.sh
+++ b/scripts/golangci-lint.sh
@@ -4,7 +4,7 @@ set -e
 
 . "$(dirname "$0")"/common.sh
 
-GOLANGCI_LINT_VERSION="1.64.2"
+GOLANGCI_LINT_VERSION="2.0.1"
 
 # IsGoLangCiLintInstalled is used to check whether golangci-lint executable is on the $PATH.
 function IsGolangCiLintInstalled() {


### PR DESCRIPTION
This was mistakenly added in #977 and is not needed.