### PR TITLE
common: create embeddable builder and reuse it for tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -120,7 +120,7 @@ linters:
         - stdlib
         - generic
         # Allow returning the controller-runtime Client interface.
-        - client\.Client$
+        - '.*client\.Client$'
     revive:
       rules:
         - name: indent-error-flow
@@ -130,9 +130,9 @@ linters:
             - []
             # initialism denylist
             - []
-            # This is so that our common package does not cause errors for the
-            # var-naming rule. builder may be a better name, but would cause
-            # confusion with method receivers.
+            # This is so that our pkg/internal/common package does not cause
+            # errors for the var-naming rule. builder may be a better name, but
+            # would cause confusion with method receivers.
             - [{ skip-package-name-checks: true }]
         - name: increment-decrement
         - name: exported

--- a/pkg/internal/common/embeddable_builder.go
+++ b/pkg/internal/common/embeddable_builder.go
@@ -1,0 +1,97 @@
+package common
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// EmbeddableBuilder is a struct implementing the Builder interface that can be embedded in existing builder structs. It
+// provides the basic fields and methods for CRUD functions that builders need.
+type EmbeddableBuilder[O any, SO objectPointer[O]] struct {
+	// Definition is the desired form of the resource.
+	Definition SO
+	// Object is the last pulled form of the resource.
+	Object SO
+	// err is the error stored in the builder.
+	err error
+	// apiClient is the client used for connecting with the K8s cluster.
+	apiClient runtimeclient.Client
+	// gvk is the GVK of the resource the builder represents. It is set by [SetGVK] and then returned by all
+	// subsequent [GetGVK] calls.
+	gvk schema.GroupVersionKind
+}
+
+// GetDefinition returns the desired form of the resource. This method returns a pointer to the definition, which can be
+// modified directly.
+func (b *EmbeddableBuilder[O, SO]) GetDefinition() SO {
+	return b.Definition
+}
+
+// SetDefinition updates the desired form of the resource. In general, end users would want to use either the builder
+// modifiers or make changes to the definition returned from [GetDefinition].
+func (b *EmbeddableBuilder[O, SO]) SetDefinition(definition SO) {
+	b.Definition = definition
+}
+
+// GetObject returns the last pulled form of the resource.
+func (b *EmbeddableBuilder[O, SO]) GetObject() SO {
+	return b.Object
+}
+
+// SetObject updates the last pulled form of the resource. End users should not call this method directly since the
+// object is automatically updated when the resource is pulled from the cluster.
+func (b *EmbeddableBuilder[O, SO]) SetObject(object SO) {
+	b.Object = object
+}
+
+// GetError returns the error stored in the builder. End users should not call this method directly since the error is
+// returned during validation.
+func (b *EmbeddableBuilder[O, SO]) GetError() error {
+	return b.err
+}
+
+// SetError updates the error stored in the builder. End users should not call this method directly since the error is
+// automatically set by the builder modifiers.
+func (b *EmbeddableBuilder[O, SO]) SetError(err error) {
+	b.err = err
+}
+
+// GetClient returns the client used for connecting with the K8s cluster.
+func (b *EmbeddableBuilder[O, SO]) GetClient() runtimeclient.Client {
+	return b.apiClient
+}
+
+// SetClient updates the client used for connecting with the K8s cluster. End users should not call this method directly
+// since the client is automatically set when the builder is created.
+func (b *EmbeddableBuilder[O, SO]) SetClient(apiClient runtimeclient.Client) {
+	b.apiClient = apiClient
+}
+
+// GetGVK returns the GVK for the resource the builder represents, even if the builder is zero-valued. However,
+// embedders should override this method to return the proper GVK for the embedding builder.
+//
+// During builder initialization, the [SetGVK] method is called to set the GVK for the builder. This method returns the
+// value provided through [SetGVK].
+func (b *EmbeddableBuilder[O, SO]) GetGVK() schema.GroupVersionKind {
+	return b.gvk
+}
+
+// SetGVK updates the GVK for the resource the builder represents. Embedders should not override this method since it
+// will be called when initializing the builder to ensure that [GetGVK] returns the proper GVK.
+func (b *EmbeddableBuilder[O, SO]) SetGVK(gvk schema.GroupVersionKind) {
+	b.gvk = gvk
+}
+
+// Get pulls the resource from the cluster and returns it. It does not modify the builder.
+func (b *EmbeddableBuilder[O, SO]) Get() (SO, error) {
+	return Get(context.TODO(), b)
+}
+
+// Exists checks whether the resource exists on the cluster. If the resource does exist, the builder's object is updated
+// with the resource and this returns true. If the builder is invalid, or the resource cannot be retrieved, this returns
+// false without modifying the builder.
+func (b *EmbeddableBuilder[O, SO]) Exists() bool {
+	return Exists(context.TODO(), b)
+}

