### PR TITLE
PoC: Common Validate() func

### DIFF
--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -1,0 +1,6 @@
+package common
+
+const (
+	// DeploymentType is the type for deployment resources.
+	DeploymentType = "deployment"
+)

--- a/pkg/common/validate.go
+++ b/pkg/common/validate.go
@@ -1,0 +1,50 @@
+package common
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/golang/glog"
+	"github.com/openshift-kni/eco-goinfra/pkg/msg"
+)
+
+// BuilderInterface is an interface that defining Builders.
+type BuilderInterface interface {
+	GetDefinition() interface{}
+	GetErrorMsg() string
+	GetAPIClient() interface{}
+	GetResourceType() string
+}
+
+// ValidateBuilder checks if the builder is valid.
+func ValidateBuilder(builder BuilderInterface) (bool, error) {
+	if builder == nil || reflect.ValueOf(builder).IsNil() {
+		glog.V(100).Info("The builder is uninitialized or nil")
+
+		return false, fmt.Errorf("error: received nil builder")
+	}
+
+	resourceType := builder.GetResourceType()
+
+	definition := builder.GetDefinition()
+	if definition == nil || (reflect.ValueOf(definition).Kind() == reflect.Ptr && reflect.ValueOf(definition).IsNil()) {
+		glog.V(100).Infof("The %s is undefined or has a nil underlying value", resourceType)
+
+		return false, fmt.Errorf("%s", msg.UndefinedCrdObjectErrString(resourceType))
+	}
+
+	apiClient := builder.GetAPIClient()
+	if apiClient == nil || (reflect.ValueOf(apiClient).Kind() == reflect.Ptr && reflect.ValueOf(apiClient).IsNil()) {
+		glog.V(100).Infof("The %s builder apiclient is nil", resourceType)
+
+		return false, fmt.Errorf("%s builder cannot have nil apiClient", resourceType)
+	}
+
+	if builder.GetErrorMsg() != "" {
+		glog.V(100).Infof("The %s builder has error message: %s", resourceType, builder.GetErrorMsg())
+
+		return false, fmt.Errorf("%s", builder.GetErrorMsg())
+	}
+
+	return true, nil
+}

--- a/pkg/common/validate.go
+++ b/pkg/common/validate.go
@@ -8,16 +8,16 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/msg"
 )
 
