### PR TITLE
Add KServe sync config for API type tracking

### DIFF
--- a/internal/sync/configs/kserve-config.yaml
+++ b/internal/sync/configs/kserve-config.yaml
@@ -1,0 +1,26 @@
+---
+- name: kserve-serving-api-v1beta1
+  sync: false
+  repo_link: "https://github.com/kserve/kserve"
+  branch: master
+  remote_api_directory: pkg/apis/serving/v1beta1
+  local_api_directory: schemes/kserve/v1beta1
+  replace_imports:
+    - old: '"github.com/kserve/kserve/pkg/apis/serving/v1beta1"'
+      new: '"github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/kserve/v1beta1"'
+  excludes:
+    - "*_test.go"
+    - "testdata"
+
+- name: kserve-serving-api-v1alpha1
+  sync: false
+  repo_link: "https://github.com/kserve/kserve"
+  branch: master
+  remote_api_directory: pkg/apis/serving/v1alpha1
+  local_api_directory: schemes/kserve/v1alpha1
+  replace_imports:
+    - old: '"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"'
+      new: '"github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/kserve/v1alpha1"'
+  excludes:
+    - "*_test.go"
+    - "testdata"


### PR DESCRIPTION
Registers the upstream KServe serving API directories (v1alpha1 and v1beta1) in the sync tool configuration. Set to sync: false since the local types are intentionally minimal hand-written subsets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added configuration for managing KServe API versions to support internal tooling and integration workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->