### PR TITLE
kmm: handle nils while using ModuleLoaderSpec

### DIFF
--- a/pkg/kmm/module.go
+++ b/pkg/kmm/module.go
@@ -232,6 +232,10 @@ func (builder *ModuleBuilder) WithModuleLoaderContainer(
 		return builder
 	}
 
+	if builder.Definition.Spec.ModuleLoader == nil {
+		builder.Definition.Spec.ModuleLoader = &moduleV1Beta1.ModuleLoaderSpec{}
+	}
+
 	builder.Definition.Spec.ModuleLoader.Container = *container
 
 	return builder
@@ -464,6 +468,10 @@ func (builder *ModuleBuilder) withServiceAccount(srvAccountName string, accountT
 
 	switch accountType {
 	case "module":
+		if builder.Definition.Spec.ModuleLoader == nil {
+			builder.Definition.Spec.ModuleLoader = &moduleV1Beta1.ModuleLoaderSpec{}
+		}
+
 		builder.Definition.Spec.ModuleLoader.ServiceAccountName = srvAccountName
 	case "device":
 		if builder.Definition.Spec.DevicePlugin == nil {


### PR DESCRIPTION
ModuleLoaderSpec is now optional. Creating it when it is needed.