### PR TITLE
common: add mixin system and core methods 

### DIFF
--- a/pkg/clients/clients.go
+++ b/pkg/clients/clients.go
@@ -38,6 +38,7 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	k8sFakeClient "k8s.io/client-go/kubernetes/fake"
 	fakeRuntimeClient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	machinev1beta1client "github.com/openshift/client-go/machine/clientset/versioned/typed/machine/v1beta1"
@@ -200,11 +201,10 @@ func (settings *Settings) AttachScheme(attacher SchemeAttacher) error {
 
 // TestClientParams provides the struct to store the parameters for the test client.
 type TestClientParams struct {
-	K8sMockObjects  []runtime.Object
-	GVK             []schema.GroupVersionKind
-	SchemeAttachers []SchemeAttacher
-
-	// Note: Add more fields below if/when needed.
+	K8sMockObjects   []runtime.Object
+	GVK              []schema.GroupVersionKind
+	SchemeAttachers  []SchemeAttacher
+	InterceptorFuncs interceptor.Funcs
 }
 
 // GetTestClients returns a fake clientset for testing.
@@ -333,7 +333,7 @@ func GetModifiableTestClients(tcp TestClientParams) (*Settings, *fakeRuntimeClie
 	}
 	// Add fake runtime client to clientSet runtime client
 	clientBuilder := fakeRuntimeClient.NewClientBuilder().WithScheme(clientSet.scheme).
-		WithRuntimeObjects(genericClientObjects...)
+		WithRuntimeObjects(genericClientObjects...).WithInterceptorFuncs(tcp.InterceptorFuncs)
 
 	return clientSet, clientBuilder
 }

--- a/pkg/internal/common/embeddable_creator.go
+++ b/pkg/internal/common/embeddable_creator.go
@@ -1,0 +1,21 @@
+package common
+
+import "context"
+
+// EmbeddableCreator is a mixin which provides the Create method to the embedding builder. The Create method immediately
+// creates the resource in the cluster and returns the builder and the error from the Create method.
+type EmbeddableCreator[O any, B any, SO objectPointer[O], SB builderPointer[B, O, SO]] struct {
+	base SB
+}
+
+// SetBase sets the base builder for the mixin. When the Create method is called, the common Create method will be
+// called on the base builder. This base is also what gets returned by the Create method.
+func (creator *EmbeddableCreator[O, B, SO, SB]) SetBase(base SB) {
+	creator.base = base
+}
+
+// Create creates the resource in the cluster. It first checks if the resource already exists and if so, does nothing.
+// Otherwise, it tries to create the resource and returns the builder and the error from the Create method.
+func (creator *EmbeddableCreator[O, B, SO, SB]) Create() (SB, error) {
+	return creator.base, Create(context.TODO(), creator.base)
+}

--- a/pkg/internal/common/embeddable_deleter.go
+++ b/pkg/internal/common/embeddable_deleter.go
@@ -1,0 +1,45 @@
+package common
+
+import "context"
+
+// EmbeddableDeleter is a mixin which provides the Delete method to the embedding builder.
+type EmbeddableDeleter[O any, SO objectPointer[O]] struct {
+	base Builder[O, SO]
+}
+
+// SetBase sets the base builder for the mixin. When the Delete method is called, the common Delete method will be
+// called on the base builder. In practice, this can be either the EmbeddableBuilder or the resource-specific builder.
+func (deleter *EmbeddableDeleter[O, SO]) SetBase(base Builder[O, SO]) {
+	deleter.base = base
+}
+
+// Delete deletes the resource from the cluster. It immediately tries to delete the resource and if successful, or the
+// resource did not exist, the builder's object is set to nil. Otherwise, the error is wrapped and returned without
+// modifying the builder.
+func (deleter *EmbeddableDeleter[O, SO]) Delete() error {
+	return Delete(context.TODO(), deleter.base)
+}
+
+// EmbeddableDeleteReturner is a mixin which provides the Delete method to the embedding builder. The Delete method
+// returns the builder and the error from the Delete method. To maintain compatibility with existing Delete methods
+// which return the builder, this struct has more complicated type parameters than the EmbeddableDeleter.
+//
+// Consumers of this mixin should set the base to the embedding builder rather than the EmbeddableBuilder so that Delete
+// returns the correct type.
+type EmbeddableDeleteReturner[O any, B any, SO objectPointer[O], SB builderPointer[B, O, SO]] struct {
+	base SB
+}
+
+// SetBase sets the base builder for the mixin. When the Delete method is called, the common Delete method will be
+// called on the base builder. For EmbeddableDeleteReturner, the base should be the resource-specific builder rather
+// than EmbeddableBuilder.
+func (deleter *EmbeddableDeleteReturner[O, B, SO, SB]) SetBase(base SB) {
+	deleter.base = base
+}
+
+// Delete deletes the resource from the cluster. It immediately tries to delete the resource and if successful, or the
+// resource did not exist, the builder's object is set to nil. Otherwise, the error is wrapped and returned without
+// modifying the builder. Regardless of the error, the builder is returned.
+func (deleter *EmbeddableDeleteReturner[O, B, SO, SB]) Delete() (SB, error) {
+	return deleter.base, Delete(context.TODO(), deleter.base)
+}

