### PR TITLE
Remove redundant nil-slice checks before append

### DIFF
--- a/pkg/clusterlogging/clusterlogforwarder.go
+++ b/pkg/clusterlogging/clusterlogforwarder.go
@@ -144,11 +144,7 @@ func (builder *ClusterLogForwarderBuilder) WithOutput(
 		return builder
 	}
 
-	if builder.Definition.Spec.Outputs == nil {
-		builder.Definition.Spec.Outputs = []observabilityv1.OutputSpec{*outputSpec}
-	} else {
-		builder.Definition.Spec.Outputs = append(builder.Definition.Spec.Outputs, *outputSpec)
-	}
+	builder.Definition.Spec.Outputs = append(builder.Definition.Spec.Outputs, *outputSpec)
 
 	return builder
 }
@@ -171,11 +167,7 @@ func (builder *ClusterLogForwarderBuilder) WithPipeline(
 		return builder
 	}
 
-	if builder.Definition.Spec.Pipelines == nil {
-		builder.Definition.Spec.Pipelines = []observabilityv1.PipelineSpec{*pipelineSpec}
-	} else {
-		builder.Definition.Spec.Pipelines = append(builder.Definition.Spec.Pipelines, *pipelineSpec)
-	}
+	builder.Definition.Spec.Pipelines = append(builder.Definition.Spec.Pipelines, *pipelineSpec)
 
 	return builder
 }

--- a/pkg/console/consoleoperator.go
+++ b/pkg/console/consoleoperator.go
@@ -149,12 +149,6 @@ func (builder *ConsoleOperatorBuilder) WithPlugins(newPluginsList []string, rede
 		return builder
 	}
 
-	if builder.Definition.Spec.Plugins == nil {
-		klog.V(100).Info("Plugins are nil. Initializing one")
-
-		builder.Definition.Spec.Plugins = []string{}
-	}
-
 	if redefine {
 		klog.V(100).Infof("Redefining existing plugins list with %v", newPluginsList)
 

--- a/pkg/daemonset/daemonset.go
+++ b/pkg/daemonset/daemonset.go
@@ -238,11 +238,7 @@ func (builder *Builder) WithAdditionalContainerSpecs(specs []corev1.Container) *
 		return builder
 	}
 
-	if builder.Definition.Spec.Template.Spec.Containers == nil {
-		builder.Definition.Spec.Template.Spec.Containers = specs
-	} else {
-		builder.Definition.Spec.Template.Spec.Containers = append(builder.Definition.Spec.Template.Spec.Containers, specs...)
-	}
+	builder.Definition.Spec.Template.Spec.Containers = append(builder.Definition.Spec.Template.Spec.Containers, specs...)
 
 	return builder
 }

--- a/pkg/deployment/deployment.go
+++ b/pkg/deployment/deployment.go
@@ -221,22 +221,12 @@ func (builder *Builder) WithHugePages() *Builder {
 	klog.V(100).Infof("Applying hugePages configuration to all containers in deployment: %s",
 		builder.Definition.Name)
 
-	// If volumes are not defined, create an empty list of volumes.
-	if builder.Definition.Spec.Template.Spec.Volumes == nil {
-		builder.Definition.Spec.Template.Spec.Volumes = []corev1.Volume{}
-	}
-
 	// Append hugepages volume to the deployment.
 	builder.Definition.Spec.Template.Spec.Volumes = append(builder.Definition.Spec.Template.Spec.Volumes, corev1.Volume{
 		Name: "hugepages", VolumeSource: corev1.VolumeSource{
 			EmptyDir: &corev1.EmptyDirVolumeSource{Medium: "HugePages"}}})
 
 	for idx := range builder.Definition.Spec.Template.Spec.Containers {
-		// If volumeMounts are not defined, create an empty list of volumeMounts.
-		if builder.Definition.Spec.Template.Spec.Containers[idx].VolumeMounts == nil {
-			builder.Definition.Spec.Template.Spec.Containers[idx].VolumeMounts = []corev1.VolumeMount{}
-		}
-
 		// Append hugepages volume mount to the deployment.
 		builder.Definition.Spec.Template.Spec.Containers[idx].VolumeMounts = append(
 			builder.Definition.Spec.Template.Spec.Containers[idx].VolumeMounts,

--- a/pkg/networkpolicy/networkpolicy.go
+++ b/pkg/networkpolicy/networkpolicy.go
@@ -116,10 +116,6 @@ func (builder *NetworkPolicyBuilder) WithNamespaceIngressRule(
 		}
 	}
 
-	if builder.Definition.Spec.Ingress == nil {
-		builder.Definition.Spec.Ingress = []netv1.NetworkPolicyIngressRule{}
-	}
-
 	builder.Definition.Spec.Ingress = append(builder.Definition.Spec.Ingress, netv1.NetworkPolicyIngressRule{
 		From: []netv1.NetworkPolicyPeer{peerRule},
 	})
@@ -143,10 +139,6 @@ func (builder *NetworkPolicyBuilder) WithPolicyType(policyType netv1.PolicyType)
 		builder.errorMsg = "The policyType is an empty string"
 
 		return builder
-	}
-
-	if builder.Definition.Spec.PolicyTypes == nil {
-		builder.Definition.Spec.PolicyTypes = []netv1.PolicyType{}
 	}
 
 	builder.Definition.Spec.PolicyTypes = append(builder.Definition.Spec.PolicyTypes, policyType)

--- a/pkg/nto/tuned.go
+++ b/pkg/nto/tuned.go
@@ -256,10 +256,6 @@ func (builder *TunedBuilder) WithRecommend(
 		"Setting tuned %s in namespace %s with the Recommend: %v",
 		builder.Definition.Name, builder.Definition.Namespace, recommend)
 
-	if builder.Definition.Spec.Recommend == nil {
-		builder.Definition.Spec.Recommend = []tunedv1.TunedRecommend{}
-	}
-
 	builder.Definition.Spec.Recommend = append(builder.Definition.Spec.Recommend, recommend)
 
 	return builder

--- a/pkg/rbac/clusterrole.go
+++ b/pkg/rbac/clusterrole.go
@@ -93,12 +93,6 @@ func (builder *ClusterRoleBuilder) WithRules(rules []rbacv1.PolicyRule) *Cluster
 		}
 	}
 
