### PR TITLE
ci: fix actions not using passed branch

### DIFF
--- a/.github/workflows/eco-gotests-integration.yml
+++ b/.github/workflows/eco-gotests-integration.yml
@@ -27,7 +27,7 @@ jobs:
         if: ${{ !contains(github.event.*.labels.*.name, 'ignore-dep-check') }}
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'workflow_call' && inputs.branch || github.sha }}
+          ref: ${{ inputs.branch || github.sha }}
 
       - name: Set up Go
         if: ${{ !contains(github.event.*.labels.*.name, 'ignore-dep-check') }}

--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'workflow_call' && inputs.branch || github.sha }}
+          ref: ${{ inputs.branch || github.sha }}
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-            ref: ${{ github.event_name == 'workflow_call' && inputs.branch || github.sha }}
+            ref: ${{ inputs.branch || github.sha }}
       
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -45,7 +45,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'workflow_call' && inputs.branch || github.sha }}
+          ref: ${{ inputs.branch || github.sha }}
       
       - name: Set up Go
         uses: actions/setup-go@v5


### PR DESCRIPTION
Workflows that are called by a scheduled workflow inherit the schedule event type so the check for workflow_call was always false. It is also unnecessary since the inputs will be null if not applicable so the `||` is enough to provide a fallback.