-// BuilderInterface is an interface that defining Builders.
-type BuilderInterface interface {
-	GetDefinition() interface{}
+// BuilderInterface is a generic interface defining Builders.
+type BuilderInterface[T any] interface {
+	GetDefinition() *T
 	GetErrorMsg() string
 	GetAPIClient() interface{}
 	GetResourceType() string
 }
 
 // ValidateBuilder checks if the builder is valid.
-func ValidateBuilder(builder BuilderInterface) (bool, error) {
+func ValidateBuilder[T any](builder BuilderInterface[T]) (bool, error) {
 	if builder == nil || reflect.ValueOf(builder).IsNil() {
 		glog.V(100).Info("The builder is uninitialized or nil")
 
@@ -27,7 +27,7 @@ func ValidateBuilder(builder BuilderInterface) (bool, error) {
 	resourceType := builder.GetResourceType()
 
 	definition := builder.GetDefinition()
-	if definition == nil || (reflect.ValueOf(definition).Kind() == reflect.Ptr && reflect.ValueOf(definition).IsNil()) {
+	if definition == nil {
 		glog.V(100).Infof("The %s is undefined or has a nil underlying value", resourceType)
 
 		return false, fmt.Errorf("%s", msg.UndefinedCrdObjectErrString(resourceType))

--- a/pkg/common/validate.go
+++ b/pkg/common/validate.go
@@ -17,11 +17,11 @@ type BuilderInterface[T any] interface {
 }
 
 // ValidateBuilder checks if the builder is valid.
-func ValidateBuilder[T any](builder BuilderInterface[T]) (bool, error) {
+func ValidateBuilder[T any](builder BuilderInterface[T]) error {
 	if builder == nil || reflect.ValueOf(builder).IsNil() {
 		glog.V(100).Info("The builder is uninitialized or nil")
 
-		return false, fmt.Errorf("error: received nil builder")
+		return fmt.Errorf("error: received nil builder")
 	}
 
 	resourceType := builder.GetResourceType()
@@ -30,21 +30,21 @@ func ValidateBuilder[T any](builder BuilderInterface[T]) (bool, error) {
 	if definition == nil {
 		glog.V(100).Infof("The %s is undefined or has a nil underlying value", resourceType)
 
-		return false, fmt.Errorf("%s", msg.UndefinedCrdObjectErrString(resourceType))
+		return fmt.Errorf("%s", msg.UndefinedCrdObjectErrString(resourceType))
 	}
 
 	apiClient := builder.GetAPIClient()
 	if apiClient == nil || (reflect.ValueOf(apiClient).Kind() == reflect.Ptr && reflect.ValueOf(apiClient).IsNil()) {
 		glog.V(100).Infof("The %s builder apiclient is nil", resourceType)
 
-		return false, fmt.Errorf("%s builder cannot have nil apiClient", resourceType)
+		return fmt.Errorf("%s builder cannot have nil apiClient", resourceType)
 	}
 
 	if builder.GetErrorMsg() != "" {
 		glog.V(100).Infof("The %s builder has error message: %s", resourceType, builder.GetErrorMsg())
 
-		return false, fmt.Errorf("%s", builder.GetErrorMsg())
+		return fmt.Errorf("%s", builder.GetErrorMsg())
 	}
 
-	return true, nil
+	return nil
 }

--- a/pkg/common/validate_test.go
+++ b/pkg/common/validate_test.go
@@ -97,20 +97,17 @@ func TestValidateBuilder(t *testing.T) {
 			resourceTypeFunc: func() string { return testCase.resourceTypeReturnValue },
 		}
 
-		valid, err := ValidateBuilder(testBuilder)
+		err := ValidateBuilder(testBuilder)
 		if testCase.expectedValid {
-			assert.True(t, valid)
 			assert.Nil(t, err)
 		} else {
-			assert.False(t, valid)
 			assert.NotNil(t, err)
 			assert.Equal(t, testCase.expectedError, err.Error())
 		}
 	}
 
 	// One additional test case for nil builder
-	valid, err := ValidateBuilder[appsv1.Deployment](nil)
-	assert.False(t, valid)
+	err := ValidateBuilder[appsv1.Deployment](nil)
 	assert.NotNil(t, err)
 	assert.Equal(t, "error: received nil builder", err.Error())
 }

--- a/pkg/common/validate_test.go
+++ b/pkg/common/validate_test.go
@@ -1,0 +1,115 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type mockBuilder struct {
+	definitionFunc   func() interface{}
+	errorMsgFunc     func() string
+	apiClientFunc    func() interface{}
+	resourceTypeFunc func() string
+}
+
+func (b *mockBuilder) GetDefinition() interface{} {
+	if b.definitionFunc != nil {
+		return b.definitionFunc()
+	}
+
+	return nil
+}
+
+func (b *mockBuilder) GetErrorMsg() string {
+	if b.errorMsgFunc != nil {
+		return b.errorMsgFunc()
+	}
+
+	return ""
+}
+
+func (b *mockBuilder) GetAPIClient() interface{} {
+	if b.apiClientFunc != nil {
+		return b.apiClientFunc()
+	}
+
+	return nil
+}
+
+func (b *mockBuilder) GetResourceType() string {
+	if b.resourceTypeFunc != nil {
+		return b.resourceTypeFunc()
+	}
+
+	return "default"
+}
+
+func TestValidateBuilder(t *testing.T) {
+	testCases := []struct {
+		definitionReturnValue   interface{}
+		errorMsgReturnValue     string
+		apiClientReturnValue    interface{}
+		resourceTypeReturnValue string
+		expectedValid           bool
+		expectedError           string
+	}{
+		{
+			definitionReturnValue:   nil,
+			errorMsgReturnValue:     "",
+			apiClientReturnValue:    nil,
+			resourceTypeReturnValue: "testResource",
+			expectedValid:           false,
+			expectedError:           "can not redefine the undefined testResource",
+		},
+		{
+			definitionReturnValue:   struct{}{}, // non-nil definition
+			errorMsgReturnValue:     "",
+			apiClientReturnValue:    nil,
+			resourceTypeReturnValue: "testResource",
+			expectedValid:           false,
+			expectedError:           "testResource builder cannot have nil apiClient",
+		},
+		{
+			definitionReturnValue:   struct{}{}, // non-nil definition
+			errorMsgReturnValue:     "some error message",
+			apiClientReturnValue:    struct{}{}, // non-nil apiClient
+			resourceTypeReturnValue: "testResource",
+			expectedValid:           false,
+			expectedError:           "some error message",
+		},
+		{ // Happy path case
+			definitionReturnValue:   struct{}{}, // non-nil definition
+			errorMsgReturnValue:     "",
+			apiClientReturnValue:    struct{}{}, // non-nil apiClient
+			resourceTypeReturnValue: "testResource",
+			expectedValid:           true,
+			expectedError:           "",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testBuilder := &mockBuilder{
+			definitionFunc:   func() interface{} { return testCase.definitionReturnValue },
+			errorMsgFunc:     func() string { return testCase.errorMsgReturnValue },
+			apiClientFunc:    func() interface{} { return testCase.apiClientReturnValue },
+			resourceTypeFunc: func() string { return testCase.resourceTypeReturnValue },
+		}
+
+		valid, err := ValidateBuilder(testBuilder)
+		if testCase.expectedValid {
+			assert.True(t, valid)
+			assert.Nil(t, err)
+		} else {
+			assert.False(t, valid)
+			assert.NotNil(t, err)
+			assert.Equal(t, testCase.expectedError, err.Error())
+		}
+	}
+
+	// One additional test case for nil builder
+	valid, err := ValidateBuilder(nil)
+	assert.False(t, valid)
+	assert.NotNil(t, err)
+	assert.Equal(t, "error: received nil builder", err.Error())
+}

--- a/pkg/deployment/deployment.go
+++ b/pkg/deployment/deployment.go
@@ -136,7 +136,7 @@ func Pull(apiClient *clients.Settings, name, nsname string) (*Builder, error) {
 
 // WithNodeSelector applies a nodeSelector to the deployment definition.
 func (builder *Builder) WithNodeSelector(selector map[string]string) *Builder {
-	if valid, _ := builder.validate(); !valid {
+	if err := common.ValidateBuilder[appsv1.Deployment](builder); err != nil {
 		return builder
 	}
 
@@ -150,7 +150,7 @@ func (builder *Builder) WithNodeSelector(selector map[string]string) *Builder {
 
 // WithReplicas sets the desired number of replicas in the deployment definition.
 func (builder *Builder) WithReplicas(replicas int32) *Builder {
-	if valid, _ := builder.validate(); !valid {
+	if err := common.ValidateBuilder[appsv1.Deployment](builder); err != nil {
 		return builder
 	}
 
@@ -164,7 +164,7 @@ func (builder *Builder) WithReplicas(replicas int32) *Builder {
 
 // WithAdditionalContainerSpecs appends a list of container specs to the deployment definition.
 func (builder *Builder) WithAdditionalContainerSpecs(specs []corev1.Container) *Builder {
-	if valid, _ := builder.validate(); !valid {
+	if err := common.ValidateBuilder[appsv1.Deployment](builder); err != nil {
 		return builder
 	}
 
@@ -186,7 +186,7 @@ func (builder *Builder) WithAdditionalContainerSpecs(specs []corev1.Container) *
 
 // WithSecondaryNetwork applies Multus secondary network configuration on deployment definition.
 func (builder *Builder) WithSecondaryNetwork(networks []*multus.NetworkSelectionElement) *Builder {
-	if valid, _ := builder.validate(); !valid {
+	if err := common.ValidateBuilder[appsv1.Deployment](builder); err != nil {
 		return builder
 	}
 
@@ -214,7 +214,7 @@ func (builder *Builder) WithSecondaryNetwork(networks []*multus.NetworkSelection
 
 // WithHugePages sets hugePages on all containers inside the deployment.
 func (builder *Builder) WithHugePages() *Builder {
-	if valid, _ := builder.validate(); !valid {
+	if err := common.ValidateBuilder[appsv1.Deployment](builder); err != nil {
 		return builder
 	}
 
@@ -248,7 +248,7 @@ func (builder *Builder) WithHugePages() *Builder {
 
 // WithSecurityContext sets SecurityContext on deployment definition.
 func (builder *Builder) WithSecurityContext(securityContext *corev1.PodSecurityContext) *Builder {
-	if valid, _ := builder.validate(); !valid {
+	if err := common.ValidateBuilder[appsv1.Deployment](builder); err != nil {
 		return builder
 	}
 
@@ -270,7 +270,7 @@ func (builder *Builder) WithSecurityContext(securityContext *corev1.PodSecurityC
 
 // WithLabel applies label to deployment's definition.
 func (builder *Builder) WithLabel(labelKey, labelValue string) *Builder {
-	if valid, _ := builder.validate(); !valid {
+	if err := common.ValidateBuilder[appsv1.Deployment](builder); err != nil {
 		return builder
 	}
 
@@ -295,7 +295,7 @@ func (builder *Builder) WithLabel(labelKey, labelValue string) *Builder {
 
 // WithServiceAccountName sets the ServiceAccountName on deployment definition.
 func (builder *Builder) WithServiceAccountName(serviceAccountName string) *Builder {
-	if valid, _ := builder.validate(); !valid {
+	if err := common.ValidateBuilder[appsv1.Deployment](builder); err != nil {
 		return builder
 	}
 
@@ -317,7 +317,7 @@ func (builder *Builder) WithServiceAccountName(serviceAccountName string) *Build
 
 // WithVolume attaches given volume to the deployment.
 func (builder *Builder) WithVolume(deployVolume corev1.Volume) *Builder {
-	if valid, _ := builder.validate(); !valid {
+	if err := common.ValidateBuilder[appsv1.Deployment](builder); err != nil {
 		return builder
 	}
 
@@ -341,7 +341,7 @@ func (builder *Builder) WithVolume(deployVolume corev1.Volume) *Builder {
 
 // WithSchedulerName configures a scheduler to process pod's scheduling.
 func (builder *Builder) WithSchedulerName(schedulerName string) *Builder {
-	if valid, _ := builder.validate(); !valid {
+	if err := common.ValidateBuilder[appsv1.Deployment](builder); err != nil {
 		return builder
 	}
 
@@ -363,7 +363,7 @@ func (builder *Builder) WithSchedulerName(schedulerName string) *Builder {
 
 // WithAffinity applies Affinity to the deployment definition.
 func (builder *Builder) WithAffinity(affinity *corev1.Affinity) *Builder {
-	if valid, _ := builder.validate(); !valid {
+	if err := common.ValidateBuilder[appsv1.Deployment](builder); err != nil {
 		return builder
 	}
 
@@ -385,7 +385,7 @@ func (builder *Builder) WithAffinity(affinity *corev1.Affinity) *Builder {
 
 // WithHostNetwork applies a hostnetwork state to the deployment definition.
 func (builder *Builder) WithHostNetwork(enableHostnetwork bool) *Builder {
-	if valid, _ := builder.validate(); !valid {
+	if err := common.ValidateBuilder[appsv1.Deployment](builder); err != nil {
 		return builder
 	}
 
@@ -399,7 +399,7 @@ func (builder *Builder) WithHostNetwork(enableHostnetwork bool) *Builder {
 
 // WithOptions creates deployment with generic mutation options.
 func (builder *Builder) WithOptions(options ...AdditionalOptions) *Builder {
-	if valid, _ := builder.validate(); !valid {
+	if err := common.ValidateBuilder[appsv1.Deployment](builder); err != nil {
 		return builder
 	}
 
@@ -424,7 +424,7 @@ func (builder *Builder) WithOptions(options ...AdditionalOptions) *Builder {
 
 // Create generates a deployment in cluster and stores the created object in struct.
 func (builder *Builder) Create() (*Builder, error) {
-	if valid, err := builder.validate(); !valid {
+	if err := common.ValidateBuilder[appsv1.Deployment](builder); err != nil {
 		return builder, err
 	}
 
@@ -441,7 +441,7 @@ func (builder *Builder) Create() (*Builder, error) {
 
 // Update renovates the existing deployment object with the deployment definition in builder.
 func (builder *Builder) Update() (*Builder, error) {
-	if valid, err := builder.validate(); !valid {
+	if err := common.ValidateBuilder[appsv1.Deployment](builder); err != nil {
 		return builder, err
 	}
 
@@ -456,7 +456,7 @@ func (builder *Builder) Update() (*Builder, error) {
 
 // Delete removes a deployment.
 func (builder *Builder) Delete() error {
-	if valid, err := builder.validate(); !valid {
+	if err := common.ValidateBuilder[appsv1.Deployment](builder); err != nil {
 		return err
 	}
 
@@ -487,7 +487,7 @@ func (builder *Builder) Delete() error {
 // DeleteGraceful removes a deployment while waiting for specified duration(in seconds)
 // the object should be deleted.
 func (builder *Builder) DeleteGraceful(gracePeriod *int64) error {
-	if valid, err := builder.validate(); !valid {
+	if err := common.ValidateBuilder[appsv1.Deployment](builder); err != nil {
 		return err
 	}
 
@@ -528,7 +528,7 @@ func (builder *Builder) DeleteGraceful(gracePeriod *int64) error {
 
 // CreateAndWaitUntilReady creates a deployment in the cluster and waits until the deployment is available.
 func (builder *Builder) CreateAndWaitUntilReady(timeout time.Duration) (*Builder, error) {
-	if valid, err := builder.validate(); !valid {
+	if err := common.ValidateBuilder[appsv1.Deployment](builder); err != nil {
 		return builder, err
 	}
 
@@ -552,7 +552,7 @@ func (builder *Builder) CreateAndWaitUntilReady(timeout time.Duration) (*Builder
 
 // IsReady periodically checks if deployment is in ready status.
 func (builder *Builder) IsReady(timeout time.Duration) bool {
-	if valid, _ := builder.validate(); !valid {
+	if err := common.ValidateBuilder[appsv1.Deployment](builder); err != nil {
 		return false
 	}
 
@@ -587,7 +587,7 @@ func (builder *Builder) IsReady(timeout time.Duration) bool {
 
 // DeleteAndWait deletes a deployment and waits until it is removed from the cluster.
 func (builder *Builder) DeleteAndWait(timeout time.Duration) error {
-	if valid, err := builder.validate(); !valid {
+	if err := common.ValidateBuilder[appsv1.Deployment](builder); err != nil {
 		return err
 	}
 
@@ -613,7 +613,7 @@ func (builder *Builder) DeleteAndWait(timeout time.Duration) error {
 
 // Exists checks whether the given deployment exists.
 func (builder *Builder) Exists() bool {
-	if valid, _ := builder.validate(); !valid {
+	if err := common.ValidateBuilder[appsv1.Deployment](builder); err != nil {
 		return false
 	}
 
@@ -630,7 +630,7 @@ func (builder *Builder) Exists() bool {
 // WaitUntilCondition waits for the duration of the defined timeout or until the
 // deployment gets to a specific condition.
 func (builder *Builder) WaitUntilCondition(condition appsv1.DeploymentConditionType, timeout time.Duration) error {
-	if valid, err := builder.validate(); !valid {
+	if err := common.ValidateBuilder[appsv1.Deployment](builder); err != nil {
 		return err
 	}
 
@@ -661,7 +661,7 @@ func (builder *Builder) WaitUntilCondition(condition appsv1.DeploymentConditionT
 
 // WaitUntilDeleted waits for the duration of the defined timeout or until the deployment is deleted.
 func (builder *Builder) WaitUntilDeleted(timeout time.Duration) error {
-	if valid, err := builder.validate(); !valid {
+	if err := common.ValidateBuilder[appsv1.Deployment](builder); err != nil {
 		return err
 	}
 
@@ -710,14 +710,9 @@ func (builder *Builder) GetResourceType() string {
 	return common.DeploymentType
 }
 
-// Replace the validate() method with a call to common.ValidateBuilder.
-func (builder *Builder) validate() (bool, error) {
-	return common.ValidateBuilder[appsv1.Deployment](builder)
-}
-
 // WithToleration applies a toleration to the deployment's definition.
 func (builder *Builder) WithToleration(toleration corev1.Toleration) *Builder {
-	if valid, _ := builder.validate(); !valid {
+	if err := common.ValidateBuilder[appsv1.Deployment](builder); err != nil {
 		return builder
 	}
 

--- a/pkg/deployment/deployment.go
+++ b/pkg/deployment/deployment.go
@@ -687,11 +687,7 @@ func GetGVR() schema.GroupVersionResource {
 }
 
 // GetDefinition returns the deployment definition.
-func (builder *Builder) GetDefinition() interface{} {
-	if builder.Definition == nil {
-		return (*appsv1.Deployment)(nil) // Explicitly return a nil pointer of the correct type
-	}
-
+func (builder *Builder) GetDefinition() *appsv1.Deployment {
 	return builder.Definition
 }
 
@@ -716,7 +712,7 @@ func (builder *Builder) GetResourceType() string {
 
 // Replace the validate() method with a call to common.ValidateBuilder.
 func (builder *Builder) validate() (bool, error) {
-	return common.ValidateBuilder(builder)
+	return common.ValidateBuilder[appsv1.Deployment](builder)
 }
 
 // WithToleration applies a toleration to the deployment's definition.

--- a/pkg/deployment/deployment.go
+++ b/pkg/deployment/deployment.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
-	"github.com/openshift-kni/eco-goinfra/pkg/msg"
+	"github.com/openshift-kni/eco-goinfra/pkg/common"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -686,36 +686,37 @@ func GetGVR() schema.GroupVersionResource {
 	return schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
 }
 
-// validate will check that the builder and builder definition are properly initialized before
-// accessing any member fields.
-func (builder *Builder) validate() (bool, error) {
-	resourceCRD := "ClusterDeployment"
-
-	if builder == nil {
-		glog.V(100).Infof("The %s builder is uninitialized", resourceCRD)
-
-		return false, fmt.Errorf("error: received nil %s builder", resourceCRD)
-	}
-
+// GetDefinition returns the deployment definition.
+func (builder *Builder) GetDefinition() interface{} {
 	if builder.Definition == nil {
-		glog.V(100).Infof("The %s is undefined", resourceCRD)
-
-		return false, fmt.Errorf("%s", msg.UndefinedCrdObjectErrString(resourceCRD))
+		return (*appsv1.Deployment)(nil) // Explicitly return a nil pointer of the correct type
 	}
 
+	return builder.Definition
+}
+
+// GetErrorMsg returns the error message.
+func (builder *Builder) GetErrorMsg() string {
+	return builder.errorMsg
+}
+
+// GetAPIClient returns the API client.
+func (builder *Builder) GetAPIClient() interface{} {
 	if builder.apiClient == nil {
-		glog.V(100).Infof("The %s builder apiclient is nil", resourceCRD)
-
-		return false, fmt.Errorf("%s builder cannot have nil apiClient", resourceCRD)
+		return (*appsv1Typed.AppsV1Interface)(nil) // Explicitly return a nil pointer of the correct type
 	}
 
-	if builder.errorMsg != "" {
-		glog.V(100).Infof("The %s builder has error message: %s", resourceCRD, builder.errorMsg)
+	return builder.apiClient
+}
 
-		return false, fmt.Errorf("%s", builder.errorMsg)
-	}
+// GetResourceType returns the resource type of the deployment.
+func (builder *Builder) GetResourceType() string {
+	return common.DeploymentType
+}
 
-	return true, nil
+// Replace the validate() method with a call to common.ValidateBuilder.
+func (builder *Builder) validate() (bool, error) {
+	return common.ValidateBuilder(builder)
 }
 
 // WithToleration applies a toleration to the deployment's definition.

--- a/pkg/deployment/deployment_test.go
+++ b/pkg/deployment/deployment_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
+	"github.com/openshift-kni/eco-goinfra/pkg/common"
 	"github.com/stretchr/testify/assert"
 	multus "gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/types"
 	appsv1 "k8s.io/api/apps/v1"
@@ -802,19 +803,19 @@ func TestValidate(t *testing.T) {
 			builderNil:    true,
 			definitionNil: false,
 			apiClientNil:  false,
-			expectedError: "error: received nil ClusterDeployment builder",
+			expectedError: "error: received nil builder",
 		},
 		{
 			builderNil:    false,
 			definitionNil: true,
 			apiClientNil:  false,
-			expectedError: "can not redefine the undefined ClusterDeployment",
+			expectedError: fmt.Sprintf("can not redefine the undefined %s", common.DeploymentType),
 		},
 		{
 			builderNil:    false,
 			definitionNil: false,
 			apiClientNil:  true,
-			expectedError: "ClusterDeployment builder cannot have nil apiClient",
+			expectedError: fmt.Sprintf("%s builder cannot have nil apiClient", common.DeploymentType),
 		},
 		{
 			builderNil:    false,

--- a/pkg/deployment/deployment_test.go
+++ b/pkg/deployment/deployment_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
-	"github.com/openshift-kni/eco-goinfra/pkg/common"
 	"github.com/stretchr/testify/assert"
 	multus "gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/types"
 	appsv1 "k8s.io/api/apps/v1"
@@ -790,66 +789,6 @@ func TestWaitUntilCondition(t *testing.T) {
 	err := testBuilder.WaitUntilCondition(appsv1.DeploymentAvailable, time.Second*5)
 
 	assert.Nil(t, err)
-}
-
-func TestValidate(t *testing.T) {
-	testCases := []struct {
-		builderNil    bool
-		definitionNil bool
-		apiClientNil  bool
-		expectedError string
-	}{
-		{
-			builderNil:    true,
-			definitionNil: false,
-			apiClientNil:  false,
-			expectedError: "error: received nil builder",
-		},
-		{
-			builderNil:    false,
-			definitionNil: true,
-			apiClientNil:  false,
-			expectedError: fmt.Sprintf("can not redefine the undefined %s", common.DeploymentType),
-		},
-		{
-			builderNil:    false,
-			definitionNil: false,
-			apiClientNil:  true,
-			expectedError: fmt.Sprintf("%s builder cannot have nil apiClient", common.DeploymentType),
-		},
-		{
-			builderNil:    false,
-			definitionNil: false,
-			apiClientNil:  false,
-			expectedError: "",
-		},
-	}
-
-	for _, testCase := range testCases {
-		testBuilder := buildValidTestBuilder()
-
-		if testCase.builderNil {
-			testBuilder = nil
-		}
-
-		if testCase.definitionNil {
-			testBuilder.Definition = nil
-		}
-
-		if testCase.apiClientNil {
-			testBuilder.apiClient = nil
-		}
-
-		result, err := testBuilder.validate()
-		if testCase.expectedError != "" {
-			assert.NotNil(t, err)
-			assert.Equal(t, testCase.expectedError, err.Error())
-			assert.False(t, result)
-		} else {
-			assert.Nil(t, err)
-			assert.True(t, result)
-		}
-	}
 }
 
 func TestDeploymentWaitUntilDeleted(t *testing.T) {


### PR DESCRIPTION
Proof of concept for making a common interface for `Validate()` with `deployment` being the first package to take advantage of it.

### New validation mechanism:

* [`pkg/common/types.go`](diffhunk://#diff-2ff757ca5b194b9a983adc95868bd4b9600aa807cacfd2569801926e687a5ffcR1-R5): Added a new constant `DeploymentType`.
* [`pkg/common/validate.go`](diffhunk://#diff-38bda930798637d4f2d681cac4c5a43c9e647d0266f9f074380d3aed066cb583R1-R44): Introduced the `BuilderInterface` and the `ValidateBuilder` function to validate builder objects.
* [`pkg/common/validate_test.go`](diffhunk://#diff-909f495387af52986871255458cd43af0f0823e08707b828f4d639bf981fcbf9R1-R111): Added unit tests for the `ValidateBuilder` function using a mock builder.

### Integration with deployment package:

* [`pkg/deployment/deployment.go`](diffhunk://#diff-b44566f9caa976421532eb049c77b7eb247418f138516fab277a1ec33d3a7992L689-R714): Replaced the existing `validate` method with the new `ValidateBuilder` function and implemented the `BuilderInterface` methods.
* [`pkg/deployment/deployment_test.go`](diffhunk://#diff-e63ab873819d44774258d70d7498d2f000378f6611712dc641a356d19cb8b789L805-R818): Updated tests to reflect the changes in the validation mechanism.

### Import adjustments:

* [`pkg/deployment/deployment.go`](diffhunk://#diff-b44566f9caa976421532eb049c77b7eb247418f138516fab277a1ec33d3a7992L13-R13): Updated imports to include the new `common` package.
* [`pkg/deployment/deployment_test.go`](diffhunk://#diff-e63ab873819d44774258d70d7498d2f000378f6611712dc641a356d19cb8b789R10): Updated imports to include the new `common` package.