### PR TITLE
Fix nil-guard and VLAN validation in NAD master plugins

### DIFF
--- a/pkg/nad/masterplugin.go
+++ b/pkg/nad/masterplugin.go
@@ -117,6 +117,8 @@ func (plugin *MasterMacVlanPlugin) WithLinkInContainer() *MasterMacVlanPlugin {
 	if plugin.masterPlugin == nil {
 		glog.V(100).Infof(msg.UndefinedCrdObjectErrString("MasterMacVlanPlugin"))
 		plugin.errorMsg = msg.UndefinedCrdObjectErrString("MasterMacVlanPlugin")
+
+		return plugin
 	}
 
 	plugin.masterPlugin.LinkInContainer = true
@@ -552,7 +554,7 @@ func (plugin *MasterBondPlugin) WithIPAM(ipam *IPAM) *MasterBondPlugin {
 func (plugin *MasterBondPlugin) WithVLANInContainer(vlan uint16) *MasterBondPlugin {
 	glog.V(100).Infof("Adding vlan %d to MasterBoundPlugin", vlan)
 
-	if vlan > 4095 {
+	if vlan > 4094 {
 		glog.V(100).Infof("error adding incorrect vlan id %d to MasterBondPlugin", vlan)
 
 		plugin.errorMsg = "error adding incorrect vlan to MasterBondPlugin"


### PR DESCRIPTION
Changes:
- Add early return in MasterMacVlanPlugin.WithLinkInContainer when masterPlugin is nil to avoid potential panic.
- Reject reserved VLAN ID 4095 by validating vlan > 4094 in MasterBondPlugin.WithVLANInContainer.
- Follows up on review notes from the klog migration PR #1145.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Prevented a potential crash when running network plugins without a configured master plugin by stopping earlier and returning a clear error, improving stability.
  - Corrected VLAN ID validation to allow only IDs up to 4094; attempts to use 4095 now return a validation error for standards compliance and clearer feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->