### PR TITLE
pod: attempt to address integration test flakiness

### DIFF
--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -451,7 +451,6 @@ func (builder *Builder) ExecCommand(command []string, containerName ...string) (
 		VersionedParams(&corev1.PodExecOptions{
 			Container: cName,
 			Command:   command,
-			Stdin:     true,
 			Stdout:    true,
 			Stderr:    true,
 			TTY:       true,
@@ -464,7 +463,6 @@ func (builder *Builder) ExecCommand(command []string, containerName ...string) (
 	}
 
 	err = exec.StreamWithContext(context.TODO(), remotecommand.StreamOptions{
-		Stdin:  os.Stdin,
 		Stdout: &buffer,
 		Stderr: os.Stderr,
 		Tty:    true,


### PR DESCRIPTION
This PR attempts to address the cause behind the integration test flakiness by not redirecting stdin in ExecCommand.

Assisted-by: Cursor