### PR TITLE
global: update to Go 1.25.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/rh-ecosystem-edge/eco-goinfra
 
-go 1.24.5
+go 1.25
+
+toolchain go1.25.0
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0

--- a/scripts/golangci-lint.sh
+++ b/scripts/golangci-lint.sh
@@ -4,7 +4,7 @@ set -e
 
 . "$(dirname "$0")"/common.sh
 
-GOLANGCI_LINT_VERSION="2.2.2"
+GOLANGCI_LINT_VERSION="2.4.0"
 
 # IsGoLangCiLintInstalled is used to check whether golangci-lint executable is on the $PATH.
 function IsGolangCiLintInstalled() {


### PR DESCRIPTION
Related-to: openshift-kni/eco-gotests#746

This PR updates Go to 1.25.0 and takes a new approach of separating the go and toolchain directives. This allows us to express compatibility with all go1.25 versions while specifying a more exact one to build with.

Similarly, golangci-lint has been updated to 2.4.0 for Go 1.25 support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain to version 1.25, aligning the project with the latest stable Go release. This may require builders to use Go 1.25+.
  * Upgraded the linting tool to version 2.4.0 to improve code quality checks during development.

No functional changes to the application behavior or dependencies; end-user functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->