### PR TITLE
global: add coderabbit config file

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,184 @@
+language: en-US
+tone_instructions: ''
+early_access: false
+enable_free_tier: false
+reviews:
+  profile: chill
+  request_changes_workflow: false
+  high_level_summary: true
+  high_level_summary_placeholder: '@coderabbitai summary'
+  high_level_summary_in_walkthrough: false
+  auto_title_placeholder: '@coderabbitai'
+  auto_title_instructions: ''
+  review_status: true
+  commit_status: true
+  fail_commit_status: false
+  collapse_walkthrough: true
+  changed_files_summary: true
+  sequence_diagrams: false
+  estimate_code_review_effort: true
+  assess_linked_issues: true
+  related_issues: true
+  related_prs: true
+  suggested_labels: true
+  auto_apply_labels: false
+  suggested_reviewers: true
+  auto_assign_reviewers: false
+  in_progress_fortune: true
+  poem: false
+  labeling_instructions: []
+  path_filters: ['!vendor/', '!pkg/schemes/']
+  path_instructions: []
+  abort_on_close: true
+  disable_cache: false
+  auto_review:
+    enabled: true
+    auto_incremental_review: true
+    ignore_title_keywords: []
+    labels: []
+    drafts: false
+    base_branches: []
+    ignore_usernames: []
+  finishing_touches:
+    docstrings:
+      enabled: true
+    unit_tests:
+      enabled: true
+  pre_merge_checks:
+    docstrings:
+      mode: warning
+      threshold: 80
+    title:
+      mode: warning
+      requirements: ''
+    description:
+      mode: warning
+    issue_assessment:
+      mode: warning
+    custom_checks: []
+  tools:
+    ast-grep:
+      rule_dirs: []
+      util_dirs: []
+      essential_rules: true
+      packages: []
+    shellcheck:
+      enabled: true
+    ruff:
+      enabled: true
+    markdownlint:
+      enabled: true
+    github-checks:
+      enabled: true
+      timeout_ms: 900000
+    languagetool:
+      enabled: true
+      enabled_rules: []
+      disabled_rules: []
+      enabled_categories: []
+      disabled_categories: []
+      enabled_only: false
+      level: default
+    biome:
+      enabled: true
+    hadolint:
+      enabled: true
+    swiftlint:
+      enabled: true
+    phpstan:
+      enabled: true
+      level: default
+    phpmd:
+      enabled: true
+    phpcs:
+      enabled: true
+    golangci-lint:
+      enabled: true
+    yamllint:
+      enabled: true
+    gitleaks:
+      enabled: true
+    checkov:
+      enabled: true
+    detekt:
+      enabled: true
+    eslint:
+      enabled: true
+    flake8:
+      enabled: true
+    rubocop:
+      enabled: true
+    buf:
+      enabled: true
+    regal:
+      enabled: true
+    actionlint:
+      enabled: true
+    pmd:
+      enabled: true
+    cppcheck:
+      enabled: true
+    semgrep:
+      enabled: true
+    circleci:
+      enabled: true
+    clippy:
+      enabled: true
+    sqlfluff:
+      enabled: true
+    prismaLint:
+      enabled: true
+    pylint:
+      enabled: true
+    oxc:
+      enabled: true
+    shopifyThemeCheck:
+      enabled: true
+    luacheck:
+      enabled: true
+    brakeman:
+      enabled: true
+    dotenvLint:
+      enabled: true
+    htmlhint:
+      enabled: true
+    checkmake:
+      enabled: true
+    osvScanner:
+      enabled: true
+chat:
+  art: true
+  auto_reply: false
+  integrations:
+    jira:
+      usage: auto
+    linear:
+      usage: auto
+knowledge_base:
+  opt_out: false
+  web_search:
+    enabled: true
+  code_guidelines:
+    enabled: true
+    filePatterns: []
+  learnings:
+    scope: auto
+  issues:
+    scope: auto
+  jira:
+    usage: auto
+    project_keys: []
+  linear:
+    usage: auto
+    team_keys: []
+  pull_requests:
+    scope: auto
+  mcp:
+    usage: auto
+    disabled_servers: []
+code_generation:
+  docstrings:
+    language: en-US
+    path_instructions: []
+  unit_tests:
+    path_instructions: []


### PR DESCRIPTION
This PR adds a config file for coderabbit, copied from the eco-gotests one. Changes from the default config:

- `collapse_walkthrough: true` (previously `false`) [docs](https://docs.coderabbit.ai/reference/configuration#param-collapse-walkthrough)
- `sequence_diagrams: false` (previously `true`) [docs](https://docs.coderabbit.ai/reference/configuration#param-sequence-diagrams)
- `path_filters: ['!vendor/', '!pkg/schemes/']` (previously `[]`) [docs](https://docs.coderabbit.ai/reference/configuration#param-path-filters)
- `github-checks.timeout_ms: 900000` (previously `90000`) [docs](https://docs.coderabbit.ai/reference/configuration#param-timeout-ms)

The first two are to reduce the noise from the coderabbit comment with the walkthrough and diagrams. The diagrams especially do not seem very useful and take up a lot of space.

The third option is to exclude the vendor directory; we cannot change it so there is no reason to review it. **Different from eco-gotests**: also includes pkg/schemes since it's a similar situation.

The fourth option bumps the timeout on github checks to 15 minutes from 90 seconds. Since the linter workflow takes 6-7 minutes to complete, coderabbit would previously not have access to these checks.

Related-to: https://github.com/rh-ecosystem-edge/eco-gotests/pull/838

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Set up comprehensive automated code review and CI checks, including pre-merge validation for docstrings and unit tests.
  * Enabled a broad suite of linters and security/static analysis tools to improve code quality across multiple languages.
  * Configured integrations with project management and knowledge sources to streamline PR reviews and labeling.
  * Operational improvements only; no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->