### PR TITLE
nad add bond mode alb and tlb

### DIFF
--- a/pkg/nad/masterplugin.go
+++ b/pkg/nad/masterplugin.go
@@ -426,6 +426,8 @@ func NewMasterBondPlugin(name, mode string) *MasterBondPlugin {
 		"balance-rr":    true,
 		"active-backup": true,
 		"balance-xor":   true,
+		"balance-tlb":   true,
+		"balance-alb":   true,
 	}
 
 	builder := &MasterBondPlugin{


### PR DESCRIPTION
add to valiad bond modes balance-alb and balance=tlb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for two additional network bond modes: balance-tlb and balance-alb. Users can now configure these modes without validation errors.

* **Bug Fixes**
  * None.

* **Other Notes**
  * No changes to existing behavior or workflows. Backward compatible; unsupported modes still produce the same error as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->