### PR TITLE
common: add helper to convert metav1 to runtimeclient ListOptions

### DIFF
--- a/pkg/configmap/list.go
+++ b/pkg/configmap/list.go
@@ -1,112 +1,45 @@
 package configmap
 
 import (
-	"fmt"
+	"context"
 
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/logging"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common"
+	commonerrors "github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common/errors"
+	commonkey "github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common/key"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/klog/v2"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // List returns configmap inventory in the given namespace.
 func List(apiClient *clients.Settings, nsname string, options ...metav1.ListOptions) ([]*Builder, error) {
-	if apiClient == nil {
-		klog.V(100).Info("The apiClient cannot be nil")
-
-		return nil, fmt.Errorf("the apiClient cannot be nil")
-	}
-
 	if nsname == "" {
 		klog.V(100).Info("configmap 'nsname' parameter can not be empty")
 
-		return nil, fmt.Errorf("failed to list configmaps, 'nsname' parameter is empty")
+		return nil, commonerrors.NewBuilderFieldEmpty(
+			commonkey.NewResourceKey("ConfigMap", "", ""), commonerrors.BuilderFieldNamespace)
 	}
 
-	passedOptions := metav1.ListOptions{}
-	logMessage := fmt.Sprintf("Listing configmaps in the namespace %s", nsname)
-
-	if len(options) > 1 {
-		klog.V(100).Info("'options' parameter must be empty or single-valued")
-
-		return nil, fmt.Errorf("error: more than one ListOptions was passed")
-	}
-
-	if len(options) == 1 {
-		passedOptions = options[0]
-		logMessage += fmt.Sprintf(" with the options %v", passedOptions)
-	}
-
-	klog.V(100).Infof("%v", logMessage)
-
-	configmapList, err := apiClient.ConfigMaps(nsname).List(logging.DiscardContext(), passedOptions)
+	convertedOptions, err := common.ConvertMetaListOptionsToListOptions(options)
 	if err != nil {
-		klog.V(100).Infof("Failed to list configmaps in the namespace %s due to %s", nsname, err.Error())
-
 		return nil, err
 	}
 
-	var configmapObjects []*Builder
+	allOptions := append([]runtimeclient.ListOption{runtimeclient.InNamespace(nsname)}, convertedOptions...)
 
-	for _, runningConfigmap := range configmapList.Items {
-		copiedConfigmap := runningConfigmap
-		configmapObjects = append(configmapObjects, newListedBuilder(apiClient, &copiedConfigmap))
-	}
-
-	return configmapObjects, nil
+	return common.List[corev1.ConfigMap, corev1.ConfigMapList, Builder](
+		context.TODO(), apiClient, corev1.AddToScheme, allOptions...)
 }
 
-// ListInAllNamespaces returns configmap inventory in the all the namespaces.
+// ListInAllNamespaces returns configmap inventory in all the namespaces.
 func ListInAllNamespaces(apiClient *clients.Settings, options ...metav1.ListOptions) ([]*Builder, error) {
-	if apiClient == nil {
-		klog.V(100).Info("The apiClient cannot be nil")
-
-		return nil, fmt.Errorf("the apiClient cannot be nil")
-	}
-
-	passedOptions := metav1.ListOptions{}
-	logMessage := "Listing configmaps in all namespaces"
-
-	if len(options) > 1 {
-		klog.V(100).Info("'options' parameter must be either empty or single-valued")
-
-		return nil, fmt.Errorf("error: more than one ListOptions was passed")
-	}
-
-	if len(options) == 1 {
-		passedOptions = options[0]
-		logMessage += fmt.Sprintf(" with the options %v", passedOptions)
-	}
-
-	klog.V(100).Infof("%v", logMessage)
-
-	configmapList, err := apiClient.ConfigMaps("").List(logging.DiscardContext(), passedOptions)
+	convertedOptions, err := common.ConvertMetaListOptionsToListOptions(options)
 	if err != nil {
-		klog.V(100).Infof("Failed to list configmaps in all namespaces due to %s", err.Error())
-
 		return nil, err
 	}
 
-	var configmapObjects []*Builder
-
-	for _, runningConfigmap := range configmapList.Items {
-		copiedConfigmap := runningConfigmap
-		configmapObjects = append(configmapObjects, newListedBuilder(apiClient, &copiedConfigmap))
-	}
-
-	return configmapObjects, nil
-}
-
-// newListedBuilder returns a fully initialized builder for a configmap obtained through a list call.
-func newListedBuilder(apiClient *clients.Settings, configMap *corev1.ConfigMap) *Builder {
-	builder := &Builder{}
-	builder.AttachMixins()
-	builder.SetClient(apiClient)
-	builder.SetGVK(builder.GetGVK())
-	builder.SetObject(configMap)
-	builder.SetDefinition(configMap)
-
-	return builder
+	return common.List[corev1.ConfigMap, corev1.ConfigMapList, Builder](
+		context.TODO(), apiClient, corev1.AddToScheme, convertedOptions...)
 }

--- a/pkg/configmap/list_test.go
+++ b/pkg/configmap/list_test.go
@@ -4,175 +4,29 @@ import (
 	"testing"
 
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common/testhelper"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestList(t *testing.T) {
 	t.Parallel()
 
-	testCases := []struct {
-		name           string
-		nsname         string
-		withClient     bool
-		configMaps     []runtime.Object
-		configmapCount int
-		expectedError  string
-	}{
-		{
-			name:       "returns configmaps from namespace",
-			nsname:     "test-namespace",
-			withClient: true,
-			configMaps: []runtime.Object{
-				newConfigMapObject("test-name1", "test-namespace"),
-				newConfigMapObject("test-name2", "test-namespace"),
-			},
-			configmapCount: 2,
+	testhelper.NewNamespacedListTestConfig(
+		func(apiClient *clients.Settings, nsname string, _ ...runtimeclient.ListOptions) ([]*Builder, error) {
+			return List(apiClient, nsname)
 		},
-		{
-			name:       "filters configmaps from other namespaces",
-			nsname:     "test-namespace",
-			withClient: true,
-			configMaps: []runtime.Object{
-				newConfigMapObject("test-name1", "test-namespace"),
-				newConfigMapObject("test-name2", "test-namespace2"),
-			},
-			configmapCount: 1,
-		},
-		{
-			name:          "rejects empty namespace",
-			nsname:        "",
-			withClient:    true,
-			expectedError: "failed to list configmaps, 'nsname' parameter is empty",
-		},
-		{
-			name:          "rejects nil client",
-			nsname:        "test-namespace",
-			withClient:    false,
-			expectedError: "the apiClient cannot be nil",
-		},
-	}
-
-	for _, testCase := range testCases {
-		testCase := testCase
-
-		t.Run(testCase.name, func(t *testing.T) {
-			t.Parallel()
-
-			var testSettings *clients.Settings
-
-			if testCase.withClient {
-				testSettings = clients.GetTestClients(clients.TestClientParams{
-					K8sMockObjects: testCase.configMaps,
-				})
-			}
-
-			configmapBuilders, err := List(testSettings, testCase.nsname)
-
-			if testCase.expectedError != "" {
-				require.Error(t, err)
-				assert.EqualError(t, err, testCase.expectedError)
-				assert.Nil(t, configmapBuilders)
-
-				return
-			}
-
-			require.NoError(t, err)
-			assert.Len(t, configmapBuilders, testCase.configmapCount)
-
-			for _, builder := range configmapBuilders {
-				require.NotNil(t, builder)
-				require.NotNil(t, builder.GetClient())
-				require.NotNil(t, builder.GetDefinition())
-				require.NotNil(t, builder.GetObject())
-				assert.Equal(t, configMapGVK, builder.GetGVK())
-			}
-		})
-	}
+		corev1.AddToScheme,
+		configMapGVK,
+	).ExecuteTests(t)
 }
 
 func TestListInAllNamespaces(t *testing.T) {
 	t.Parallel()
 
-	testCases := []struct {
-		name           string
-		withClient     bool
-		configMaps     []runtime.Object
-		configmapCount int
-		expectedError  string
-	}{
-		{
-			name:       "returns all configmaps",
-			withClient: true,
-			configMaps: []runtime.Object{
-				newConfigMapObject("test-name1", "test-namespace"),
-				newConfigMapObject("test-name2", "test-namespace"),
-			},
-			configmapCount: 2,
-		},
-		{
-			name:       "includes multiple namespaces",
-			withClient: true,
-			configMaps: []runtime.Object{
-				newConfigMapObject("test-name1", "test-namespace"),
-				newConfigMapObject("test-name2", "test-namespace2"),
-			},
-			configmapCount: 2,
-		},
-		{
-			name:          "rejects nil client",
-			withClient:    false,
-			expectedError: "the apiClient cannot be nil",
-		},
-	}
-
-	for _, testCase := range testCases {
-		testCase := testCase
-
-		t.Run(testCase.name, func(t *testing.T) {
-			t.Parallel()
-
-			var testSettings *clients.Settings
-
-			if testCase.withClient {
-				testSettings = clients.GetTestClients(clients.TestClientParams{
-					K8sMockObjects: testCase.configMaps,
-				})
-			}
-
-			configmapBuilders, err := ListInAllNamespaces(testSettings)
-
-			if testCase.expectedError != "" {
-				require.Error(t, err)
-				assert.EqualError(t, err, testCase.expectedError)
-				assert.Nil(t, configmapBuilders)
-
-				return
-			}
-
-			require.NoError(t, err)
-			assert.Len(t, configmapBuilders, testCase.configmapCount)
-
-			for _, builder := range configmapBuilders {
-				require.NotNil(t, builder)
-				require.NotNil(t, builder.GetClient())
-				require.NotNil(t, builder.GetDefinition())
-				require.NotNil(t, builder.GetObject())
-				assert.Equal(t, configMapGVK, builder.GetGVK())
-			}
-		})
-	}
-}
-
-// newConfigMapObject returns a ConfigMap runtime object for list tests.
-func newConfigMapObject(name, namespace string) *corev1.ConfigMap {
-	return &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
-	}
+	testhelper.NewListTestConfig(
+		ListInAllNamespaces,
+		corev1.AddToScheme,
+		configMapGVK,
+	).ExecuteTests(t)
 }

--- a/pkg/internal/common/common.go
+++ b/pkg/internal/common/common.go
@@ -11,6 +11,9 @@ import (
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/logging"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog/v2"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -602,6 +605,43 @@ func ConvertListOptionsToOptions(options []runtimeclient.ListOptions) []runtimec
 	}
 
 	return listOptions
+}
+
+// ConvertMetaListOptionsToListOptions converts a slice of metav1.ListOptions to a slice of runtimeclient.ListOption. It
+// parses the LabelSelector and FieldSelector strings into their strongly-typed equivalents and copies Limit and
+// Continue directly. Fields such as ResourceVersion, TimeoutSeconds, and Watch have no first-class equivalents in
+// runtimeclient.ListOptions and are intentionally not carried over.
+func ConvertMetaListOptionsToListOptions(options []metav1.ListOptions) ([]runtimeclient.ListOption, error) {
+	listOptions := make([]runtimeclient.ListOption, 0, len(options))
+
+	for _, option := range options {
+		runtimeOption := &runtimeclient.ListOptions{}
+
+		if option.LabelSelector != "" {
+			selector, err := labels.Parse(option.LabelSelector)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse label selector %q: %w", option.LabelSelector, err)
+			}
+
+			runtimeOption.LabelSelector = selector
+		}
+
+		if option.FieldSelector != "" {
+			selector, err := fields.ParseSelector(option.FieldSelector)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse field selector %q: %w", option.FieldSelector, err)
+			}
+
+			runtimeOption.FieldSelector = selector
+		}
+
+		runtimeOption.Limit = option.Limit
+		runtimeOption.Continue = option.Continue
+
+		listOptions = append(listOptions, runtimeOption)
+	}
+
+	return listOptions, nil
 }
 
 // AdditionalOption is a constraint satisfied by any named function type whose underlying type is

