### PR TITLE
cnf network: add ethernet interface type to nmstate policy

### DIFF
--- a/pkg/nmstate/policy.go
+++ b/pkg/nmstate/policy.go
@@ -399,6 +399,64 @@ func (builder *PolicyBuilder) WithVlanInterfaceIP(baseInterface, ipv4Addresses, 
 	return builder.withInterface(newInterface)
 }
 
+// WithEthernetInterface adds type ethernet interface and IPs configuration to the NodeNetworkConfigurationPolicy.
+func (builder *PolicyBuilder) WithEthernetInterface(interfaceName, ipv4Address, ipv6Address string) *PolicyBuilder {
+	if valid, _ := builder.validate(); !valid {
+		return builder
+	}
+
+	glog.V(100).Infof("Creating NodeNetworkConfigurationPolicy %s with an ethernet interface %s",
+		builder.Definition.Name, interfaceName)
+
+	if interfaceName == "" {
+		glog.V(100).Infof("The interfaceName can not be empty string")
+
+		builder.errorMsg = "nodenetworkconfigurationpolicy 'interfaceName' cannot be empty"
+
+		return builder
+	}
+
+	if net.ParseIP(ipv4Address) == nil {
+		glog.V(100).Infof("the ethernet interface contains an invalid ipv4 address")
+
+		builder.errorMsg = "ethernet interface 'ipv4Addresses' is an invalid ipv4 address"
+
+		return builder
+	}
+
+	if net.ParseIP(ipv6Address) == nil {
+		glog.V(100).Infof("the ethernet interface contains an invalid ipv6 address")
+
+		builder.errorMsg = "ethernet interface 'ipv6Addresses' is an invalid ipv6 address"
+
+		return builder
+	}
+
+	newInterface := NetworkInterface{
+		Name:  interfaceName,
+		Type:  "ethernet",
+		State: "up",
+		Ipv4: InterfaceIpv4{
+			Enabled: true,
+			Dhcp:    false,
+			Address: []InterfaceIPAddress{{
+				PrefixLen: 24,
+				IP:        net.ParseIP(ipv4Address),
+			}},
+		},
+		Ipv6: InterfaceIpv6{
+			Enabled: true,
+			Dhcp:    false,
+			Address: []InterfaceIPAddress{{
+				PrefixLen: 64,
+				IP:        net.ParseIP(ipv6Address),
+			}},
+		},
+	}
+
+	return builder.withInterface(newInterface)
+}
+
 // WithAbsentInterface appends the configuration for an absent interface to the NodeNetworkConfigurationPolicy.
 func (builder *PolicyBuilder) WithAbsentInterface(interfaceName string) *PolicyBuilder {
 	if valid, _ := builder.validate(); !valid {

--- a/pkg/nmstate/policy_test.go
+++ b/pkg/nmstate/policy_test.go
@@ -468,6 +468,77 @@ func TestPolicyWithVlanInterfaceIP(t *testing.T) {
 	}
 }
 
+func TestPolicyWithEthernetInterfaceIP(t *testing.T) {
+	testCases := []struct {
+		testNMStatePolicy *PolicyBuilder
+		expectedError     string
+		sriovInterface    string
+		ipv4              string
+		ipv6              string
+	}{
+		{
+			testNMStatePolicy: buildValidPolicyTestBuilder(buildTestClientWithDummyPolicyObject()),
+			expectedError:     "",
+			sriovInterface:    "ens1",
+			ipv4:              "10.10.10.10",
+			ipv6:              "2001:db8::68",
+		},
+		{
+			testNMStatePolicy: buildValidPolicyTestBuilder(buildTestClientWithDummyPolicyObject()),
+			expectedError:     "nodenetworkconfigurationpolicy 'interfaceName' cannot be empty",
+			sriovInterface:    "",
+			ipv4:              "10.10.10.10",
+			ipv6:              "2001:db8::68",
+		},
+		{
+			testNMStatePolicy: buildValidPolicyTestBuilder(buildTestClientWithDummyPolicyObject()),
+			expectedError:     "ethernet interface 'ipv4Addresses' is an invalid ipv4 address",
+			sriovInterface:    "ens1",
+			ipv4:              "",
+			ipv6:              "2001:db8::68",
+		},
+		{
+			testNMStatePolicy: buildValidPolicyTestBuilder(buildTestClientWithDummyPolicyObject()),
+			expectedError:     "ethernet interface 'ipv6Addresses' is an invalid ipv6 address",
+			sriovInterface:    "ens1",
+			ipv4:              "10.10.10.10",
+			ipv6:              "",
+		},
+	}
+	for _, testCase := range testCases {
+		testPolicy := testCase.testNMStatePolicy.WithEthernetInterface(testCase.sriovInterface,
+			testCase.ipv4, testCase.ipv6)
+		assert.Equal(t, testCase.expectedError, testPolicy.errorMsg)
+
+		desireState := &DesiredState{}
+		if testCase.expectedError == "" {
+			_ = yaml.Unmarshal(testPolicy.Definition.Spec.DesiredState.Raw, desireState)
+			assert.Equal(t, &DesiredState{
+				Interfaces: []NetworkInterface{
+					{
+						Name:  testCase.sriovInterface,
+						Type:  "ethernet",
+						State: "up",
+						Ipv4: InterfaceIpv4{
+							Enabled: true,
+							Address: []InterfaceIPAddress{{
+								PrefixLen: 24,
+								IP:        net.ParseIP(testCase.ipv4),
+							}},
+						},
+						Ipv6: InterfaceIpv6{Enabled: true,
+							Address: []InterfaceIPAddress{{
+								PrefixLen: 64,
+								IP:        net.ParseIP(testCase.ipv6),
+							}},
+						},
+					},
+				},
+			}, desireState)
+		}
+	}
+}
+
 func TestPolicyWithAbsentInterface(t *testing.T) {
 	testCases := []struct {
 		testNMStatePolicy *PolicyBuilder


### PR DESCRIPTION
Add a ethernet interface with IP addresses to the nmstate policy