### PR TITLE
nmstate: support interface alternative names in policy and NodeNetworkState

### DIFF
--- a/pkg/nmstate/nodenetworkstate.go
+++ b/pkg/nmstate/nodenetworkstate.go
@@ -106,6 +106,114 @@ func (builder *StateBuilder) GetTotalVFs(sriovInterfaceName string) (int, error)
 	return 0, fmt.Errorf("failed to find interface %s", sriovInterfaceName)
 }
 
+// GetInterfaceAltnames returns non-empty alternative interface names for the given interface from current state.
+func (builder *StateBuilder) GetInterfaceAltnames(interfaceName string) ([]string, error) {
+	if valid, err := builder.validate(); !valid {
+		return nil, err
+	}
+
+	klog.V(100).Infof("Getting interface altnames for interface %s from NodeNetworkState %s",
+		interfaceName, builder.Object.Name)
+
+	if interfaceName == "" {
+		klog.V(100).Info("The interfaceName can not be empty string")
+
+		return nil, fmt.Errorf("the interfaceName is empty sting")
+	}
+
+	var CurrentState DesiredState
+
+	err := yaml.Unmarshal(builder.Object.Status.CurrentState.Raw, &CurrentState)
+	if err != nil {
+		return nil, fmt.Errorf("failed to Unmarshal NMState state")
+	}
+
+	for _, interfaceFromCurrentState := range CurrentState.Interfaces {
+		if interfaceFromCurrentState.Name == interfaceName {
+			names := make([]string, 0, len(interfaceFromCurrentState.AltNames))
+			for _, alt := range interfaceFromCurrentState.AltNames {
+				if alt.Name != "" {
+					names = append(names, alt.Name)
+				}
+			}
+
+			return names, nil
+		}
+	}
+
+	return nil, fmt.Errorf("failed to find interface %s", interfaceName)
+}
+
+// GetInterfaceMACAddress returns the mac-address field for the interface from NodeNetworkState current state.
+func (builder *StateBuilder) GetInterfaceMACAddress(interfaceName string) (string, error) {
+	if valid, err := builder.validate(); !valid {
+		return "", err
+	}
+
+	klog.V(100).Infof("Getting interface MAC address for interface %s from NodeNetworkState %s",
+		interfaceName, builder.Object.Name)
+
+	if interfaceName == "" {
+		klog.V(100).Info("The interfaceName can not be empty string")
+
+		return "", fmt.Errorf("the interfaceName is empty sting")
+	}
+
+	var CurrentState DesiredState
+
+	err := yaml.Unmarshal(builder.Object.Status.CurrentState.Raw, &CurrentState)
+	if err != nil {
+		return "", fmt.Errorf("failed to Unmarshal NMState state")
+	}
+
+	for _, interfaceFromCurrentState := range CurrentState.Interfaces {
+		if interfaceFromCurrentState.Name == interfaceName {
+			if interfaceFromCurrentState.MacAddress == "" {
+				return "", fmt.Errorf("failed to find mac-address for interface %s", interfaceName)
+			}
+
+			return interfaceFromCurrentState.MacAddress, nil
+		}
+	}
+
+	return "", fmt.Errorf("failed to find interface %s", interfaceName)
+}
+
+// GetInterfacePCIAddress returns the pci-address field for the interface from NodeNetworkState current state.
+func (builder *StateBuilder) GetInterfacePCIAddress(interfaceName string) (string, error) {
+	if valid, err := builder.validate(); !valid {
+		return "", err
+	}
+
+	klog.V(100).Infof("Getting interface PCI address for interface %s from NodeNetworkState %s",
+		interfaceName, builder.Object.Name)
+
+	if interfaceName == "" {
+		klog.V(100).Info("The interfaceName can not be empty string")
+
+		return "", fmt.Errorf("the interfaceName is empty sting")
+	}
+
+	var CurrentState DesiredState
+
+	err := yaml.Unmarshal(builder.Object.Status.CurrentState.Raw, &CurrentState)
+	if err != nil {
+		return "", fmt.Errorf("failed to Unmarshal NMState state")
+	}
+
+	for _, interfaceFromCurrentState := range CurrentState.Interfaces {
+		if interfaceFromCurrentState.Name == interfaceName {
+			if interfaceFromCurrentState.PciAddress == "" {
+				return "", fmt.Errorf("failed to find pci-address for interface %s", interfaceName)
+			}
+
+			return interfaceFromCurrentState.PciAddress, nil
+		}
+	}
+
+	return "", fmt.Errorf("failed to find interface %s", interfaceName)
+}
+
 // GetInterfaceType returns Interface with the given interface name and given type.
 func (builder *StateBuilder) GetInterfaceType(interfaceName, interfaceType string) (NetworkInterface, error) {
 	if valid, err := builder.validate(); !valid {

--- a/pkg/nmstate/nodenetworkstate_test.go
+++ b/pkg/nmstate/nodenetworkstate_test.go
@@ -18,6 +18,9 @@ var (
 		nmstateV1beta1.AddToScheme,
 	}
 	sriovExistingInterface = "ensf0"
+	sriovTestMACAddress    = "52:54:00:12:34:56"
+	sriovTestPCIAddress    = "0000:00:03.0"
+	sriovTestAltnames      = []string{"eth-alt1", "eth-alt2"}
 	vfNumber               = 10
 )
 
@@ -233,6 +236,148 @@ func TestStateBuilderGetInterfaceType(t *testing.T) {
 	}
 }
 
