### PR TITLE
network:operator fix setmultinetworkpolicy

### DIFF
--- a/pkg/network/operator.go
+++ b/pkg/network/operator.go
@@ -204,13 +204,8 @@ func (builder *OperatorBuilder) SetIPForwarding(
 	return builder, err
 }
 
-// SetMultiNetworkPolicy enables or disables the network.operator multinetworkpolicy feature.
-// When disabling, the Cluster Network Operator often does not set Progressing=True; the initial
-// wait for Progressing=True is skipped in that case only. Enabling keeps the original sequence.
-// On disable, we wait until status.observedGeneration catches metadata.generation from the update
-// so condition polling is not satisfied from stale status from before this change.
-// The wait for Progressing=False uses a disable-specific path: CNO may omit the Progressing
-// condition when idle, which would otherwise never match WaitUntilInCondition(..., False).
+// SetMultiNetworkPolicy sets network.operator spec.useMultiNetworkPolicy to state.
+// No-op if unchanged; otherwise Update then wait until Available=True within timeout.
 func (builder *OperatorBuilder) SetMultiNetworkPolicy(state bool, timeout time.Duration) (*OperatorBuilder, error) {
 	if valid, err := builder.validate(); !valid {
 		return builder, err
@@ -224,32 +219,6 @@ func (builder *OperatorBuilder) SetMultiNetworkPolicy(state bool, timeout time.D
 		builder.Definition.Spec.UseMultiNetworkPolicy = &state
 
 		builder, err := builder.Update()
-		if err != nil {
-			return nil, err
-		}
-
-		targetGeneration := builder.Definition.Generation
-
-		if state {
-			err = builder.WaitUntilInCondition(
-				operatorv1.OperatorStatusTypeProgressing, 60*time.Second, operatorv1.ConditionTrue)
-			if err != nil {
-				return nil, err
-			}
-		} else {
-			err = builder.waitUntilObservedGeneration(targetGeneration, timeout)
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		if state {
-			err = builder.WaitUntilInCondition(
-				operatorv1.OperatorStatusTypeProgressing, timeout, operatorv1.ConditionFalse)
-		} else {
-			err = builder.waitUntilProgressingSettledOnDisable(timeout)
-		}
-
 		if err != nil {
 			return nil, err
 		}
@@ -314,11 +283,18 @@ func (builder *OperatorBuilder) WaitUntilInCondition(
 
 	err := wait.PollUntilContextTimeout(
 		context.TODO(), 3*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
-			if !builder.Exists() {
-				return false, fmt.Errorf("network.operator object %s does not exist", builder.Definition.Name)
+			obj, getErr := builder.Get()
+			if getErr != nil {
+				if k8serrors.IsNotFound(getErr) {
+					return false, fmt.Errorf("network.operator object %s does not exist", builder.Definition.Name)
+				}
+
+				return false, nil
 			}
 
-			for _, c := range builder.Object.Status.Conditions {
+			builder.Object = obj
+
+			for _, c := range obj.Status.Conditions {
 				if c.Type == condition && c.Status == status {
 					return true, nil
 				}
@@ -333,77 +309,6 @@ func (builder *OperatorBuilder) WaitUntilInCondition(
 	}
 
 	return err
-}
-
-// waitUntilObservedGeneration waits until status.observedGeneration reflects the given metadata.generation,
-// indicating the operator has reconciled that spec revision.
-func (builder *OperatorBuilder) waitUntilObservedGeneration(targetGeneration int64, timeout time.Duration) error {
-	if valid, err := builder.validate(); !valid {
-		return err
-	}
-
-	klog.V(100).Infof("Wait until network.operator %s observedGeneration >= %d",
-		builder.Definition.Name, targetGeneration)
-
-	return wait.PollUntilContextTimeout(
-		context.TODO(), 3*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
-			if !builder.Exists() {
-				return false, fmt.Errorf("network.operator object %s does not exist", builder.Definition.Name)
-			}
-
-			return builder.Object.Status.ObservedGeneration >= targetGeneration, nil
-		})
-}
-
-// waitUntilProgressingSettledOnDisable waits until Progressing is False, or until the operator
-// reports available and not degraded while Progressing is absent (CNO may omit Progressing when idle).
-func (builder *OperatorBuilder) waitUntilProgressingSettledOnDisable(timeout time.Duration) error {
-	if valid, err := builder.validate(); !valid {
-		return err
-	}
-
-	klog.V(100).Infof("Wait until network.operator %s is settled after disabling MultiNetworkPolicy",
-		builder.Definition.Name)
-
-	return wait.PollUntilContextTimeout(
-		context.TODO(), 3*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
-			if !builder.Exists() {
-				return false, fmt.Errorf("network.operator object %s does not exist", builder.Definition.Name)
-			}
-
-			for _, c := range builder.Object.Status.Conditions {
-				if c.Type != operatorv1.OperatorStatusTypeProgressing {
-					continue
-				}
-
-				return c.Status == operatorv1.ConditionFalse, nil
-			}
-
-			return operatorAvailableAndNotDegraded(builder.Object.Status.Conditions), nil
-		})
-}
-
-func operatorAvailableAndNotDegraded(conditions []operatorv1.OperatorCondition) bool {
-	var available, degraded *operatorv1.OperatorCondition
-
-	for i := range conditions {
-		switch conditions[i].Type {
-		case operatorv1.OperatorStatusTypeAvailable:
-			available = &conditions[i]
-		case operatorv1.OperatorStatusTypeDegraded:
-			degraded = &conditions[i]
-		}
-	}
-
-	if available == nil || available.Status != operatorv1.ConditionTrue {
-		return false
-	}
-
-	if degraded != nil && degraded.Status == operatorv1.ConditionTrue {
-		return false
-	}
-
-	return len(conditions) > 0
 }
 
 // validate will check that the builder and builder definition are properly initialized before


### PR DESCRIPTION
I have an issue with the last change I made in eco-goinfra with setmultinetworkpolicy in network operator.
We were checking the status.observedGeneration against metadata.generation to verify that a change was made to the network operator cluster CRD.  I  tested the solution and it worked fine. However the status.observedGenerationis ia an optional field and apparently not always populated, when its not it equals = 0. Any wait that requires observedGeneration >= metadata.generation then becomes 0 >= the number in observedGeneration, and the function never sees the change.
To solute this issue i added a short “probe” window of 30s which polls status.observedGeneration >= metadata.generation. If the probe times out and observedGeneration is still 0 the func moves to the next steps (Progressing settled + Available).

Fix SetMultiNetworkPolicy(false, …): skip waiting for Progressing=True on disable (CNO often never sets it). After Update(), wait for observedGeneration to catch generation when present; if observedGeneration stays unset after a short probe, skip that gate. Then wait for Progressing settled / Available.

Also: WaitUntilInCondition timeout logging guards builder.Object != nil; restore SetIPForwarding for pkg/network tests.

Verify: go test ./pkg/network/...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Post-update readiness now requires Availability to remain stable for a continuous 60s window before final confirmation, reducing flapping and transient success reports.

* **Bug Fixes**
  * Prevents nil-reference waits by treating missing objects as not-ready until present, avoiding unexpected errors during status checks.

* **Chores**
  * No public API changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rh-ecosystem-edge/eco-goinfra/pull/1345)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->