--- a/pkg/internal/common/common_test.go
+++ b/pkg/internal/common/common_test.go
@@ -7,7 +7,9 @@ import (
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common/testhelper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -165,6 +167,89 @@ func TestConvertListOptionsToOptions(t *testing.T) {
 			for i, option := range options {
 				_, ok := option.(*runtimeclient.ListOptions)
 				assert.Truef(t, ok, "option %d is not a runtimeclient.ListOptions", i)
+			}
+		})
+	}
+}
+
+func TestConvertMetaListOptionsToListOptions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("single option with all fields populated", func(t *testing.T) {
+		t.Parallel()
+
+		result, err := common.ConvertMetaListOptionsToListOptions([]metav1.ListOptions{{
+			LabelSelector: "app=foo",
+			FieldSelector: "metadata.name=bar",
+			Limit:         10,
+			Continue:      "token",
+		}})
+
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+
+		runtimeOption, ok := result[0].(*runtimeclient.ListOptions)
+		require.True(t, ok, "option should be *runtimeclient.ListOptions")
+
+		assert.Nil(t, runtimeOption.Raw)
+		assert.NotNil(t, runtimeOption.LabelSelector)
+		assert.NotNil(t, runtimeOption.FieldSelector)
+		assert.Equal(t, int64(10), runtimeOption.Limit)
+		assert.Equal(t, "token", runtimeOption.Continue)
+	})
+
+	testCases := []struct {
+		name          string
+		options       []metav1.ListOptions
+		expectedLen   int
+		expectedError bool
+	}{
+		{
+			name:        "empty input returns empty slice",
+			options:     nil,
+			expectedLen: 0,
+		},
+		{
+			name:          "invalid label selector returns error",
+			options:       []metav1.ListOptions{{LabelSelector: "app in (foo"}},
+			expectedError: true,
+		},
+		{
+			name:          "invalid field selector returns error",
+			options:       []metav1.ListOptions{{FieldSelector: "a b"}},
+			expectedError: true,
+		},
+		{
+			name: "multiple options converted independently",
+			options: []metav1.ListOptions{
+				{LabelSelector: "app=foo", Limit: 5},
+				{LabelSelector: "app=bar", Limit: 10},
+			},
+			expectedLen: 2,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := common.ConvertMetaListOptionsToListOptions(testCase.options)
+
+			if testCase.expectedError {
+				assert.Error(t, err)
+				assert.Nil(t, result)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Len(t, result, testCase.expectedLen)
+
+			for _, opt := range result {
+				rtOpt, ok := opt.(*runtimeclient.ListOptions)
+				require.True(t, ok, "option should be *runtimeclient.ListOptions")
+
+				assert.Nil(t, rtOpt.Raw)
 			}
 		})
 	}

