### PR TITLE
nmstate: add method to set interface up

### DIFF
--- a/pkg/nmstate/policy.go
+++ b/pkg/nmstate/policy.go
@@ -664,6 +664,32 @@ func (builder *PolicyBuilder) WithEthernetIPv6LinkLocalInterface(interfaceName s
 	return builder.withInterface(newInterface)
 }
 
+// WithInterfaceUp appends the configuration for an interface with state "up" to the NodeNetworkConfigurationPolicy.
+func (builder *PolicyBuilder) WithInterfaceUp(interfaceName string) *PolicyBuilder {
+	if valid, _ := builder.validate(); !valid {
+		return builder
+	}
+
+	klog.V(100).Infof("Creating NodeNetworkConfigurationPolicy %s to set interface %s to state up",
+		builder.Definition.Name, interfaceName)
+
+	if interfaceName == "" {
+		klog.V(100).Info("The interfaceName can not be empty string")
+
+		builder.errorMsg = nodeNetConfPolIntError
+
+		return builder
+	}
+
+	newInterface := NetworkInterface{
+		Name:  interfaceName,
+		State: "up",
+		Type:  "ethernet",
+	}
+
+	return builder.withInterface(newInterface)
+}
+
 // WithAbsentInterface appends the configuration for an absent interface to the NodeNetworkConfigurationPolicy.
 func (builder *PolicyBuilder) WithAbsentInterface(interfaceName string) *PolicyBuilder {
 	if valid, _ := builder.validate(); !valid {

--- a/pkg/nmstate/policy_test.go
+++ b/pkg/nmstate/policy_test.go
@@ -900,6 +900,36 @@ func TestPolicyWithAbsentInterface(t *testing.T) {
 	}
 }
 
+func TestPolicyWithInterfaceUp(t *testing.T) {
+	testCases := []struct {
+		testNMStatePolicy *PolicyBuilder
+		expectedError     string
+		baseInterface     string
+	}{
+		{
+			testNMStatePolicy: buildValidPolicyTestBuilder(buildTestClientWithDummyPolicyObject()),
+			expectedError:     "",
+			baseInterface:     "ens1",
+		},
+		{
+			testNMStatePolicy: buildValidPolicyTestBuilder(buildTestClientWithDummyPolicyObject()),
+			expectedError:     "nodenetworkconfigurationpolicy 'interfaceName' cannot be empty",
+			baseInterface:     "",
+		},
+	}
+	for _, testCase := range testCases {
+		testPolicy := testCase.testNMStatePolicy.WithInterfaceUp(testCase.baseInterface)
+		assert.Equal(t, testCase.expectedError, testPolicy.errorMsg)
+
+		desireState := &DesiredState{}
+		if testCase.expectedError == "" {
+			_ = yaml.Unmarshal(testPolicy.Definition.Spec.DesiredState.Raw, desireState)
+			assert.Equal(t, desireState, &DesiredState{
+				Interfaces: []NetworkInterface{{Name: testCase.baseInterface, Type: "ethernet", State: "up"}}})
+		}
+	}
+}
+
 func TestPolicyWithStaticRoute(t *testing.T) {
 	testCases := []struct {
 		testNMStatePolicy *PolicyBuilder


### PR DESCRIPTION
Add `WithInterfaceUp` method to PolicyBuilder that configures an interface with state "up" on a `NodeNetworkConfigurationPolicy`, mirroring the existing `WithAbsentInterface` pattern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added functionality to configure network interfaces in an active "up" state as part of policy configuration management.

* **Tests**
  * Added test coverage for the new interface configuration capability, validating error handling and verifying correct configuration generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->