--- a/pkg/internal/common/testutils.go
+++ b/pkg/internal/common/testutils.go
@@ -54,11 +54,7 @@ func buildDummyClusterScopedResource() *corev1.Namespace {
 
 // mockClusterScopedBuilder implements the Builder interface for testing using a cluster-scoped resource.
 type mockClusterScopedBuilder struct {
-	apiClient  runtimeclient.Client
-	definition *corev1.Namespace
-	object     *corev1.Namespace
-	err        error
-	gvk        schema.GroupVersionKind
+	EmbeddableBuilder[corev1.Namespace, *corev1.Namespace]
 }
 
 // Compile-time check to ensure mockClusterScopedBuilder implements Builder interface.
@@ -66,63 +62,31 @@ var _ Builder[corev1.Namespace, *corev1.Namespace] = (*mockClusterScopedBuilder)
 
 func buildValidMockClusterScopedBuilder(client runtimeclient.Client) *mockClusterScopedBuilder {
 	return &mockClusterScopedBuilder{
-		apiClient:  client,
-		definition: buildDummyClusterScopedResource(),
-		object:     buildDummyClusterScopedResource(),
-		err:        nil,
+		EmbeddableBuilder: EmbeddableBuilder[corev1.Namespace, *corev1.Namespace]{
+			apiClient:  client,
+			Definition: buildDummyClusterScopedResource(),
+			Object:     buildDummyClusterScopedResource(),
+			err:        nil,
+		},
 	}
 }
 
 func buildInvalidMockClusterScopedBuilder(client runtimeclient.Client) *mockClusterScopedBuilder {
 	return &mockClusterScopedBuilder{
-		apiClient:  client,
-		definition: buildDummyClusterScopedResource(),
-		object:     buildDummyClusterScopedResource(),
-		err:        errInvalidBuilder,
+		EmbeddableBuilder: EmbeddableBuilder[corev1.Namespace, *corev1.Namespace]{
+			apiClient:  client,
+			Definition: buildDummyClusterScopedResource(),
+			Object:     buildDummyClusterScopedResource(),
+			err:        errInvalidBuilder,
+		},
 	}
-}
-
-func (builder *mockClusterScopedBuilder) GetDefinition() *corev1.Namespace {
-	return builder.definition
-}
-
-func (builder *mockClusterScopedBuilder) SetDefinition(definition *corev1.Namespace) {
-	builder.definition = definition
-}
-
-func (builder *mockClusterScopedBuilder) GetObject() *corev1.Namespace {
-	return builder.object
-}
-
-func (builder *mockClusterScopedBuilder) SetObject(object *corev1.Namespace) {
-	builder.object = object
-}
-
-func (builder *mockClusterScopedBuilder) GetError() error {
-	return builder.err
-}
-
-func (builder *mockClusterScopedBuilder) SetError(err error) {
-	builder.err = err
-}
-
-func (builder *mockClusterScopedBuilder) GetClient() runtimeclient.Client {
-	return builder.apiClient
-}
-
-func (builder *mockClusterScopedBuilder) SetClient(client runtimeclient.Client) {
-	builder.apiClient = client
 }
 
 func (builder *mockClusterScopedBuilder) GetGVK() schema.GroupVersionKind {
 	return clusterScopedGVK
 }
 
-func (builder *mockClusterScopedBuilder) SetGVK(gvk schema.GroupVersionKind) {
-	builder.gvk = gvk
-}
-
-// buildDummyNamespacedResource creates a dummy cluster-scoped resource for testing. In this case, it is a ConfigMap,
+// buildDummyNamespacedResource creates a dummy namespaced resource for testing. In this case, it is a ConfigMap,
 // although the specific resource type is intentionally unimportant for the purpose of testing.
 func buildDummyNamespacedResource(name, namespace string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
@@ -135,52 +99,12 @@ func buildDummyNamespacedResource(name, namespace string) *corev1.ConfigMap {
 
 // mockNamespacedBuilder implements the Builder interface for testing using a namespaced resource.
 type mockNamespacedBuilder struct {
-	apiClient  runtimeclient.Client
-	definition *corev1.ConfigMap
-	object     *corev1.ConfigMap
-	err        error
-	gvk        schema.GroupVersionKind
+	EmbeddableBuilder[corev1.ConfigMap, *corev1.ConfigMap]
 }
 
 // Compile-time check to ensure mockNamespacedBuilder implements Builder interface.
 var _ Builder[corev1.ConfigMap, *corev1.ConfigMap] = (*mockNamespacedBuilder)(nil)
 
-func (builder *mockNamespacedBuilder) GetDefinition() *corev1.ConfigMap {
-	return builder.definition
-}
-
-func (builder *mockNamespacedBuilder) SetDefinition(definition *corev1.ConfigMap) {
-	builder.definition = definition
-}
-
-func (builder *mockNamespacedBuilder) GetObject() *corev1.ConfigMap {
-	return builder.object
-}
-
-func (builder *mockNamespacedBuilder) SetObject(object *corev1.ConfigMap) {
-	builder.object = object
-}
-
-func (builder *mockNamespacedBuilder) GetError() error {
-	return builder.err
-}
-
-func (builder *mockNamespacedBuilder) SetError(err error) {
-	builder.err = err
-}
-
-func (builder *mockNamespacedBuilder) GetClient() runtimeclient.Client {
-	return builder.apiClient
-}
-
-func (builder *mockNamespacedBuilder) SetClient(client runtimeclient.Client) {
-	builder.apiClient = client
-}
-
 func (builder *mockNamespacedBuilder) GetGVK() schema.GroupVersionKind {
 	return namespacedGVK
-}
-
-func (builder *mockNamespacedBuilder) SetGVK(gvk schema.GroupVersionKind) {
-	builder.gvk = gvk
 }


### PR DESCRIPTION
Depends-on: #1094

The initial PR focused on defining the Builder interface and some functions using it but did not include the EmbeddableBuilder from PoC #1008. This PR adds the EmbeddableBuilder struct then uses it for the mock builders in testutils.go. This ensures that the EmbeddableBuilder correctly implements the expected functionality of Builder as a drop-in replacement.

Assisted-by: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated linting configuration rules.

* **Refactor**
  * Improved internal builder architecture for enhanced code organization and reusability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->