--- a/pkg/namespace/list.go
+++ b/pkg/namespace/list.go
@@ -1,58 +1,21 @@
 package namespace
 
 import (
-	"fmt"
+	"context"
 
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/logging"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog/v2"
 )
 
 // List returns namespace inventory.
 func List(apiClient *clients.Settings, options ...metav1.ListOptions) ([]*Builder, error) {
-	logMessage := "Listing all namespace resources"
-	passedOptions := metav1.ListOptions{}
-
-	if len(options) > 1 {
-		klog.V(100).Info("'options' parameter must be empty or single-valued")
-
-		return nil, fmt.Errorf("error: more than one ListOptions was passed")
-	}
-
-	if len(options) == 1 {
-		passedOptions = options[0]
-		logMessage += fmt.Sprintf(" with the options %v", passedOptions)
-	}
-
-	klog.V(100).Infof("%v", logMessage)
-
-	namespacesList, err := apiClient.CoreV1Interface.Namespaces().List(logging.DiscardContext(), passedOptions)
+	convertedOptions, err := common.ConvertMetaListOptionsToListOptions(options)
 	if err != nil {
-		klog.V(100).Infof("Failed to list namespaces due to %s", err.Error())
-
 		return nil, err
 	}
 
-	var namespaceObjects []*Builder
-
-	for _, runningNamespace := range namespacesList.Items {
-		copiedNamespace := runningNamespace
-		namespaceObjects = append(namespaceObjects, newListedBuilder(apiClient, &copiedNamespace))
-	}
-
-	return namespaceObjects, nil
-}
-
-// newListedBuilder returns a fully initialized builder for a namespace obtained through a list call.
-func newListedBuilder(apiClient *clients.Settings, namespace *corev1.Namespace) *Builder {
-	builder := &Builder{}
-	builder.AttachMixins()
-	builder.SetClient(apiClient)
-	builder.SetGVK(builder.GetGVK())
-	builder.SetObject(namespace)
-	builder.SetDefinition(namespace)
-
-	return builder
+	return common.List[corev1.Namespace, corev1.NamespaceList, Builder](
+		context.TODO(), apiClient, corev1.AddToScheme, convertedOptions...)
 }