+func TestStateBuilderGetInterfaceMACAddress(t *testing.T) {
+	testCases := []struct {
+		testNodeNetState *StateBuilder
+		interfaceName    string
+		expectedMAC      string
+		expectedError    error
+		mutateBuilder    func(*StateBuilder)
+	}{
+		{
+			testNodeNetState: buildValidNodeNetworkStateTestBuilder(buildTestClientWithDummyNodeNetworkStateObject()),
+			interfaceName:    sriovExistingInterface,
+			expectedMAC:      sriovTestMACAddress,
+			expectedError:    nil,
+			mutateBuilder:    nil,
+		},
+		{
+			testNodeNetState: buildValidNodeNetworkStateTestBuilder(buildTestClientWithDummyNodeNetworkStateObject()),
+			interfaceName:    "unknown",
+			expectedMAC:      "",
+			expectedError:    fmt.Errorf("failed to find interface unknown"),
+			mutateBuilder:    nil,
+		},
+		{
+			testNodeNetState: buildValidNodeNetworkStateTestBuilder(buildTestClientWithDummyNodeNetworkStateObject()),
+			interfaceName:    "",
+			expectedMAC:      "",
+			expectedError:    fmt.Errorf("the interfaceName is empty sting"),
+			mutateBuilder:    nil,
+		},
+		{
+			testNodeNetState: buildValidNodeNetworkStateTestBuilder(buildTestClientWithDummyNodeNetworkStateObject()),
+			interfaceName:    sriovExistingInterface,
+			expectedMAC:      "",
+			expectedError:    fmt.Errorf("failed to find mac-address for interface %s", sriovExistingInterface),
+			mutateBuilder: func(builder *StateBuilder) {
+				currentState := DesiredState{}
+				_ = yaml.Unmarshal(builder.Object.Status.CurrentState.Raw, &currentState)
+				currentState.Interfaces[0].MacAddress = ""
+				builder.Object.Status.CurrentState.Raw, _ = yaml.Marshal(currentState)
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		if testCase.mutateBuilder != nil {
+			testCase.mutateBuilder(testCase.testNodeNetState)
+		}
+
+		mac, err := testCase.testNodeNetState.GetInterfaceMACAddress(testCase.interfaceName)
+		assert.Equal(t, testCase.expectedError, err)
+		assert.Equal(t, testCase.expectedMAC, mac)
+	}
+}
+
+func TestStateBuilderGetInterfacePCIAddress(t *testing.T) {
+	testCases := []struct {
+		testNodeNetState *StateBuilder
+		interfaceName    string
+		expectedPCI      string
+		expectedError    error
+		mutateBuilder    func(*StateBuilder)
+	}{
+		{
+			testNodeNetState: buildValidNodeNetworkStateTestBuilder(buildTestClientWithDummyNodeNetworkStateObject()),
+			interfaceName:    sriovExistingInterface,
+			expectedPCI:      sriovTestPCIAddress,
+			expectedError:    nil,
+			mutateBuilder:    nil,
+		},
+		{
+			testNodeNetState: buildValidNodeNetworkStateTestBuilder(buildTestClientWithDummyNodeNetworkStateObject()),
+			interfaceName:    "unknown",
+			expectedPCI:      "",
+			expectedError:    fmt.Errorf("failed to find interface unknown"),
+			mutateBuilder:    nil,
+		},
+		{
+			testNodeNetState: buildValidNodeNetworkStateTestBuilder(buildTestClientWithDummyNodeNetworkStateObject()),
+			interfaceName:    "",
+			expectedPCI:      "",
+			expectedError:    fmt.Errorf("the interfaceName is empty sting"),
+			mutateBuilder:    nil,
+		},
+		{
+			testNodeNetState: buildValidNodeNetworkStateTestBuilder(buildTestClientWithDummyNodeNetworkStateObject()),
+			interfaceName:    sriovExistingInterface,
+			expectedPCI:      "",
+			expectedError:    fmt.Errorf("failed to find pci-address for interface %s", sriovExistingInterface),
+			mutateBuilder: func(builder *StateBuilder) {
+				currentState := DesiredState{}
+				_ = yaml.Unmarshal(builder.Object.Status.CurrentState.Raw, &currentState)
+				currentState.Interfaces[0].PciAddress = ""
+				builder.Object.Status.CurrentState.Raw, _ = yaml.Marshal(currentState)
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		if testCase.mutateBuilder != nil {
+			testCase.mutateBuilder(testCase.testNodeNetState)
+		}
+
+		pci, err := testCase.testNodeNetState.GetInterfacePCIAddress(testCase.interfaceName)
+		assert.Equal(t, testCase.expectedError, err)
+		assert.Equal(t, testCase.expectedPCI, pci)
+	}
+}
+
+func TestStateBuilderGetInterfaceAltnames(t *testing.T) {
+	testCases := []struct {
+		testNodeNetState *StateBuilder
+		interfaceName    string
+		expectedAltnames []string
+		expectedError    error
+	}{
+		{
+			testNodeNetState: buildValidNodeNetworkStateTestBuilder(buildTestClientWithDummyNodeNetworkStateObject()),
+			interfaceName:    sriovExistingInterface,
+			expectedAltnames: sriovTestAltnames,
+			expectedError:    nil,
+		},
+		{
+			testNodeNetState: buildValidNodeNetworkStateTestBuilder(buildTestClientWithDummyNodeNetworkStateObject()),
+			interfaceName:    "unknown",
+			expectedAltnames: nil,
+			expectedError:    fmt.Errorf("failed to find interface unknown"),
+		},
+		{
+			testNodeNetState: buildValidNodeNetworkStateTestBuilder(buildTestClientWithDummyNodeNetworkStateObject()),
+			interfaceName:    "",
+			expectedAltnames: nil,
+			expectedError:    fmt.Errorf("the interfaceName is empty sting"),
+		},
+	}
+
+	for _, testCase := range testCases {
+		names, err := testCase.testNodeNetState.GetInterfaceAltnames(testCase.interfaceName)
+		assert.Equal(t, testCase.expectedError, err)
+		assert.Equal(t, testCase.expectedAltnames, names)
+	}
+}
+
 func TestStateBuilderGetSriovVfs(t *testing.T) {
 	testCases := []struct {
 		testNodeNetState *StateBuilder
@@ -293,9 +438,15 @@ func newNodeNetworkStateBuilder(apiClient *clients.Settings, name string) *State
 	desiredState := DesiredState{
 		Interfaces: []NetworkInterface{
 			{
-				Name:  sriovExistingInterface,
-				Type:  "ethernet",
-				State: "up",
+				Name:       sriovExistingInterface,
+				Type:       "ethernet",
+				State:      "up",
+				MacAddress: sriovTestMACAddress,
+				PciAddress: sriovTestPCIAddress,
+				AltNames: []InterfaceAltName{
+					{Name: sriovTestAltnames[0]},
+					{Name: sriovTestAltnames[1]},
+				},
 				Ethernet: Ethernet{
 					Sriov: Sriov{
 						TotalVfs: &vfNumber,

--- a/pkg/nmstate/policy.go
+++ b/pkg/nmstate/policy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"regexp"
 	"time"
 
 	"gopkg.in/yaml.v2"
@@ -27,12 +28,14 @@ import (
 )
 
 const (
-	nodeNetConfPolIntError = "nodenetworkconfigurationpolicy 'interfaceName' cannot be empty"
+	nodeNetConfPolIntError      = "nodenetworkconfigurationpolicy 'interfaceName' cannot be empty"
+	nodeNetConfPolAltnamesEmpty = "altnames cannot be empty array"
 )
 
 var (
 	// allowedBondModes represents all allowed modes for Bond interface.
 	allowedBondModes = []string{"balance-rr", "active-backup", "balance-xor", "broadcast", "802.3ad"}
+	pciAddressRegexp = regexp.MustCompile(`^[0-9a-fA-F]{4}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-7]$`)
 )
 
 // AdditionalOptions additional options for pod object.
@@ -407,6 +410,168 @@ func (builder *PolicyBuilder) WithVlanInterfaceIP(baseInterface, ipv4Addresses, 
 	return builder.withInterface(newInterface)
 }
 
+// WithInterfaceAltnames adds ethernet interface configuration with alternative names to the policy.
+func (builder *PolicyBuilder) WithInterfaceAltnames(interfaceName string, altnames []string) *PolicyBuilder {
+	if valid, _ := builder.validate(); !valid {
+		return builder
+	}
+
+	klog.V(100).Infof("Creating NodeNetworkConfigurationPolicy %s with an interface altnames %v",
+		builder.Definition.Name, altnames)
+
+	if interfaceName == "" {
+		klog.V(100).Info("The interfaceName can not be empty string")
+
+		builder.errorMsg = nodeNetConfPolIntError
+
+		return builder
+	}
+
+	if len(altnames) == 0 {
+		klog.V(100).Info("The altnames can not be empty array")
+
+		builder.errorMsg = nodeNetConfPolAltnamesEmpty
+
+		return builder
+	}
+
+	altnamesList := make([]InterfaceAltName, len(altnames))
+	for i, altname := range altnames {
+		altnamesList[i] = InterfaceAltName{
+			Name: altname,
+		}
+	}
+
+	newInterface := NetworkInterface{
+		Name:     interfaceName,
+		Type:     "ethernet",
+		State:    "up",
+		AltNames: altnamesList,
+	}
+
+	return builder.withInterface(newInterface)
+}
+
+// WithMACAddressAltnames adds ethernet interface configuration identified by MAC address with alternative names.
+func (builder *PolicyBuilder) WithMACAddressAltnames(interfaceName string, macaddress string, altnames []string) *PolicyBuilder {
+	if valid, _ := builder.validate(); !valid {
+		return builder
+	}
+
+	klog.V(100).Infof("Creating NodeNetworkConfigurationPolicy %s with an interface macaddress %s and altnames %v",
+		builder.Definition.Name, macaddress, altnames)
+
+	if interfaceName == "" {
+		klog.V(100).Info("The interfaceName can not be empty string")
+
+		builder.errorMsg = nodeNetConfPolIntError
+
+		return builder
+	}
+
+	if macaddress == "" {
+		klog.V(100).Info("The macaddress can not be empty string")
+
+		builder.errorMsg = "macaddress cannot be empty string"
+
+		return builder
+	}
+
+	if _, err := net.ParseMAC(macaddress); err != nil {
+		klog.V(100).Infof("The macaddress %s is invalid", macaddress)
+
+		builder.errorMsg = "macaddress is invalid"
+
+		return builder
+	}
+
+	if len(altnames) == 0 {
+		klog.V(100).Info("The altnames can not be empty array")
+
+		builder.errorMsg = nodeNetConfPolAltnamesEmpty
+
+		return builder
+	}
+
+	altnamesList := make([]InterfaceAltName, len(altnames))
+	for i, altname := range altnames {
+		altnamesList[i] = InterfaceAltName{
+			Name: altname,
+		}
+	}
+
+	newInterface := NetworkInterface{
+		Name:       interfaceName,
+		Type:       "ethernet",
+		State:      "up",
+		MacAddress: macaddress,
+		Identifier: "mac-address",
+		AltNames:   altnamesList,
+	}
+
+	return builder.withInterface(newInterface)
+}
+
+// WithPCIAddressAltnames adds ethernet interface configuration identified by PCI address with alternative names.
+func (builder *PolicyBuilder) WithPCIAddressAltnames(interfaceName string, pciAddress string, altnames []string) *PolicyBuilder {
+	if valid, _ := builder.validate(); !valid {
+		return builder
+	}
+
+	klog.V(100).Infof("Creating NodeNetworkConfigurationPolicy %s with an interface pci-address %s and altnames %v",
+		builder.Definition.Name, pciAddress, altnames)
+
+	if interfaceName == "" {
+		klog.V(100).Info("The interfaceName can not be empty string")
+
+		builder.errorMsg = nodeNetConfPolIntError
+
+		return builder
+	}
+
+	if pciAddress == "" {
+		klog.V(100).Info("The pciAddress can not be empty string")
+
+		builder.errorMsg = "pciAddress cannot be empty string"
+
+		return builder
+	}
+
+	if !pciAddressRegexp.MatchString(pciAddress) {
+		klog.V(100).Infof("The pciAddress %s is invalid", pciAddress)
+
+		builder.errorMsg = "pciAddress is invalid"
+
+		return builder
+	}
+
+	if len(altnames) == 0 {
+		klog.V(100).Info("The altnames can not be empty array")
+
+		builder.errorMsg = nodeNetConfPolAltnamesEmpty
+
+		return builder
+	}
+
+	altnamesList := make([]InterfaceAltName, len(altnames))
+	for i, altname := range altnames {
+		altnamesList[i] = InterfaceAltName{
+			Name: altname,
+		}
+	}
+
+	newInterface := NetworkInterface{
+		Name:       interfaceName,
+		Type:       "ethernet",
+		State:      "up",
+		PciAddress: pciAddress,
+		Identifier: "pci-address",
+		AltNames:   altnamesList,
+	}
+
+	return builder.withInterface(newInterface)
+}
+
 // WithEthernetInterface adds type ethernet interface and IPs configuration to the NodeNetworkConfigurationPolicy.
 func (builder *PolicyBuilder) WithEthernetInterface(interfaceName, ipv4Address, ipv6Address string) *PolicyBuilder {
 	if valid, _ := builder.validate(); !valid {
@@ -605,6 +770,38 @@ func (builder *PolicyBuilder) WithOptions(options ...AdditionalOptions) *PolicyB
 	}
 
 	return builder
+}
+
+// RemoveInterfaceAltname appends configuration to mark the given alternative names absent on the interface.
+func (builder *PolicyBuilder) RemoveInterfaceAltname(interfaceName string, altnames []string) *PolicyBuilder {
+	if valid, _ := builder.validate(); !valid {
+		return builder
+	}
+
+	klog.V(100).Infof("Removing interface altnames for interface %s from NodeNetworkConfigurationPolicy %s",
+		interfaceName, builder.Definition.Name)
+
+	if interfaceName == "" {
+		klog.V(100).Info("The interfaceName can not be empty string")
+
+		builder.errorMsg = nodeNetConfPolIntError
+
+		return builder
+	}
+
+	altnamesList := []InterfaceAltName{}
+	for _, altname := range altnames {
+		altnamesList = append(altnamesList, InterfaceAltName{Name: altname, State: "absent"})
+	}
+
+	newInterface := NetworkInterface{
+		Name:     interfaceName,
+		Type:     "ethernet",
+		State:    "up",
+		AltNames: altnamesList,
+	}
+
+	return builder.withInterface(newInterface)
 }
 
 // WaitUntilCondition waits for the duration of the defined timeout or until the

--- a/pkg/nmstate/policy_test.go
+++ b/pkg/nmstate/policy_test.go
@@ -501,6 +501,261 @@ func TestPolicyWithVlanInterfaceIP(t *testing.T) {
 	}
 }
 
+func TestPolicyWithInterfaceAltnames(t *testing.T) {
+	testCases := []struct {
+		testNMStatePolicy *PolicyBuilder
+		interfaceName     string
+		altnames          []string
+		expectedError     string
+	}{
+		{
+			testNMStatePolicy: buildValidPolicyTestBuilder(buildTestClientWithDummyPolicyObject()),
+			interfaceName:     "ens1",
+			altnames:          []string{"alt-a", "alt-b"},
+			expectedError:     "",
+		},
+		{
+			testNMStatePolicy: buildValidPolicyTestBuilder(buildTestClientWithDummyPolicyObject()),
+			interfaceName:     "",
+			altnames:          []string{"alt-a"},
+			expectedError:     nodeNetConfPolIntError,
+		},
+		{
+			testNMStatePolicy: buildValidPolicyTestBuilder(buildTestClientWithDummyPolicyObject()),
+			interfaceName:     "ens1",
+			altnames:          []string{},
+			expectedError:     nodeNetConfPolAltnamesEmpty,
+		},
+	}
+	for _, testCase := range testCases {
+		testPolicy := testCase.testNMStatePolicy.WithInterfaceAltnames(testCase.interfaceName, testCase.altnames)
+		assert.Equal(t, testCase.expectedError, testPolicy.errorMsg)
+
+		if testCase.expectedError != "" {
+			continue
+		}
+
+		desireState := &DesiredState{}
+		_ = yaml.Unmarshal(testPolicy.Definition.Spec.DesiredState.Raw, desireState)
+
+		wantAlts := make([]InterfaceAltName, len(testCase.altnames))
+		for i, n := range testCase.altnames {
+			wantAlts[i] = InterfaceAltName{Name: n}
+		}
+
+		assert.Equal(t, &DesiredState{
+			Interfaces: []NetworkInterface{{
+				Name:     testCase.interfaceName,
+				Type:     "ethernet",
+				State:    "up",
+				AltNames: wantAlts,
+			}},
+		}, desireState)
+	}
+}
+
+func TestPolicyWithMACAddressAltnames(t *testing.T) {
+	const testMAC = "52:54:00:ab:cd:ef"
+
+	testCases := []struct {
+		testNMStatePolicy *PolicyBuilder
+		interfaceName     string
+		mac               string
+		altnames          []string
+		expectedError     string
+	}{
+		{
+			testNMStatePolicy: buildValidPolicyTestBuilder(buildTestClientWithDummyPolicyObject()),
+			interfaceName:     "ens9",
+			mac:               testMAC,
+			altnames:          []string{"vf0"},
+			expectedError:     "",
+		},
+		{
+			testNMStatePolicy: buildValidPolicyTestBuilder(buildTestClientWithDummyPolicyObject()),
+			interfaceName:     "ens9",
+			mac:               "",
+			altnames:          []string{"vf0"},
+			expectedError:     "macaddress cannot be empty string",
+		},
+		{
+			testNMStatePolicy: buildValidPolicyTestBuilder(buildTestClientWithDummyPolicyObject()),
+			interfaceName:     "",
+			mac:               testMAC,
+			altnames:          []string{"vf0"},
+			expectedError:     nodeNetConfPolIntError,
+		},
+		{
+			testNMStatePolicy: buildValidPolicyTestBuilder(buildTestClientWithDummyPolicyObject()),
+			interfaceName:     "ens9",
+			mac:               "invalid",
+			altnames:          []string{"vf0"},
+			expectedError:     "macaddress is invalid",
+		},
+		{
+			testNMStatePolicy: buildValidPolicyTestBuilder(buildTestClientWithDummyPolicyObject()),
+			interfaceName:     "ens9",
+			mac:               testMAC,
+			altnames:          []string{},
+			expectedError:     nodeNetConfPolAltnamesEmpty,
+		},
+	}
+	for _, testCase := range testCases {
+		testPolicy := testCase.testNMStatePolicy.WithMACAddressAltnames(
+			testCase.interfaceName, testCase.mac, testCase.altnames)
+		assert.Equal(t, testCase.expectedError, testPolicy.errorMsg)
+
+		if testCase.expectedError != "" {
+			continue
+		}
+
+		desireState := &DesiredState{}
+		_ = yaml.Unmarshal(testPolicy.Definition.Spec.DesiredState.Raw, desireState)
+
+		wantAlts := make([]InterfaceAltName, len(testCase.altnames))
+		for i, n := range testCase.altnames {
+			wantAlts[i] = InterfaceAltName{Name: n}
+		}
+
+		assert.Equal(t, &DesiredState{
+			Interfaces: []NetworkInterface{{
+				Name:       testCase.interfaceName,
+				Type:       "ethernet",
+				State:      "up",
+				MacAddress: testCase.mac,
+				Identifier: "mac-address",
+				AltNames:   wantAlts,
+			}},
+		}, desireState)
+	}
+}
+
+func TestPolicyWithPCIAddressAltnames(t *testing.T) {
+	const testPCI = "0000:03:00.0"
+
+	testCases := []struct {
+		testNMStatePolicy *PolicyBuilder
+		interfaceName     string
+		pci               string
+		altnames          []string
+		expectedError     string
+	}{
+		{
+			testNMStatePolicy: buildValidPolicyTestBuilder(buildTestClientWithDummyPolicyObject()),
+			interfaceName:     "ens8",
+			pci:               testPCI,
+			altnames:          []string{"nic-pf"},
+			expectedError:     "",
+		},
+		{
+			testNMStatePolicy: buildValidPolicyTestBuilder(buildTestClientWithDummyPolicyObject()),
+			interfaceName:     "ens8",
+			pci:               "",
+			altnames:          []string{"nic-pf"},
+			expectedError:     "pciAddress cannot be empty string",
+		},
+		{
+			testNMStatePolicy: buildValidPolicyTestBuilder(buildTestClientWithDummyPolicyObject()),
+			interfaceName:     "",
+			pci:               testPCI,
+			altnames:          []string{"nic-pf"},
+			expectedError:     nodeNetConfPolIntError,
+		},
+		{
+			testNMStatePolicy: buildValidPolicyTestBuilder(buildTestClientWithDummyPolicyObject()),
+			interfaceName:     "ens8",
+			pci:               "0000:03:00",
+			altnames:          []string{"nic-pf"},
+			expectedError:     "pciAddress is invalid",
+		},
+		{
+			testNMStatePolicy: buildValidPolicyTestBuilder(buildTestClientWithDummyPolicyObject()),
+			interfaceName:     "ens8",
+			pci:               testPCI,
+			altnames:          []string{},
+			expectedError:     nodeNetConfPolAltnamesEmpty,
+		},
+	}
+	for _, testCase := range testCases {
+		testPolicy := testCase.testNMStatePolicy.WithPCIAddressAltnames(
+			testCase.interfaceName, testCase.pci, testCase.altnames)
+		assert.Equal(t, testCase.expectedError, testPolicy.errorMsg)
+
+		if testCase.expectedError != "" {
+			continue
+		}
+
+		desireState := &DesiredState{}
+		_ = yaml.Unmarshal(testPolicy.Definition.Spec.DesiredState.Raw, desireState)
+
+		wantAlts := make([]InterfaceAltName, len(testCase.altnames))
+		for i, n := range testCase.altnames {
+			wantAlts[i] = InterfaceAltName{Name: n}
+		}
+
+		assert.Equal(t, &DesiredState{
+			Interfaces: []NetworkInterface{{
+				Name:       testCase.interfaceName,
+				Type:       "ethernet",
+				State:      "up",
+				PciAddress: testCase.pci,
+				Identifier: "pci-address",
+				AltNames:   wantAlts,
+			}},
+		}, desireState)
+	}
+}
+
+func TestPolicyRemoveInterfaceAltname(t *testing.T) {
+	testCases := []struct {
+		testNMStatePolicy *PolicyBuilder
+		interfaceName     string
+		altnames          []string
+		expectedError     string
+		wantAltnames      []InterfaceAltName
+	}{
+		{
+			testNMStatePolicy: buildValidPolicyTestBuilder(buildTestClientWithDummyPolicyObject()),
+			interfaceName:     "ens1",
+			altnames:          []string{"old-alt"},
+			expectedError:     "",
+			wantAltnames:      []InterfaceAltName{{Name: "old-alt", State: "absent"}},
+		},
+		{
+			testNMStatePolicy: buildValidPolicyTestBuilder(buildTestClientWithDummyPolicyObject()),
+			interfaceName:     "",
+			altnames:          []string{"x"},
+			expectedError:     nodeNetConfPolIntError,
+		},
+		{
+			testNMStatePolicy: buildValidPolicyTestBuilder(buildTestClientWithDummyPolicyObject()),
+			interfaceName:     "ens1",
+			altnames:          nil,
+			expectedError:     "",
+			wantAltnames:      nil,
+		},
+	}
+	for _, testCase := range testCases {
+		testPolicy := testCase.testNMStatePolicy.RemoveInterfaceAltname(testCase.interfaceName, testCase.altnames)
+		assert.Equal(t, testCase.expectedError, testPolicy.errorMsg)
+
+		if testCase.expectedError != "" {
+			continue
+		}
+
+		desireState := &DesiredState{}
+		_ = yaml.Unmarshal(testPolicy.Definition.Spec.DesiredState.Raw, desireState)
+		assert.Equal(t, &DesiredState{
+			Interfaces: []NetworkInterface{{
+				Name:     testCase.interfaceName,
+				Type:     "ethernet",
+				State:    "up",
+				AltNames: testCase.wantAltnames,
+			}},
+		}, desireState)
+	}
+}
+
 func TestPolicyWithEthernetInterfaceIP(t *testing.T) {
 	testCases := []struct {
 		testNMStatePolicy *PolicyBuilder

--- a/pkg/nmstate/shared.go
+++ b/pkg/nmstate/shared.go
@@ -10,15 +10,26 @@ type DesiredState struct {
 
 // NetworkInterface provides struct for the NMState interface state object containing interface information.
 type NetworkInterface struct {
-	Name            string          `yaml:"name"`
-	Type            string          `yaml:"type"`
-	State           string          `yaml:"state"`
-	Ethernet        Ethernet        `yaml:"ethernet,omitempty"`
-	Bridge          Bridge          `yaml:"bridge,omitempty"`
-	LinkAggregation LinkAggregation `yaml:"link-aggregation,omitempty"`
-	Vlan            Vlan            `yaml:"vlan,omitempty"`
-	Ipv4            InterfaceIpv4   `yaml:"ipv4,omitempty"`
-	Ipv6            InterfaceIpv6   `yaml:"ipv6,omitempty"`
+	Name            string             `yaml:"name"`
+	Type            string             `yaml:"type"`
+	State           string             `yaml:"state"`
+	Identifier      string             `yaml:"identifier,omitempty"`
+	PciAddress      string             `yaml:"pci-address,omitempty"`
+	MacAddress      string             `yaml:"mac-address,omitempty"`
+	AltNames        []InterfaceAltName `yaml:"alt-names,omitempty"`
+	Ethernet        Ethernet           `yaml:"ethernet,omitempty"`
+	Bridge          Bridge             `yaml:"bridge,omitempty"`
+	LinkAggregation LinkAggregation    `yaml:"link-aggregation,omitempty"`
+	Vlan            Vlan               `yaml:"vlan,omitempty"`
+	Ipv4            InterfaceIpv4      `yaml:"ipv4,omitempty"`
+	Ipv6            InterfaceIpv6      `yaml:"ipv6,omitempty"`
+}
+
+// InterfaceAltName is an alternative interface name in desired state (nmstate.io/v1).
+// Set State to "absent" to remove an existing alt-name.
+type InterfaceAltName struct {
+	Name  string `yaml:"name"`
+	State string `yaml:"state,omitempty"`
 }
 
 // InterfaceIpv4 enables an IPv4 address on an interface.
@@ -59,6 +70,7 @@ type Sriov struct {
 // Vf provides struct for the NMState SR-IOV VF state object containing SR-IOV VF information.
 type Vf struct {
 	ID         int    `yaml:"id"`
+	IfaceName  string `yaml:"iface-name,omitempty"`
 	MacAddress string `yaml:"mac-address,omitempty"`
 	MaxTxRate  *int   `yaml:"max-tx-rate,omitempty"`
 	MinTxRate  *int   `yaml:"min-tx-rate,omitempty"`


### PR DESCRIPTION
## Summary

Extends the nmstate builders so callers can:

- Configure **interface alternative names** (`alt-names`) on `NodeNetworkConfigurationPolicy` desired state
- Read those names back from `NodeNetworkState` current state
- Query **MAC** and **PCI** identifiers for an interface from reported state

---

## Changes

### `pkg/nmstate/shared.go`

- Extends **`NetworkInterface`** with optional `identifier`, `pci-address`, `mac-address`, and `alt-names` (YAML-aligned with nmstate).
- Introduces **`InterfaceAltName`** (`name`, optional `state`) so desired state can add names or mark names **`absent`** for removal.

### `pkg/nmstate/policy.go` — `PolicyBuilder`

| Method | Purpose |
|--------|---------|
| **`WithInterfaceAltnames`** | Ethernet up, altnames by interface name (validates non-empty name and altnames). |
| **`WithMACAddressAltnames`** | Same pattern, keyed by **`mac-address`** identifier (validates MAC and altnames). |
| **`WithPCIAddressAltnames`** | Same pattern, keyed by **`pci-address`** identifier (validates PCI and altnames). |
| **`RemoveInterfaceAltname`** | Appends altnames with `state: absent` for removal on the given interface. |

- Shared validation for empty altnames: **`nodeNetConfPolAltnamesEmpty`** (alongside existing interface-name error constant).

### `pkg/nmstate/nodenetworkstate.go` — `StateBuilder`

| Method | Purpose |
|--------|---------|
| **`GetInterfaceAltnames`** | Returns non-empty alt names for a named interface from unmarshaled current state. |
| **`GetInterfaceMACAddress`** | Returns `mac-address` from current state for a named interface. |
| **`GetInterfacePCIAddress`** | Returns `pci-address` from current state for a named interface. |

---

## Tests

- **`pkg/nmstate/policy_test.go`** — Table-driven tests for the new policy helpers (success paths, validation errors, `RemoveInterfaceAltname` including empty alt list).
- **`pkg/nmstate/nodenetworkstate_test.go`** — Tests for the new getters; dummy current state extended with MAC, PCI, and altnames where needed.

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retrieve network interface metadata: alternate names, MAC addresses, and PCI addresses.
  * Configure interface alternate names via network policies, including MAC- and PCI-based identifiers.
  * Remove interface alternate names from network configurations (marked absent).

* **Tests**
  * Added unit tests validating new interface attribute accessors and policy behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->