### PR TITLE
ci: fix sync-libs testing

### DIFF
--- a/.github/workflows/eco-gotests-integration.yml
+++ b/.github/workflows/eco-gotests-integration.yml
@@ -2,6 +2,12 @@ name: eco-gotests integration
 
 on:
   workflow_call:
+    inputs:
+      branch:
+        description: Branch to run on
+        required: true
+        default: main
+        type: string
   workflow_dispatch:
   pull_request:
     branches:
@@ -20,6 +26,8 @@ jobs:
       - name: Check out the eco-goinfra code
         if: ${{ !contains(github.event.*.labels.*.name, 'ignore-dep-check') }}
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_call' && inputs.branch || github.sha }}
 
       - name: Set up Go
         if: ${{ !contains(github.event.*.labels.*.name, 'ignore-dep-check') }}

--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -2,6 +2,12 @@ name: Integration Testing (PRs)
 
 on:
   workflow_call:
+    inputs:
+      branch:
+        description: Branch to run on
+        required: true
+        default: main
+        type: string
   workflow_dispatch:
   pull_request:
     branches:
@@ -19,6 +25,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_call' && inputs.branch || github.sha }}
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -2,6 +2,12 @@ name: Test Incoming Changes
 
 on:
   workflow_call:
+    inputs:
+      branch:
+        description: Branch to run on
+        required: true
+        default: main
+        type: string
 
   workflow_dispatch:
 
@@ -20,6 +26,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+            ref: ${{ github.event_name == 'workflow_call' && inputs.branch || github.sha }}
       
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -36,6 +44,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_call' && inputs.branch || github.sha }}
       
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/sync-libs.yaml
+++ b/.github/workflows/sync-libs.yaml
@@ -50,14 +50,20 @@ jobs:
   makefile:
     needs: sync-libs
     uses: ./.github/workflows/makefile.yml
+    with:
+      branch: sync
 
   gotests:
     needs: sync-libs
     uses: ./.github/workflows/eco-gotests-integration.yml
+    with:
+      branch: sync
 
   integration:
     needs: sync-libs
     uses: ./.github/workflows/integration-testing.yml
+    with:
+      branch: sync
     
   label:
     needs: [sync-libs, makefile, gotests, integration]


### PR DESCRIPTION
Although sync-libs uses the sync branch for its changes, all of the subsequent tests would run on the default branch. This hides the errors from the tests unless main also has broken CI.

This PR updates all the workflows that sync-libs calls to take a branch input that determines what to checkout. Other triggers for the workflows just use the GITHUB_SHA for that event type.

[Example action run](https://github.com/klaskosk/eco-goinfra/actions/runs/14064759649/job/39384364965)