--- a/pkg/namespace/namespace_test.go
+++ b/pkg/namespace/namespace_test.go
@@ -15,17 +15,25 @@ var namespaceGVK = corev1.SchemeGroupVersion.WithKind("Namespace")
 func TestNewBuilder(t *testing.T) {
 	t.Parallel()
 
-	testhelper.NewClusterScopedBuilderTestConfig[corev1.Namespace, Builder](
-		NewBuilder, corev1.AddToScheme, namespaceGVK).
+	testhelper.NewClusterScopedBuilderTestConfig(NewBuilder, corev1.AddToScheme, namespaceGVK).
 		ExecuteTests(t)
 }
 
 func TestPull(t *testing.T) {
 	t.Parallel()
 
-	testhelper.NewClusterScopedPullTestConfig[corev1.Namespace, Builder](
-		Pull, corev1.AddToScheme, namespaceGVK).
+	testhelper.NewClusterScopedPullTestConfig(Pull, corev1.AddToScheme, namespaceGVK).
 		ExecuteTests(t)
+}
+
+func TestList(t *testing.T) {
+	t.Parallel()
+
+	testhelper.NewListTestConfig(
+		List,
+		corev1.AddToScheme,
+		namespaceGVK,
+	).ExecuteTests(t)
 }
 
 func TestBuilderMethods(t *testing.T) {


### PR DESCRIPTION
This commit adds a helper for converting metav1.ListOptions into
runtimeclient.ListOptions. Builders for core resources like configmap or
namespace did not use the controller-runtime client prior to the common
builder migration, so their List functions used the metav1 options
rather than the runtimeclient ones. To keep the signatures the same, we
have to introduce a conversion helper.

The only risk here is for callers which used options that are not
supported by the controller-runtime client. These options relate to
watching and a timeout. However, the only places they are used in
eco-gotests they behave as no-ops, so this change will not impact them.

Depends-on: #1496 

Assisted-by: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved listing behavior for namespaces and config maps, including better handling of empty namespace input and selector-based filtering.
  * Made list operations more consistent across views, with support for additional list parameters like limits and continuation tokens.

* **Refactor**
  * Streamlined list retrieval to use shared logic, which should improve consistency and reduce duplicate behavior.

* **Tests**
  * Updated coverage for listing flows and selector conversion scenarios, including invalid selector handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->