### PR TITLE
storage: fully remove ManageNodes references

### DIFF
--- a/pkg/storage/ocs.go
+++ b/pkg/storage/ocs.go
@@ -243,23 +243,6 @@ func (builder *StorageClusterBuilder) Update() (*StorageClusterBuilder, error) {
 	return builder, nil
 }
 
-// GetManageNodes fetches storageCluster manageNodes value.
-func (builder *StorageClusterBuilder) GetManageNodes() (bool, error) {
-	if valid, err := builder.validate(); !valid {
-		return false, err
-	}
-
-	glog.V(100).Infof("Getting storageCluster %s in namespace %s manageNodes configuration",
-		builder.Definition.Name, builder.Definition.Namespace)
-
-	if !builder.Exists() {
-		return false, fmt.Errorf("storageCluster object %s does not exist in namespace %s",
-			builder.Definition.Name, builder.Definition.Namespace)
-	}
-
-	return builder.Object.Spec.ManageNodes, nil
-}
-
 // GetManagedResources fetches storageCluster managedResources value.
 func (builder *StorageClusterBuilder) GetManagedResources() (*ocsoperatorv1.ManagedResourcesSpec, error) {
 	if valid, err := builder.validate(); !valid {

--- a/pkg/storage/ocs_test.go
+++ b/pkg/storage/ocs_test.go
@@ -35,7 +35,6 @@ func TestSorageClusterPull(t *testing.T) {
 				Namespace: namespace,
 			},
 			Spec: ocsoperatorv1.StorageClusterSpec{
-				ManageNodes: false,
 				ManagedResources: ocsoperatorv1.ManagedResourcesSpec{
 					CephBlockPools: ocsoperatorv1.ManageCephBlockPools{
 						ReconcileStrategy: "manage",
@@ -339,32 +338,6 @@ func TestStorageClusterUpdate(t *testing.T) {
 			assert.Equal(t, testCase.flexibleScaling, testCase.testStorageCluster.Definition.Spec.FlexibleScaling)
 		} else {
 			assert.Equal(t, testCase.expectedError, err)
-		}
-	}
-}
-
-func TestStorageClusterGetManageNodes(t *testing.T) {
-	testCases := []struct {
-		testStorageCluster *StorageClusterBuilder
-		expectedError      error
-	}{
-		{
-			testStorageCluster: buildValidStorageClusterBuilder(buildStorageClusterClientWithDummyObject()),
-			expectedError:      nil,
-		},
-		{
-			testStorageCluster: buildValidStorageClusterBuilder(clients.GetTestClients(clients.TestClientParams{})),
-			expectedError:      errStorageClusterNotExists,
-		},
-	}
-
-	for _, testCase := range testCases {
-		currentStorageClusterManageNodesValue, err := testCase.testStorageCluster.GetManageNodes()
-
-		if testCase.expectedError == nil {
-			assert.Equal(t, currentStorageClusterManageNodesValue, testCase.testStorageCluster.Object.Spec.ManageNodes)
-		} else {
-			assert.Equal(t, testCase.expectedError.Error(), err.Error())
 		}
 	}
 }
@@ -718,7 +691,6 @@ func buildDummyStorageCluster() []runtime.Object {
 			Namespace: defaultStorageClusterNamespace,
 		},
 		Spec: ocsoperatorv1.StorageClusterSpec{
-			ManageNodes:        false,
 			ManagedResources:   ocsoperatorv1.ManagedResourcesSpec{},
 			MonDataDirHostPath: "",
 			MultiCloudGateway:  nil,


### PR DESCRIPTION
Although #1081 removed the WithManageNodes function that was used in eco-gotests, it neglected to remove GetManagedNodes and any other references in eco-goinfra. This PR fully removes it so #1080 will work.