-	if builder.Definition.Rules == nil {
-		builder.Definition.Rules = rules
-
-		return builder
-	}
-
 	builder.Definition.Rules = append(builder.Definition.Rules, rules...)
 
 	return builder

--- a/pkg/rbac/role.go
+++ b/pkg/rbac/role.go
@@ -114,11 +114,7 @@ func (builder *RoleBuilder) WithRules(rules []rbacv1.PolicyRule) *RoleBuilder {
 		}
 	}
 
-	if builder.Definition.Rules == nil {
-		builder.Definition.Rules = rules
-	} else {
-		builder.Definition.Rules = append(builder.Definition.Rules, rules...)
-	}
+	builder.Definition.Rules = append(builder.Definition.Rules, rules...)
 
 	return builder
 }

--- a/pkg/scc/scc.go
+++ b/pkg/scc/scc.go
@@ -262,12 +262,6 @@ func (builder *Builder) WithDropCapabilities(requiredDropCapabilities []corev1.C
 		return builder
 	}
 
-	if builder.Definition.RequiredDropCapabilities == nil {
-		builder.Definition.RequiredDropCapabilities = requiredDropCapabilities
-
-		return builder
-	}
-
 	builder.Definition.RequiredDropCapabilities = append(
 		builder.Definition.RequiredDropCapabilities, requiredDropCapabilities...)
 
@@ -291,12 +285,6 @@ func (builder *Builder) WithAllowCapabilities(allowCapabilities []corev1.Capabil
 		return builder
 	}
 
-	if builder.Definition.AllowedCapabilities == nil {
-		builder.Definition.AllowedCapabilities = allowCapabilities
-
-		return builder
-	}
-
 	builder.Definition.AllowedCapabilities = append(builder.Definition.AllowedCapabilities, allowCapabilities...)
 
 	return builder
@@ -315,12 +303,6 @@ func (builder *Builder) WithDefaultAddCapabilities(defaultAddCapabilities []core
 		klog.V(100).Info("SecurityContextConstraints 'defaultAddCapabilities' argument cannot be empty")
 
 		builder.errorMsg = "securityContextConstraints 'defaultAddCapabilities' cannot be empty list"
-
-		return builder
-	}
-
-	if builder.Definition.DefaultAddCapabilities == nil {
-		builder.Definition.DefaultAddCapabilities = defaultAddCapabilities
 
 		return builder
 	}
@@ -382,14 +364,8 @@ func (builder *Builder) WithFSGroupRange(fsGroupMin, fsGroupMax int64) *Builder 
 		return builder
 	}
 
-	if builder.Definition.FSGroup.Ranges == nil {
-		builder.Definition.FSGroup.Ranges = []securityV1.IDRange{{Min: fsGroupMin, Max: fsGroupMax}}
-
-		return builder
-	}
-
 	builder.Definition.FSGroup.Ranges = append(
-		builder.Definition.FSGroup.Ranges, securityV1.IDRange{Max: fsGroupMax, Min: fsGroupMin})
+		builder.Definition.FSGroup.Ranges, securityV1.IDRange{Min: fsGroupMin, Max: fsGroupMax})
 
 	return builder
 }
