### PR TITLE
sriov: make SriovNetwork targetNs optional

### DIFF
--- a/pkg/sriov/network.go
+++ b/pkg/sriov/network.go
@@ -78,17 +78,33 @@ func NewNetworkBuilder(
 		return builder
 	}
 
-	if targetNsname == "" {
-		builder.errorMsg = "SrIovNetwork 'targetNsname' cannot be empty"
-
-		return builder
-	}
-
 	if resName == "" {
 		builder.errorMsg = "SrIovNetwork 'resName' cannot be empty"
 
 		return builder
 	}
+
+	return builder
+}
+
+// WithTargetNamespace sets the target namespace for the SriovNetwork.
+func (builder *NetworkBuilder) WithTargetNamespace(targetNsname string) *NetworkBuilder {
+	if valid, _ := builder.validate(); !valid {
+		return builder
+	}
+
+	glog.V(100).Infof("Adding targetNsname %s to SriovNetwork %s in namespace %s",
+		targetNsname, builder.Definition.Name, builder.Definition.Namespace)
+
+	if targetNsname == "" {
+		glog.V(100).Infof("SrIovNetwork 'targetNsname' cannot be empty")
+
+		builder.errorMsg = "SrIovNetwork 'targetNsname' cannot be empty"
+
+		return builder
+	}
+
+	builder.Definition.Spec.NetworkNamespace = targetNsname
 
 	return builder
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * You can now set the target namespace for SR-IOV networks after initialization via a new setter; the namespace is validated when set, and the constructor no longer enforces a non-empty namespace at creation time.
* **Tests**
  * Tests updated to remove the constructor-based namespace validation check and to cover the new post-initialization namespace setter, including valid and empty-namespace behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->