### PR TITLE
kmm: add support for tolerations

### DIFF
--- a/pkg/kmm/module.go
+++ b/pkg/kmm/module.go
@@ -179,6 +179,46 @@ func (builder *ModuleBuilder) WithDevicePluginVolume(name string, configMapName 
 	return builder
 }
 
+// WithToleration adds the specified toleration to the Module.
+func (builder *ModuleBuilder) WithToleration(key, operator, value, effect string,
+	seconds *int64) *ModuleBuilder {
+	if valid, _ := builder.validate(); !valid {
+		return builder
+	}
+
+	if key == "" {
+		builder.errorMsg = "cannot redefine with empty 'key' value"
+
+		return builder
+	}
+
+	if operator == "" {
+		builder.errorMsg = "cannot redefine with empty 'operator' value"
+
+		return builder
+	}
+
+	if effect == "" {
+		builder.errorMsg = "cannot redefine with empty 'effect' value"
+
+		return builder
+	}
+
+	glog.V(100).Infof(
+		"Appending toleration with key: %s, operator: %s, value: %s, effect: %s and seconds: %s",
+		key, operator, value, effect, seconds)
+
+	builder.Definition.Spec.Tolerations = append(builder.Definition.Spec.Tolerations, []corev1.Toleration{{
+		Key:               key,
+		Effect:            corev1.TaintEffect(effect),
+		Operator:          corev1.TolerationOperator(operator),
+		Value:             value,
+		TolerationSeconds: seconds,
+	}}...)
+
+	return builder
+}
+
 // WithModuleLoaderContainer adds the specified ModuleLoader container to the Module.
 func (builder *ModuleBuilder) WithModuleLoaderContainer(
 	container *moduleV1Beta1.ModuleLoaderContainerSpec) *ModuleBuilder {


### PR DESCRIPTION
Adding support for tolerations in KMM Modules.

The checks are only added for `key`, `effect` and `operator` fields.

For `value` and `seconds` , given that are optional, no checks were added. 