@@ -406,12 +382,6 @@ func (builder *Builder) WithGroups(groups []string) *Builder {
 		klog.V(100).Info("SecurityContextConstraints 'groups' argument cannot be empty")
 
 		builder.errorMsg = "securityContextConstraints 'fsGroupType' cannot be empty string"
-
-		return builder
-	}
-
-	if builder.Definition.Groups == nil {
-		builder.Definition.Groups = groups
 
 		return builder
 	}
@@ -434,12 +404,6 @@ func (builder *Builder) WithSeccompProfiles(seccompProfiles []string) *Builder {
 		klog.V(100).Info("SecurityContextConstraints 'seccompProfiles' argument cannot be empty")
 
 		builder.errorMsg = "securityContextConstraints 'seccompProfiles' cannot be empty list"
-
-		return builder
-	}
-
-	if builder.Definition.SeccompProfiles == nil {
-		builder.Definition.SeccompProfiles = seccompProfiles
 
 		return builder
 	}
@@ -487,12 +451,6 @@ func (builder *Builder) WithUsers(users []string) *Builder {
 		return builder
 	}
 
-	if builder.Definition.Users == nil {
-		builder.Definition.Users = users
-
-		return builder
-	}
-
 	builder.Definition.Users = append(builder.Definition.Users, users...)
 
 	return builder
@@ -510,12 +468,6 @@ func (builder *Builder) WithVolumes(volumes []securityV1.FSType) *Builder {
 		klog.V(100).Info("SecurityContextConstraints 'volumes' argument cannot be empty")
 
 		builder.errorMsg = "securityContextConstraints 'volumes' cannot be empty list"
-
-		return builder
-	}
-
-	if builder.Definition.Volumes == nil {
-		builder.Definition.Volumes = volumes
 
 		return builder
 	}

--- a/pkg/servicemesh/memberroll.go
+++ b/pkg/servicemesh/memberroll.go
@@ -259,11 +259,7 @@ func (builder *MemberRollBuilder) WithMembersList(membersList []string) *MemberR
 		return builder
 	}
 
-	if builder.Definition.Spec.Members == nil {
-		builder.Definition.Spec.Members = membersList
-	} else {
-		builder.Definition.Spec.Members = append(builder.Definition.Spec.Members, membersList...)
-	}
+	builder.Definition.Spec.Members = append(builder.Definition.Spec.Members, membersList...)
 
 	return builder
 }

--- a/pkg/statefulset/statefulset.go
+++ b/pkg/statefulset/statefulset.go
@@ -110,12 +110,6 @@ func (builder *Builder) WithAdditionalContainerSpecs(specs []corev1.Container) *
 		return builder
 	}
 
-	if builder.Definition.Spec.Template.Spec.Containers == nil {
-		builder.Definition.Spec.Template.Spec.Containers = specs
-
-		return builder
-	}
-
 	builder.Definition.Spec.Template.Spec.Containers = append(builder.Definition.Spec.Template.Spec.Containers, specs...)
 
 	return builder


### PR DESCRIPTION
## Summary

Go's built-in `append()` handles nil slices correctly by allocating a new underlying array, so pre-initializing a slice to `[]T{}` or branching between direct assignment and append based on nil is unnecessary.

This removes 21 such checks across 11 files:

| Package | File | Instances |
|---------|------|-----------|
| scc | scc.go | 8 |
| networkpolicy | networkpolicy.go | 2 |
| deployment | deployment.go | 2 |
| clusterlogging | clusterlogforwarder.go | 2 |
| console | consoleoperator.go | 1 |
| daemonset | daemonset.go | 1 |
| statefulset | statefulset.go | 1 |
| servicemesh | memberroll.go | 1 |
| nto | tuned.go | 1 |
| rbac | clusterrole.go | 1 |
| rbac | role.go | 1 |

Two patterns were cleaned up:

**Pattern A** — empty init before append (no-op):
```go
// before
if slice == nil {
    slice = []T{}
}
slice = append(slice, item)

// after
slice = append(slice, item)
```

**Pattern B** — if/else choosing assign vs append:
```go
// before
if slice == nil {
    slice = items
} else {
    slice = append(slice, items...)
}

// after
slice = append(slice, items...)
```

No functional change. All existing tests pass. Linter clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal code across multiple modules and components by removing redundant nil-check initialization guards that preceded slice append operations. Updated functions now rely on Go's native nil-slice handling behavior, eliminating unnecessary conditional initialization branches. These improvements enhance overall code consistency, readability, and maintainability while preserving all existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->