### PR TITLE
nmstate&network: Add static route support, IP forwarding structs, and SetIPForwarding method

### DIFF
--- a/pkg/network/operator.go
+++ b/pkg/network/operator.go
@@ -156,6 +156,53 @@ func (builder *OperatorBuilder) SetLocalGWMode(state bool, timeout time.Duration
 	return builder, err
 }
 
+// SetIPForwarding sets the IPForwarding mode on the OVN-Kubernetes gateway configuration
+// and waits for the network operator to stabilize.
+func (builder *OperatorBuilder) SetIPForwarding(
+	mode operatorv1.IPForwardingMode, timeout time.Duration) (*OperatorBuilder, error) {
+	if valid, err := builder.validate(); !valid {
+		return builder, err
+	}
+
+	klog.V(100).Infof("Setting IPForwarding mode %q on network.operator %s", mode, builder.Definition.Name)
+
+	if builder.Definition.Spec.DefaultNetwork.OVNKubernetesConfig == nil {
+		builder.Definition.Spec.DefaultNetwork.OVNKubernetesConfig = &operatorv1.OVNKubernetesConfig{}
+	}
+
+	if builder.Definition.Spec.DefaultNetwork.OVNKubernetesConfig.GatewayConfig == nil {
+		builder.Definition.Spec.DefaultNetwork.OVNKubernetesConfig.GatewayConfig = &operatorv1.GatewayConfig{}
+	}
+
+	var err error
+
+	if builder.Definition.Spec.DefaultNetwork.OVNKubernetesConfig.GatewayConfig.IPForwarding != mode {
+		builder.Definition.Spec.DefaultNetwork.OVNKubernetesConfig.GatewayConfig.IPForwarding = mode
+
+		builder, err := builder.Update()
+		if err != nil {
+			return nil, err
+		}
+
+		err = builder.WaitUntilInCondition(
+			operatorv1.OperatorStatusTypeProgressing, 300*time.Second, operatorv1.ConditionTrue)
+		if err != nil {
+			return nil, err
+		}
+
+		err = builder.WaitUntilInCondition(
+			operatorv1.OperatorStatusTypeProgressing, timeout, operatorv1.ConditionFalse)
+		if err != nil {
+			return nil, err
+		}
+
+		return builder, builder.WaitUntilInCondition(
+			operatorv1.OperatorStatusTypeAvailable, 60*time.Second, operatorv1.ConditionTrue)
+	}
+
+	return builder, err
+}
+
 // SetMultiNetworkPolicy enables network.operator multinetworkpolicy feature.
 func (builder *OperatorBuilder) SetMultiNetworkPolicy(state bool, timeout time.Duration) (*OperatorBuilder, error) {
 	if valid, err := builder.validate(); !valid {

--- a/pkg/network/operator_test.go
+++ b/pkg/network/operator_test.go
@@ -340,6 +340,60 @@ func TestOperatorSetRouteAdvertisements(t *testing.T) {
 	}
 }
 
+func TestOperatorSetIPForwarding(t *testing.T) {
+	testCases := []struct {
+		testBuilder   *OperatorBuilder
+		mode          operatorv1.IPForwardingMode
+		alreadySet    bool
+		expectedError string
+	}{
+		{
+			testBuilder:   newOperatorBuilder(buildTestClientWithDummyNetworkOperator()),
+			mode:          operatorv1.IPForwardingRestricted,
+			alreadySet:    true,
+			expectedError: "",
+		},
+		{
+			testBuilder:   newOperatorBuilder(buildTestClientWithDummyNetworkOperator()),
+			mode:          operatorv1.IPForwardingGlobal,
+			alreadySet:    true,
+			expectedError: "",
+		},
+		{
+			testBuilder:   newOperatorBuilder(clients.GetTestClients(clients.TestClientParams{})),
+			mode:          operatorv1.IPForwardingRestricted,
+			alreadySet:    false,
+			expectedError: "network.operator object cluster does not exist",
+		},
+	}
+
+	for _, testCase := range testCases {
+		if testCase.alreadySet {
+			testCase.testBuilder.Definition.Spec.DefaultNetwork.OVNKubernetesConfig = &operatorv1.OVNKubernetesConfig{
+				GatewayConfig: &operatorv1.GatewayConfig{
+					IPForwarding: testCase.mode,
+				},
+			}
+		}
+
+		testCase.testBuilder.Definition.ResourceVersion = "999"
+
+		testBuilder, err := testCase.testBuilder.SetIPForwarding(testCase.mode, time.Second)
+
+		if testCase.expectedError == "" {
+			assert.Nil(t, err)
+			assert.NotNil(t, testBuilder)
+			assert.NotNil(t, testBuilder.Definition.Spec.DefaultNetwork.OVNKubernetesConfig)
+			assert.NotNil(t, testBuilder.Definition.Spec.DefaultNetwork.OVNKubernetesConfig.GatewayConfig)
+			assert.Equal(t, testCase.mode,
+				testBuilder.Definition.Spec.DefaultNetwork.OVNKubernetesConfig.GatewayConfig.IPForwarding)
+		} else {
+			assert.NotNil(t, err)
+			assert.Contains(t, err.Error(), testCase.expectedError)
+		}
+	}
+}
+
 // buildDummyNetworkOperator builds a dummy network.operator object. It uses the clusterNetworkName.
 func buildDummyNetworkOperator() *operatorv1.Network {
 	return &operatorv1.Network{

--- a/pkg/nmstate/policy.go
+++ b/pkg/nmstate/policy.go
@@ -524,6 +524,65 @@ func (builder *PolicyBuilder) WithAbsentInterface(interfaceName string) *PolicyB
 	return builder.withInterface(newInterface)
 }
 
+// WithStaticRoute adds a static route to the NodeNetworkConfigurationPolicy desired state.
+func (builder *PolicyBuilder) WithStaticRoute(
+	destination, nextHopAddress, nextHopInterface string, metric, tableID int) *PolicyBuilder {
+	if valid, _ := builder.validate(); !valid {
+		return builder
+	}
+
+	klog.V(100).Infof("Adding static route %s via %s dev %s to NodeNetworkConfigurationPolicy %s",
+		destination, nextHopAddress, nextHopInterface, builder.Definition.Name)
+
+	if destination == "" {
+		builder.errorMsg = "route 'destination' cannot be empty"
+
+		return builder
+	}
+
+	if nextHopAddress == "" && nextHopInterface == "" {
+		builder.errorMsg = "route must have either 'nextHopAddress' or 'nextHopInterface'"
+
+		return builder
+	}
+
+	var currentState DesiredState
+
+	err := yaml.Unmarshal(builder.Definition.Spec.DesiredState.Raw, &currentState)
+	if err != nil {
+		klog.V(100).Info("Failed Unmarshal DesiredState")
+
+		builder.errorMsg = "Failed Unmarshal DesiredState"
+
+		return builder
+	}
+
+	if currentState.Routes == nil {
+		currentState.Routes = &DesiredRoutes{}
+	}
+
+	currentState.Routes.Config = append(currentState.Routes.Config, RouteConfig{
+		Destination:      destination,
+		NextHopAddress:   nextHopAddress,
+		NextHopInterface: nextHopInterface,
+		Metric:           metric,
+		TableID:          tableID,
+	})
+
+	desiredStateYaml, err := yaml.Marshal(currentState)
+	if err != nil {
+		klog.V(100).Info("Failed Marshal DesiredState")
+
+		builder.errorMsg = "failed to Marshal a new Desired state"
+
+		return builder
+	}
+
+	builder.Definition.Spec.DesiredState = nmstateShared.NewState(string(desiredStateYaml))
+
+	return builder
+}
+
 // WithOptions creates pod with generic mutation options.
 func (builder *PolicyBuilder) WithOptions(options ...AdditionalOptions) *PolicyBuilder {
 	if valid, _ := builder.validate(); !valid {

--- a/pkg/nmstate/policy_test.go
+++ b/pkg/nmstate/policy_test.go
@@ -645,6 +645,84 @@ func TestPolicyWithAbsentInterface(t *testing.T) {
 	}
 }
 
+func TestPolicyWithStaticRoute(t *testing.T) {
+	testCases := []struct {
+		testNMStatePolicy *PolicyBuilder
+		expectedError     string
+		destination       string
+		nextHopAddress    string
+		nextHopInterface  string
+		metric            int
+		tableID           int
+	}{
+		{
+			testNMStatePolicy: buildValidPolicyTestBuilder(buildTestClientWithDummyPolicyObject()),
+			expectedError:     "",
+			destination:       "192.168.1.0/24",
+			nextHopAddress:    "10.10.10.1",
+			nextHopInterface:  "ens1",
+			metric:            100,
+			tableID:           254,
+		},
+		{
+			testNMStatePolicy: buildValidPolicyTestBuilder(buildTestClientWithDummyPolicyObject()),
+			expectedError:     "",
+			destination:       "192.168.2.0/24",
+			nextHopAddress:    "10.10.10.1",
+			nextHopInterface:  "",
+			metric:            0,
+			tableID:           0,
+		},
+		{
+			testNMStatePolicy: buildValidPolicyTestBuilder(buildTestClientWithDummyPolicyObject()),
+			expectedError:     "",
+			destination:       "192.168.3.0/24",
+			nextHopAddress:    "",
+			nextHopInterface:  "ens1",
+			metric:            50,
+			tableID:           0,
+		},
+		{
+			testNMStatePolicy: buildValidPolicyTestBuilder(buildTestClientWithDummyPolicyObject()),
+			expectedError:     "route 'destination' cannot be empty",
+			destination:       "",
+			nextHopAddress:    "10.10.10.1",
+			nextHopInterface:  "ens1",
+			metric:            100,
+			tableID:           254,
+		},
+		{
+			testNMStatePolicy: buildValidPolicyTestBuilder(buildTestClientWithDummyPolicyObject()),
+			expectedError:     "route must have either 'nextHopAddress' or 'nextHopInterface'",
+			destination:       "192.168.1.0/24",
+			nextHopAddress:    "",
+			nextHopInterface:  "",
+			metric:            100,
+			tableID:           254,
+		},
+	}
+	for _, testCase := range testCases {
+		testPolicy := testCase.testNMStatePolicy.WithStaticRoute(
+			testCase.destination, testCase.nextHopAddress, testCase.nextHopInterface,
+			testCase.metric, testCase.tableID)
+		assert.Equal(t, testCase.expectedError, testPolicy.errorMsg)
+
+		if testCase.expectedError == "" {
+			desireState := &DesiredState{}
+			_ = yaml.Unmarshal(testPolicy.Definition.Spec.DesiredState.Raw, desireState)
+			assert.NotNil(t, desireState.Routes)
+			assert.Len(t, desireState.Routes.Config, 1)
+			assert.Equal(t, RouteConfig{
+				Destination:      testCase.destination,
+				NextHopAddress:   testCase.nextHopAddress,
+				NextHopInterface: testCase.nextHopInterface,
+				Metric:           testCase.metric,
+				TableID:          testCase.tableID,
+			}, desireState.Routes.Config[0])
+		}
+	}
+}
+
 func TestPolicyWithWithOptions(t *testing.T) {
 	testSettings := buildTestClientWithDummyPolicyObject()
 	testBuilder := buildValidPolicyTestBuilder(testSettings).WithOptions(

--- a/pkg/nmstate/shared.go
+++ b/pkg/nmstate/shared.go
@@ -5,6 +5,7 @@ import "net"
 // DesiredState provides struct for the NMState desired state object containing all NMState configuration.
 type DesiredState struct {
 	Interfaces []NetworkInterface `yaml:"interfaces,omitempty"`
+	Routes     *DesiredRoutes     `yaml:"routes,omitempty"`
 }
 
 // NetworkInterface provides struct for the NMState interface state object containing interface information.
@@ -22,17 +23,19 @@ type NetworkInterface struct {
 
 // InterfaceIpv4 enables an IPv4 address on an interface.
 type InterfaceIpv4 struct {
-	Enabled bool                 `yaml:"enabled,omitempty"`
-	Dhcp    bool                 `yaml:"dhcp,omitempty"`
-	Address []InterfaceIPAddress `yaml:"address,omitempty"`
+	Enabled    bool                 `yaml:"enabled,omitempty"`
+	Dhcp       bool                 `yaml:"dhcp,omitempty"`
+	Forwarding *bool                `yaml:"forwarding,omitempty"`
+	Address    []InterfaceIPAddress `yaml:"address,omitempty"`
 }
 
 // InterfaceIpv6 enables an IPv6 address on an interface.
 type InterfaceIpv6 struct {
-	Enabled  bool                 `yaml:"enabled,omitempty"`
-	Dhcp     bool                 `json:"dhcp,omitempty"`
-	Autoconf bool                 `json:"autoconf,omitempty"`
-	Address  []InterfaceIPAddress `yaml:"address,omitempty"`
+	Enabled    bool                 `yaml:"enabled,omitempty"`
+	Dhcp       bool                 `yaml:"dhcp,omitempty"`
+	Autoconf   bool                 `yaml:"autoconf,omitempty"`
+	Forwarding *bool                `yaml:"forwarding,omitempty"`
+	Address    []InterfaceIPAddress `yaml:"address,omitempty"`
 }
 
 // InterfaceIPAddress is a struct for constructing an IP with prefix.
@@ -94,4 +97,18 @@ type OptionsLinkAggregation struct {
 type Vlan struct {
 	BaseIface string `yaml:"base-iface"`
 	ID        int    `yaml:"id"`
+}
+
+// DesiredRoutes provides struct for the NMState routes configuration.
+type DesiredRoutes struct {
+	Config []RouteConfig `yaml:"config,omitempty"`
+}
+
+// RouteConfig provides struct for a single NMState static route entry.
+type RouteConfig struct {
+	Destination      string `yaml:"destination"`
+	Metric           int    `yaml:"metric,omitempty"`
+	NextHopAddress   string `yaml:"next-hop-address,omitempty"`
+	NextHopInterface string `yaml:"next-hop-interface,omitempty"`
+	TableID          int    `yaml:"table-id,omitempty"`
 }


### PR DESCRIPTION
Add WithStaticRoute to PolicyBuilder for configuring NMState static routes, extend shared types with DesiredRoutes/RouteConfig structs and IP forwarding fields, and add SetIPForwarding to OperatorBuilder for OVN gateway config. Include unit tests for all new functionality.

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Network operator now supports IP forwarding mode configuration with status validation
  * Static route management added with destination, next-hop address, interface, metric, and table ID support
  * IPv4 and IPv6 interface configurations extended with forwarding toggle capability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->