--- a/pkg/internal/common/embeddable_updater.go
+++ b/pkg/internal/common/embeddable_updater.go
@@ -1,0 +1,42 @@
+package common
+
+import "context"
+
+// EmbeddableUpdater is a mixin which provides the Update method to the embedding builder. The Update method does not
+// force the update and will return an error if the resource could not be updated.
+type EmbeddableUpdater[O any, B any, SO objectPointer[O], SB builderPointer[B, O, SO]] struct {
+	base SB
+}
+
+// SetBase sets the base builder for the mixin. When the Update method is called, the common Update method will be
+// called on the base builder. This base is also what gets returned by the Update method.
+func (updater *EmbeddableUpdater[O, B, SO, SB]) SetBase(base SB) {
+	updater.base = base
+}
+
+// Update updates the resource in the cluster. It does not force the update and will return an error if the resource
+// could not be updated. It checks for the resource's existence and attempts to align resource versions to avoid
+// conflict.
+func (updater *EmbeddableUpdater[O, B, SO, SB]) Update() (SB, error) {
+	return updater.base, Update(context.TODO(), updater.base, false)
+}
+
+// EmbeddableForceUpdater is a mixin which provides the Update method to the embedding builder. The Update method
+// provides the option to force an update by deleting and recreating the resource.
+type EmbeddableForceUpdater[O any, B any, SO objectPointer[O], SB builderPointer[B, O, SO]] struct {
+	base SB
+}
+
+// SetBase sets the base builder for the mixin. When the Update method is called, the common Update method will be
+// called on the base builder. This base is also what gets returned by the Update method.
+func (updater *EmbeddableForceUpdater[O, B, SO, SB]) SetBase(base SB) {
+	updater.base = base
+}
+
+// Update updates the resource in the cluster. It provides the option to force an update by deleting and recreating the
+// resource. It checks for the resource's existence and attempts to align resource versions to avoid conflict.
+// Regardless of the force flag, this function returns an error if the resource does not exist. When it exists, the
+// resource version just pulled from the cluster is used to avoid conflicts.
+func (updater *EmbeddableForceUpdater[O, B, SO, SB]) Update(force bool) (SB, error) {
+	return updater.base, Update(context.TODO(), updater.base, force)
+}

--- a/pkg/internal/common/errors/errors.go
+++ b/pkg/internal/common/errors/errors.go
@@ -133,6 +133,14 @@ func IsAPICallFailed(err error) bool {
 	return errors.As(err, &apiCallFailed)
 }
 
+// IsAPICallFailedWithVerb returns true if an error, or any error in the error's tree, is due to an API call failing
+// with the given verb.
+func IsAPICallFailedWithVerb(err error, verb string) bool {
+	var apiCallFailed *apiCallFailedError
+
+	return errors.As(err, &apiCallFailed) && apiCallFailed.verb == verb
+}
+
 type builderNilError struct{}
 
 var _ error = (*builderNilError)(nil)

--- a/pkg/oran/api/provisioning.go
+++ b/pkg/oran/api/provisioning.go
@@ -236,7 +236,7 @@ func (client *ProvisioningClient) DeleteAllOf(
 
 // Status always returns nil since the ProvisioningRequest cannot have its status updated via the O2IMS API.
 //
-//nolint:ireturn // forced to return interface to satisfy runtimeclient.Client interface
+//nolint:ireturn,nolintlint // forced to return interface to satisfy runtimeclient.Client interface
 func (client *ProvisioningClient) Status() runtimeclient.SubResourceWriter {
 	return nil
 }
@@ -244,7 +244,7 @@ func (client *ProvisioningClient) Status() runtimeclient.SubResourceWriter {
 // SubResource always returns nil since the ProvisioningRequest has no subresources that can be updated via the O2IMS
 // API.
 //
-//nolint:ireturn // forced to return interface to satisfy runtimeclient.Client interface
+//nolint:ireturn,nolintlint // forced to return interface to satisfy runtimeclient.Client interface
 func (client *ProvisioningClient) SubResource(_ string) runtimeclient.SubResourceClient {
 	return nil
 }
@@ -256,7 +256,7 @@ func (client *ProvisioningClient) Scheme() *runtime.Scheme {
 
 // RESTMapper always returns nil since the ProvisioningClient does not use a REST mapper.
 //
-//nolint:ireturn // forced to return interface to satisfy runtimeclient.Client interface
+//nolint:ireturn,nolintlint // forced to return interface to satisfy runtimeclient.Client interface
 func (client *ProvisioningClient) RESTMapper() meta.RESTMapper {
 	return nil
 }


### PR DESCRIPTION
Depends-on: #1095
Closes #1100 

This PR addresses the lack of common functions for the remaining CRUD methods by creating the mixin system. This allows the resource-specific builders to provide an AttachMixins function which handles the initialization of these mixins, which get embedded as siblings of EmbeddableBuilder.

Assisted-by: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Expanded test coverage for resource lifecycle operations with interceptor function support, enabling more comprehensive validation scenarios.

* **Chores**
  * Enhanced internal testing infrastructure to better simulate API failures and improve error diagnostics.
  * Improved linting configuration for code quality standards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->