### PR TITLE
cgu: refactor builders to use pkg/internal/common

### DIFF
--- a/pkg/cgu/cgu.go
+++ b/pkg/cgu/cgu.go
@@ -2,34 +2,60 @@ package cgu
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/openshift-kni/cluster-group-upgrades-operator/pkg/api/clustergroupupgrades/v1alpha1"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/logging"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/msg"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
-	goclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var conditionComplete = metav1.Condition{Type: "Succeeded", Status: metav1.ConditionTrue}
+var (
+	conditionComplete           = metav1.Condition{Type: "Succeeded", Status: metav1.ConditionTrue}
+	errInvalidCguMaxConcurrency = fmt.Errorf("CGU 'maxConcurrency' cannot be less than 1")
+	errClusterNameEmpty         = errors.New("cluster name cannot be empty")
+	errStateEmpty               = errors.New("state cannot be empty")
+)
+
+type cguObjectNotExistsError struct {
+	name      string
+	namespace string
+}
+
+func (e cguObjectNotExistsError) Error() string {
+	return fmt.Sprintf("cgu object %s does not exist in namespace %s", e.name, e.namespace)
+}
+
+func errCguObjectNotExists(name, namespace string) error {
+	return cguObjectNotExistsError{name: name, namespace: namespace}
+}
 
 // CguBuilder provides struct for the cgu object containing connection to
 // the cluster and the cgu definitions.
 type CguBuilder struct {
-	// cgu Definition, used to create the cgu object.
-	Definition *v1alpha1.ClusterGroupUpgrade
-	// created cgu object.
-	Object *v1alpha1.ClusterGroupUpgrade
-	// api client to interact with the cluster.
-	apiClient goclient.Client
-	// used to store latest error message upon defining or mutating application definition.
-	errorMsg string
+	common.EmbeddableBuilder[v1alpha1.ClusterGroupUpgrade, *v1alpha1.ClusterGroupUpgrade]
+	common.EmbeddableCreator[v1alpha1.ClusterGroupUpgrade, CguBuilder, *v1alpha1.ClusterGroupUpgrade, *CguBuilder]
+	common.EmbeddableDeleteReturner[v1alpha1.ClusterGroupUpgrade, CguBuilder, *v1alpha1.ClusterGroupUpgrade, *CguBuilder]
+	common.EmbeddableForceUpdater[v1alpha1.ClusterGroupUpgrade, CguBuilder, *v1alpha1.ClusterGroupUpgrade, *CguBuilder]
+}
+
+// AttachMixins wires the embedded CRUD mixins to this builder instance.
+func (builder *CguBuilder) AttachMixins() {
+	builder.EmbeddableCreator.SetBase(builder)
+	builder.EmbeddableDeleteReturner.SetBase(builder)
+	builder.EmbeddableForceUpdater.SetBase(builder)
+}
+
+// GetGVK returns the ClusterGroupUpgrade GVK for this builder.
+func (builder *CguBuilder) GetGVK() schema.GroupVersionKind {
+	return v1alpha1.SchemeGroupVersion.WithKind("ClusterGroupUpgrade")
 }
 
 // NewCguBuilder creates a new instance of CguBuilder.
@@ -38,56 +64,24 @@ func NewCguBuilder(apiClient *clients.Settings, name, nsname string, maxConcurre
 		"Initializing new CGU structure with the following params: name: %s, nsname: %s, maxConcurrency: %d",
 		name, nsname, maxConcurrency)
 
-	if apiClient == nil {
-		klog.V(100).Info("The apiClient for the CGU is nil")
-
-		return nil
-	}
-
-	err := apiClient.AttachScheme(v1alpha1.AddToScheme)
-	if err != nil {
-		klog.V(100).Info("Failed to add cgu v1alpha1 scheme to client schemes")
-
-		return nil
-	}
-
-	builder := &CguBuilder{
-		apiClient: apiClient.Client,
-		Definition: &v1alpha1.ClusterGroupUpgrade{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: nsname,
-			},
-			Spec: v1alpha1.ClusterGroupUpgradeSpec{
-				RemediationStrategy: &v1alpha1.RemediationStrategySpec{
-					MaxConcurrency: maxConcurrency,
-				},
-			},
-		},
-	}
-
-	if name == "" {
-		klog.V(100).Info("The name of the CGU is empty")
-
-		builder.errorMsg = "CGU 'name' cannot be empty"
-
-		return builder
-	}
-
-	if nsname == "" {
-		klog.V(100).Info("The namespace of the CGU is empty")
-
-		builder.errorMsg = "CGU 'nsname' cannot be empty"
-
+	builder := common.NewNamespacedBuilder[v1alpha1.ClusterGroupUpgrade, CguBuilder](
+		apiClient, v1alpha1.AddToScheme, name, nsname)
+	if builder.GetError() != nil {
 		return builder
 	}
 
 	if maxConcurrency < 1 {
 		klog.V(100).Info("The maxConcurrency of the CGU has a minimum of 1")
 
-		builder.errorMsg = "CGU 'maxConcurrency' cannot be less than 1"
+		builder.SetError(errInvalidCguMaxConcurrency)
 
 		return builder
+	}
+
+	builder.Definition.Spec = v1alpha1.ClusterGroupUpgradeSpec{
+		RemediationStrategy: &v1alpha1.RemediationStrategySpec{
+			MaxConcurrency: maxConcurrency,
+		},
 	}
 
 	return builder
@@ -95,14 +89,14 @@ func NewCguBuilder(apiClient *clients.Settings, name, nsname string, maxConcurre
 
 // WithCluster appends a cluster to the clusters list in the CGU definition.
 func (builder *CguBuilder) WithCluster(cluster string) *CguBuilder {
-	if valid, _ := builder.validate(); !valid {
+	if err := common.Validate(builder); err != nil {
 		return builder
 	}
 
 	if cluster == "" {
 		klog.V(100).Info("The cluster to be added to the CGU is empty")
 
-		builder.errorMsg = "cluster in CGU cluster spec cannot be empty"
+		builder.SetError(fmt.Errorf("cluster in CGU cluster spec cannot be empty"))
 
 		return builder
 	}
@@ -114,14 +108,14 @@ func (builder *CguBuilder) WithCluster(cluster string) *CguBuilder {
 
 // WithManagedPolicy appends a policies to the managed policies list in the CGU definition.
 func (builder *CguBuilder) WithManagedPolicy(policy string) *CguBuilder {
-	if valid, _ := builder.validate(); !valid {
+	if err := common.Validate(builder); err != nil {
 		return builder
 	}
 
 	if policy == "" {
 		klog.V(100).Info("The policy to be added to the CGU's ManagedPolicies is empty")
 
-		builder.errorMsg = "policy in CGU managedpolicies spec cannot be empty"
+		builder.SetError(fmt.Errorf("policy in CGU managedpolicies spec cannot be empty"))
 
 		return builder
 	}
@@ -133,14 +127,14 @@ func (builder *CguBuilder) WithManagedPolicy(policy string) *CguBuilder {
 
 // WithCanary appends a canary to the RemediationStrategy canaries list in the CGU definition.
 func (builder *CguBuilder) WithCanary(canary string) *CguBuilder {
-	if valid, _ := builder.validate(); !valid {
+	if err := common.Validate(builder); err != nil {
 		return builder
 	}
 
 	if canary == "" {
 		klog.V(100).Info("The canary to be added to the CGU's RemediationStrategy is empty")
 
-		builder.errorMsg = "canary in CGU remediationstrategy spec cannot be empty"
+		builder.SetError(fmt.Errorf("canary in CGU remediationstrategy spec cannot be empty"))
 
 		return builder
 	}
@@ -155,178 +149,13 @@ func (builder *CguBuilder) WithCanary(canary string) *CguBuilder {
 func Pull(apiClient *clients.Settings, name, nsname string) (*CguBuilder, error) {
 	klog.V(100).Infof("Pulling existing cgu name %s under namespace %s from cluster", name, nsname)
 
-	if apiClient == nil {
-		klog.V(100).Info("The apiClient is empty")
-
-		return nil, fmt.Errorf("cgu 'apiClient' cannot be empty")
-	}
-
-	err := apiClient.AttachScheme(v1alpha1.AddToScheme)
-	if err != nil {
-		klog.V(100).Info("Failed to add cgu v1alpha1 scheme to client schemes")
-
-		return nil, err
-	}
-
-	builder := CguBuilder{
-		apiClient: apiClient.Client,
-		Definition: &v1alpha1.ClusterGroupUpgrade{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: nsname,
-			},
-		},
-	}
-
-	if name == "" {
-		klog.V(100).Info("The name of the cgu is empty")
-
-		return nil, fmt.Errorf("cgu 'name' cannot be empty")
-	}
-
-	if nsname == "" {
-		klog.V(100).Info("The namespace of the cgu is empty")
-
-		return nil, fmt.Errorf("cgu 'namespace' cannot be empty")
-	}
-
-	if !builder.Exists() {
-		return nil, fmt.Errorf("cgu object %s does not exist in namespace %s", name, nsname)
-	}
-
-	builder.Definition = builder.Object
-
-	return &builder, nil
-}
-
-// Get returns ClusterGroupUpgrade object if found.
-func (builder *CguBuilder) Get() (*v1alpha1.ClusterGroupUpgrade, error) {
-	if valid, err := builder.validate(); !valid {
-		return nil, err
-	}
-
-	klog.V(100).Infof(
-		"Collecting clusterGroupUpgrade object %s in namespace %s",
-		builder.Definition.Name, builder.Definition.Namespace)
-
-	clusterGroupUpgrade := &v1alpha1.ClusterGroupUpgrade{}
-
-	err := builder.apiClient.Get(logging.DiscardContext(),
-		goclient.ObjectKey{Name: builder.Definition.Name, Namespace: builder.Definition.Namespace},
-		clusterGroupUpgrade)
-	if err != nil {
-		klog.V(100).Infof(
-			"clusterGroupUpgrade object %s does not exist in namespace %s",
-			builder.Definition.Name, builder.Definition.Namespace)
-
-		return nil, err
-	}
-
-	return clusterGroupUpgrade, nil
-}
-
-// Exists checks whether the given cgu exists.
-func (builder *CguBuilder) Exists() bool {
-	if valid, _ := builder.validate(); !valid {
-		return false
-	}
-
-	klog.V(100).Infof("Checking if cgu %s exists in namespace %s",
-		builder.Definition.Name, builder.Definition.Namespace)
-
-	var err error
-
-	builder.Object, err = builder.Get()
-
-	return err == nil || !k8serrors.IsNotFound(err)
-}
-
-// Create makes a cgu in the cluster and stores the created object in struct.
-func (builder *CguBuilder) Create() (*CguBuilder, error) {
-	if valid, err := builder.validate(); !valid {
-		return builder, err
-	}
-
-	klog.V(100).Infof("Creating the cgu %s in namespace %s",
-		builder.Definition.Name, builder.Definition.Namespace)
-
-	var err error
-	if !builder.Exists() {
-		err = builder.apiClient.Create(logging.DiscardContext(), builder.Definition)
-		if err != nil {
-			klog.V(100).Info("Failed to create clusterGroupUpgrade")
-
-			return nil, err
-		}
-	}
-
-	builder.Object = builder.Definition
-
-	return builder, err
-}
-
-// Delete removes a cgu from a cluster.
-func (builder *CguBuilder) Delete() (*CguBuilder, error) {
-	if valid, err := builder.validate(); !valid {
-		return builder, err
-	}
-
-	klog.V(100).Infof("Deleting the cgu %s in namespace %s",
-		builder.Definition.Name, builder.Definition.Namespace)
-
-	if !builder.Exists() {
-		klog.V(100).Infof("cgu %s in namespace %s does not exist",
-			builder.Definition.Name, builder.Definition.Namespace)
-
-		builder.Object = nil
-
-		return builder, nil
-	}
-
-	err := builder.apiClient.Delete(logging.DiscardContext(), builder.Definition)
-	if err != nil {
-		return builder, fmt.Errorf("can not delete cgu: %w", err)
-	}
-
-	builder.Object = nil
-
-	return builder, nil
-}
-
-// Update renovates the existing cgu object with the cgu definition in builder.
-func (builder *CguBuilder) Update(force bool) (*CguBuilder, error) {
-	if valid, err := builder.validate(); !valid {
-		return builder, err
-	}
-
-	klog.V(100).Infof("Updating the cgu object %s", builder.Definition.Name)
-
-	err := builder.apiClient.Update(logging.DiscardContext(), builder.Definition)
-	if err == nil {
-		builder.Object = builder.Definition
-	} else if force {
-		klog.V(100).Infof("%v", msg.FailToUpdateNotification("cgu", builder.Definition.Name))
-
-		// Deleting the cgu may take time, so wait for it to be deleted before recreating. Otherwise,
-		// the create happens before the delete finishes and this update results in just deletion.
-		builder, err := builder.DeleteAndWait(time.Minute)
-		builder.Definition.ResourceVersion = ""
-
-		if err != nil {
-			klog.V(100).Infof("%v", msg.FailToUpdateError("cgu", builder.Definition.Name))
-
-			return nil, err
-		}
-
-		return builder.Create()
-	}
-
-	return builder, err
+	return common.PullNamespacedBuilder[v1alpha1.ClusterGroupUpgrade, CguBuilder](
+		context.TODO(), apiClient, v1alpha1.AddToScheme, name, nsname)
 }
 
 // DeleteAndWait deletes the cgu object and waits until the cgu is deleted.
 func (builder *CguBuilder) DeleteAndWait(timeout time.Duration) (*CguBuilder, error) {
-	if valid, err := builder.validate(); !valid {
+	if err := common.Validate(builder); err != nil {
 		return builder, err
 	}
 
@@ -345,7 +174,7 @@ func (builder *CguBuilder) DeleteAndWait(timeout time.Duration) (*CguBuilder, er
 
 // WaitUntilDeleted waits for the duration of the defined timeout or until the cgu is deleted.
 func (builder *CguBuilder) WaitUntilDeleted(timeout time.Duration) error {
-	if valid, err := builder.validate(); !valid {
+	if err := common.Validate(builder); err != nil {
 		return err
 	}
 
@@ -378,15 +207,14 @@ func (builder *CguBuilder) WaitUntilDeleted(timeout time.Duration) error {
 // Reason, and Message fields. For the message field, it matches if the message contains the expected. Zero fields in
 // the expected condition are ignored.
 func (builder *CguBuilder) WaitForCondition(expected metav1.Condition, timeout time.Duration) (*CguBuilder, error) {
-	if valid, err := builder.validate(); !valid {
+	if err := common.Validate(builder); err != nil {
 		return builder, err
 	}
 
 	if !builder.Exists() {
 		klog.V(100).Info("The CGU does not exist on the cluster")
 
-		return builder, fmt.Errorf(
-			"cgu object %s does not exist in namespace %s", builder.Definition.Name, builder.Definition.Namespace)
+		return builder, errCguObjectNotExists(builder.Definition.Name, builder.Definition.Namespace)
 	}
 
 	err := wait.PollUntilContextTimeout(
@@ -435,20 +263,20 @@ func (builder *CguBuilder) WaitUntilComplete(timeout time.Duration) (*CguBuilder
 
 // WaitUntilClusterInState waits the specified timeout for a cluster in the CGU to be in the specified state.
 func (builder *CguBuilder) WaitUntilClusterInState(cluster, state string, timeout time.Duration) (*CguBuilder, error) {
-	if valid, err := builder.validate(); !valid {
+	if err := common.Validate(builder); err != nil {
 		return nil, err
 	}
 
 	if cluster == "" {
 		klog.V(100).Info("Cluster name cannot be empty")
 
-		return nil, fmt.Errorf("cluster name cannot be empty")
+		return nil, errClusterNameEmpty
 	}
 
 	if state == "" {
 		klog.V(100).Info("State cannot be empty")
 
-		return nil, fmt.Errorf("state cannot be empty")
+		return nil, errStateEmpty
 	}
 
 	klog.V(100).Infof(
@@ -456,8 +284,7 @@ func (builder *CguBuilder) WaitUntilClusterInState(cluster, state string, timeou
 		cluster, builder.Definition.Name, builder.Definition.Namespace, state)
 
 	if !builder.Exists() {
-		return nil, fmt.Errorf(
-			"cgu object %s does not exist in namespace %s", builder.Definition.Name, builder.Definition.Namespace)
+		return nil, errCguObjectNotExists(builder.Definition.Name, builder.Definition.Namespace)
 	}
 
 	var err error
@@ -499,7 +326,7 @@ func (builder *CguBuilder) WaitUntilClusterInProgress(cluster string, timeout ti
 
 // WaitUntilBackupStarts waits the specified timeout for the backup to start.
 func (builder *CguBuilder) WaitUntilBackupStarts(timeout time.Duration) (*CguBuilder, error) {
-	if valid, err := builder.validate(); !valid {
+	if err := common.Validate(builder); err != nil {
 		return builder, err
 	}
 
@@ -509,7 +336,7 @@ func (builder *CguBuilder) WaitUntilBackupStarts(timeout time.Duration) (*CguBui
 	if !builder.Exists() {
 		klog.V(100).Info("The CGU does not exist on the cluster")
 
-		return builder, fmt.Errorf("%s", builder.errorMsg)
+		return builder, errCguObjectNotExists(builder.Definition.Name, builder.Definition.Namespace)
 	}
 
 	var err error
@@ -534,36 +361,4 @@ func (builder *CguBuilder) WaitUntilBackupStarts(timeout time.Duration) (*CguBui
 		builder.Definition.Name, builder.Definition.Namespace, err)
 
 	return nil, err
-}
-
-// validate will check that the builder and builder definition are properly initialized before
-// accessing any member fields.
-func (builder *CguBuilder) validate() (bool, error) {
-	resourceCRD := "cgu"
-
-	if builder == nil {
-		klog.V(100).Infof("The %s builder is uninitialized", resourceCRD)
-
-		return false, fmt.Errorf("error: received nil %s builder", resourceCRD)
-	}
-
-	if builder.Definition == nil {
-		klog.V(100).Infof("The %s is undefined", resourceCRD)
-
-		return false, fmt.Errorf("%s", msg.UndefinedCrdObjectErrString(resourceCRD))
-	}
-
-	if builder.apiClient == nil {
-		klog.V(100).Infof("The %s builder apiclient is nil", resourceCRD)
-
-		return false, fmt.Errorf("%s builder cannot have nil apiClient", resourceCRD)
-	}
-
-	if builder.errorMsg != "" {
-		klog.V(100).Infof("The %s builder has error message: %s", resourceCRD, builder.errorMsg)
-
-		return false, fmt.Errorf("%s", builder.errorMsg)
-	}
-
-	return true, nil
 }

--- a/pkg/cgu/cgu_test.go
+++ b/pkg/cgu/cgu_test.go
@@ -8,7 +8,9 @@ import (
 
 	"github.com/openshift-kni/cluster-group-upgrades-operator/pkg/api/clustergroupupgrades/v1alpha1"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common/testhelper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -22,428 +24,301 @@ var (
 	defaultCguCondition      = conditionComplete
 )
 
-var (
-	testSchemes = []clients.SchemeAttacher{
-		v1alpha1.AddToScheme,
-	}
-)
+var cguGVK = v1alpha1.SchemeGroupVersion.WithKind("ClusterGroupUpgrade")
 
 func TestPullCgu(t *testing.T) {
-	generateCgu := func(name, namespace string) *v1alpha1.ClusterGroupUpgrade {
-		return &v1alpha1.ClusterGroupUpgrade{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: namespace,
-			},
-			Spec: v1alpha1.ClusterGroupUpgradeSpec{},
-		}
-	}
+	t.Parallel()
 
-	testCases := []struct {
-		cguName             string
-		cguNamespace        string
-		expectedError       bool
-		addToRuntimeObjects bool
-		expectedErrorText   string
-		client              bool
-	}{
-		{
-			cguName:             "test1",
-			cguNamespace:        "test-namespace",
-			expectedError:       false,
-			addToRuntimeObjects: true,
-			client:              true,
-		},
-		{
-			cguName:             "test2",
-			cguNamespace:        "test-namespace",
-			expectedError:       true,
-			addToRuntimeObjects: false,
-			expectedErrorText:   "cgu object test2 does not exist in namespace test-namespace",
-			client:              true,
-		},
-		{
-			cguName:             "",
-			cguNamespace:        "test-namespace",
-			expectedError:       true,
-			addToRuntimeObjects: false,
-			expectedErrorText:   "cgu 'name' cannot be empty",
-			client:              true,
-		},
-		{
-			cguName:             "test3",
-			cguNamespace:        "",
-			expectedError:       true,
-			addToRuntimeObjects: false,
-			expectedErrorText:   "cgu 'namespace' cannot be empty",
-			client:              true,
-		},
-		{
-			cguName:             "test3",
-			cguNamespace:        "test-namespace",
-			expectedError:       true,
-			addToRuntimeObjects: false,
-			expectedErrorText:   "cgu 'apiClient' cannot be empty",
-			client:              false,
-		},
-	}
-	for _, testCase := range testCases {
-		// Pre-populate the runtime objects
-		var runtimeObjects []runtime.Object
-
-		var testSettings *clients.Settings
-
-		testCgu := generateCgu(testCase.cguName, testCase.cguNamespace)
-
-		if testCase.addToRuntimeObjects {
-			runtimeObjects = append(runtimeObjects, testCgu)
-		}
-
-		if testCase.client {
-			testSettings = clients.GetTestClients(clients.TestClientParams{
-				K8sMockObjects:  runtimeObjects,
-				SchemeAttachers: testSchemes,
-			})
-		}
-
-		// Test the Pull method
-		builderResult, err := Pull(testSettings, testCgu.Name, testCgu.Namespace)
-
-		// Check the error
-		if testCase.expectedError {
-			assert.NotNil(t, err)
-
-			// Check the error message
-			if testCase.expectedErrorText != "" {
-				assert.Equal(t, testCase.expectedErrorText, err.Error())
-			}
-		} else {
-			assert.Nil(t, err)
-			assert.Equal(t, testCgu.Name, builderResult.Object.Name)
-			assert.Equal(t, testCgu.Namespace, builderResult.Object.Namespace)
-		}
-	}
+	testhelper.NewNamespacedPullTestConfig(Pull, v1alpha1.AddToScheme, cguGVK).ExecuteTests(t)
 }
 
 func TestNewCguBuilder(t *testing.T) {
-	generateCguBuilder := NewCguBuilder
+	t.Parallel()
 
-	testCases := []struct {
-		cguName           string
-		cguNamespace      string
-		cguMaxConcurrency int
-		client            bool
-		expectedErrorText string
-	}{
-		{
-			cguName:           "test1",
-			cguNamespace:      "test-namespace",
-			cguMaxConcurrency: 1,
-			client:            true,
-			expectedErrorText: "",
-		},
-		{
-			cguName:           "",
-			cguNamespace:      "test-namespace",
-			cguMaxConcurrency: 1,
-			client:            true,
-			expectedErrorText: "CGU 'name' cannot be empty",
-		},
-		{
-			cguName:           "test1",
-			cguNamespace:      "",
-			cguMaxConcurrency: 1,
-			client:            true,
-			expectedErrorText: "CGU 'nsname' cannot be empty",
-		},
-		{
-			cguName:           "test1",
-			cguNamespace:      "test-namespace",
-			cguMaxConcurrency: 0,
-			client:            true,
-			expectedErrorText: "CGU 'maxConcurrency' cannot be less than 1",
-		},
-		{
-			cguName:           "test1",
-			cguNamespace:      "test-namespace",
-			cguMaxConcurrency: 1,
-			client:            false,
-			expectedErrorText: "CGU 'apiClient' cannot be nil",
-		},
-	}
+	t.Run("common namespaced builder behavior", func(t *testing.T) {
+		t.Parallel()
 
-	for _, testCase := range testCases {
-		var testSettings *clients.Settings
+		testhelper.NewNamespacedBuilderTestConfig(
+			func(apiClient *clients.Settings, name, nsname string) *CguBuilder {
+				return NewCguBuilder(apiClient, name, nsname, defaultCguMaxConcurrency)
+			},
+			v1alpha1.AddToScheme,
+			cguGVK,
+		).ExecuteTests(t)
+	})
 
-		if testCase.client {
-			testSettings = clients.GetTestClients(clients.TestClientParams{})
-		}
+	t.Run("maxConcurrency less than 1 returns error", func(t *testing.T) {
+		t.Parallel()
 
-		testCguStructure := generateCguBuilder(
-			testSettings,
-			testCase.cguName,
-			testCase.cguNamespace,
-			testCase.cguMaxConcurrency)
+		testBuilder := NewCguBuilder(
+			clients.GetTestClients(clients.TestClientParams{}),
+			defaultCguName,
+			defaultCguNsName,
+			0,
+		)
 
-		if testCase.client {
-			assert.NotNil(t, testCguStructure)
-			assert.Equal(t, testCase.expectedErrorText, testCguStructure.errorMsg)
-		} else {
-			assert.Nil(t, testCguStructure)
-		}
-	}
+		assert.Equal(t, errInvalidCguMaxConcurrency, testBuilder.GetError())
+	})
+
+	t.Run("valid maxConcurrency sets remediation strategy", func(t *testing.T) {
+		t.Parallel()
+
+		testBuilder := NewCguBuilder(
+			clients.GetTestClients(clients.TestClientParams{}),
+			defaultCguName,
+			defaultCguNsName,
+			defaultCguMaxConcurrency,
+		)
+
+		require.NoError(t, testBuilder.GetError())
+		require.NotNil(t, testBuilder.Definition.Spec.RemediationStrategy)
+		assert.Equal(t, defaultCguMaxConcurrency, testBuilder.Definition.Spec.RemediationStrategy.MaxConcurrency)
+	})
+}
+
+func TestCguBuilderMethods(t *testing.T) {
+	t.Parallel()
+
+	commonTestConfig := testhelper.NewCommonTestConfig[v1alpha1.ClusterGroupUpgrade, CguBuilder](
+		v1alpha1.AddToScheme,
+		cguGVK,
+		testhelper.ResourceScopeNamespaced,
+	)
+
+	testhelper.NewTestSuite().
+		With(testhelper.NewGetTestConfig(commonTestConfig)).
+		With(testhelper.NewExistsTestConfig(commonTestConfig)).
+		With(testhelper.NewCreateTestConfig(commonTestConfig)).
+		With(testhelper.NewDeleteReturnerTestConfig(commonTestConfig)).
+		With(testhelper.NewForceUpdateTestConfig(commonTestConfig)).
+		Run(t)
 }
 
 func TestCguWithCluster(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
-		cluster           string
-		expectedErrorText string
+		name          string
+		cluster       string
+		expectedError error
 	}{
 		{
-			cluster:           "test-cluster",
-			expectedErrorText: "",
+			name:          "non-empty cluster appends to spec",
+			cluster:       "test-cluster",
+			expectedError: nil,
 		},
 		{
-			cluster:           "",
-			expectedErrorText: "cluster in CGU cluster spec cannot be empty",
+			name:          "empty cluster returns error",
+			cluster:       "",
+			expectedError: fmt.Errorf("cluster in CGU cluster spec cannot be empty"),
 		},
 	}
 
 	for _, testCase := range testCases {
-		testSettings := buildTestClientWithDummyCguObject()
-		cguBuilder := buildValidCguTestBuilder(testSettings).WithCluster(testCase.cluster)
-		assert.Equal(t, testCase.expectedErrorText, cguBuilder.errorMsg)
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 
-		if testCase.expectedErrorText == "" {
-			assert.Equal(t, cguBuilder.Definition.Spec.Clusters, []string{testCase.cluster})
-		}
+			testBuilder := buildValidCguTestBuilder(buildTestClientWithDummyCguObject())
+			testBuilder.WithCluster(testCase.cluster)
+
+			assert.Equal(t, testCase.expectedError, testBuilder.GetError())
+
+			if testCase.expectedError == nil {
+				assert.Equal(t, []string{testCase.cluster}, testBuilder.Definition.Spec.Clusters)
+			}
+		})
 	}
+
+	t.Run("invalid builder short-circuits", func(t *testing.T) {
+		t.Parallel()
+
+		testBuilder := buildInvalidCguTestBuilder(buildTestClientWithDummyCguObject())
+		testBuilder.WithCluster("test-cluster")
+
+		assert.Equal(t, errInvalidCguMaxConcurrency, testBuilder.GetError())
+	})
 }
 
 func TestCguWithManagedPolicy(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
-		policy            string
-		expectedErrorText string
+		name          string
+		policy        string
+		expectedError error
 	}{
 		{
-			policy:            "test-policy",
-			expectedErrorText: "",
+			name:          "non-empty policy appends to spec",
+			policy:        "test-policy",
+			expectedError: nil,
 		},
 		{
-			policy:            "",
-			expectedErrorText: "policy in CGU managedpolicies spec cannot be empty",
+			name:          "empty policy returns error",
+			policy:        "",
+			expectedError: fmt.Errorf("policy in CGU managedpolicies spec cannot be empty"),
 		},
 	}
 
 	for _, testCase := range testCases {
-		testSettings := buildTestClientWithDummyCguObject()
-		cguBuilder := buildValidCguTestBuilder(testSettings).WithManagedPolicy(testCase.policy)
-		assert.Equal(t, testCase.expectedErrorText, cguBuilder.errorMsg)
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 
-		if testCase.expectedErrorText == "" {
-			assert.Equal(t, cguBuilder.Definition.Spec.ManagedPolicies, []string{testCase.policy})
-		}
+			testBuilder := buildValidCguTestBuilder(buildTestClientWithDummyCguObject())
+			testBuilder.WithManagedPolicy(testCase.policy)
+
+			assert.Equal(t, testCase.expectedError, testBuilder.GetError())
+
+			if testCase.expectedError == nil {
+				assert.Equal(t, []string{testCase.policy}, testBuilder.Definition.Spec.ManagedPolicies)
+			}
+		})
 	}
+
+	t.Run("invalid builder short-circuits", func(t *testing.T) {
+		t.Parallel()
+
+		testBuilder := buildInvalidCguTestBuilder(buildTestClientWithDummyCguObject())
+		testBuilder.WithManagedPolicy("test-policy")
+
+		assert.Equal(t, errInvalidCguMaxConcurrency, testBuilder.GetError())
+	})
 }
 
 func TestCguWithCanary(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
-		canary            string
-		expectedErrorText string
-	}{
-		{
-			canary:            "test-canary",
-			expectedErrorText: "",
-		},
-		{
-			canary:            "",
-			expectedErrorText: "canary in CGU remediationstrategy spec cannot be empty",
-		},
-	}
-
-	for _, testCase := range testCases {
-		testSettings := buildTestClientWithDummyCguObject()
-		cguBuilder := buildValidCguTestBuilder(testSettings).WithCanary(testCase.canary)
-		assert.Equal(t, testCase.expectedErrorText, cguBuilder.errorMsg)
-
-		if testCase.expectedErrorText == "" {
-			assert.Equal(t, cguBuilder.Definition.Spec.RemediationStrategy.Canaries, []string{testCase.canary})
-		}
-	}
-}
-
-func TestCguCreate(t *testing.T) {
-	testCases := []struct {
-		testCgu       *CguBuilder
+		name          string
+		canary        string
 		expectedError error
 	}{
 		{
-			testCgu:       buildValidCguTestBuilder(buildTestClientWithDummyCguObject()),
+			name:          "non-empty canary appends to spec",
+			canary:        "test-canary",
 			expectedError: nil,
 		},
 		{
-			testCgu:       buildInvalidCguTestBuilder(buildTestClientWithDummyCguObject()),
-			expectedError: fmt.Errorf("CGU 'nsname' cannot be empty"),
+			name:          "empty canary returns error",
+			canary:        "",
+			expectedError: fmt.Errorf("canary in CGU remediationstrategy spec cannot be empty"),
 		},
 	}
 
 	for _, testCase := range testCases {
-		cguBuilder, err := testCase.testCgu.Create()
-		assert.Equal(t, testCase.expectedError, err)
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 
-		if testCase.expectedError == nil {
-			assert.Equal(t, cguBuilder.Definition, cguBuilder.Object)
-		}
-	}
-}
+			testBuilder := buildValidCguTestBuilder(buildTestClientWithDummyCguObject())
+			testBuilder.WithCanary(testCase.canary)
 
-func TestCguDelete(t *testing.T) {
-	testCases := []struct {
-		testCgu       *CguBuilder
-		expectedError error
-	}{
-		{
-			testCgu:       buildValidCguTestBuilder(buildTestClientWithDummyCguObject()),
-			expectedError: nil,
-		},
-		{
-			testCgu:       buildValidCguTestBuilder(clients.GetTestClients(clients.TestClientParams{})),
-			expectedError: nil,
-		},
-		{
-			testCgu:       buildInvalidCguTestBuilder(buildTestClientWithDummyCguObject()),
-			expectedError: fmt.Errorf("CGU 'nsname' cannot be empty"),
-		},
+			assert.Equal(t, testCase.expectedError, testBuilder.GetError())
+
+			if testCase.expectedError == nil {
+				assert.Equal(t, []string{testCase.canary}, testBuilder.Definition.Spec.RemediationStrategy.Canaries)
+			}
+		})
 	}
 
-	for _, testCase := range testCases {
-		_, err := testCase.testCgu.Delete()
-		assert.Equal(t, testCase.expectedError, err)
+	t.Run("invalid builder short-circuits", func(t *testing.T) {
+		t.Parallel()
 
-		if testCase.expectedError == nil {
-			assert.Nil(t, testCase.testCgu.Object)
-			assert.Nil(t, testCase.testCgu.Object)
-		}
-	}
-}
+		testBuilder := buildInvalidCguTestBuilder(buildTestClientWithDummyCguObject())
+		testBuilder.WithCanary("test-canary")
 
-func TestCguExist(t *testing.T) {
-	testCases := []struct {
-		testCgu        *CguBuilder
-		expectedStatus bool
-	}{
-		{
-			testCgu:        buildValidCguTestBuilder(buildTestClientWithDummyCguObject()),
-			expectedStatus: true,
-		},
-		{
-			testCgu:        buildInvalidCguTestBuilder(buildTestClientWithDummyCguObject()),
-			expectedStatus: false,
-		},
-	}
-
-	for _, testCase := range testCases {
-		exists := testCase.testCgu.Exists()
-		assert.Equal(t, testCase.expectedStatus, exists)
-	}
-}
-
-func TestCguUpdate(t *testing.T) {
-	testCases := []struct {
-		force bool
-	}{
-		{
-			force: true,
-		},
-		{
-			force: false,
-		},
-	}
-
-	for _, testCase := range testCases {
-		// Create the builder rather than just adding it to the client so that the proper metadata is added and
-		// the update will not fail.
-		var err error
-
-		testBuilder := buildValidCguTestBuilder(clients.GetTestClients(clients.TestClientParams{}))
-		testBuilder, err = testBuilder.Create()
-		assert.Nil(t, err)
-
-		assert.NotNil(t, testBuilder.Definition)
-		assert.False(t, testBuilder.Definition.Spec.PreCaching)
-
-		testBuilder.Definition.Spec.PreCaching = true
-
-		cguBuilder, err := testBuilder.Update(testCase.force)
-		assert.NotNil(t, testBuilder.Definition)
-
-		assert.Nil(t, err)
-		assert.Equal(t, testBuilder.Definition.Name, cguBuilder.Definition.Name)
-		assert.Equal(t, testBuilder.Definition.Spec.PreCaching, cguBuilder.Definition.Spec.PreCaching)
-	}
+		assert.Equal(t, errInvalidCguMaxConcurrency, testBuilder.GetError())
+	})
 }
 
 func TestCguDeleteAndWait(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
+		name          string
 		testCgu       *CguBuilder
 		expectedError error
 	}{
 		{
+			name:          "deletes existing cgu and waits",
 			testCgu:       buildValidCguTestBuilder(buildTestClientWithDummyCguObject()),
 			expectedError: nil,
 		},
 		{
+			name:          "deletes created cgu and waits",
 			testCgu:       buildValidCguTestBuilder(clients.GetTestClients(clients.TestClientParams{})),
 			expectedError: nil,
 		},
 		{
+			name:          "invalid builder returns validation error",
 			testCgu:       buildInvalidCguTestBuilder(buildTestClientWithDummyCguObject()),
-			expectedError: fmt.Errorf("CGU 'nsname' cannot be empty"),
+			expectedError: errInvalidCguMaxConcurrency,
 		},
 	}
 
 	for _, testCase := range testCases {
-		_, err := testCase.testCgu.DeleteAndWait(time.Second)
-		assert.Equal(t, testCase.expectedError, err)
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 
-		if testCase.expectedError == nil {
-			assert.Nil(t, testCase.testCgu.Object)
-			assert.Nil(t, testCase.testCgu.Object)
-		}
+			_, err := testCase.testCgu.DeleteAndWait(time.Second)
+
+			if testCase.expectedError == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorIs(t, err, testCase.expectedError)
+			}
+
+			if testCase.expectedError == nil {
+				assert.Nil(t, testCase.testCgu.Object)
+			}
+		})
 	}
 }
 
 func TestCguWaitUntilDeleted(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
+		name          string
 		testCgu       *CguBuilder
 		expectedError error
 	}{
 		{
+			name:          "waits until deleted after delete",
 			testCgu:       buildValidCguTestBuilder(clients.GetTestClients(clients.TestClientParams{})),
 			expectedError: nil,
 		},
 		{
+			name:          "times out when cgu still exists",
 			testCgu:       buildValidCguTestBuilder(buildTestClientWithDummyCguObject()),
 			expectedError: context.DeadlineExceeded,
 		},
 		{
+			name:          "invalid builder returns validation error",
 			testCgu:       buildInvalidCguTestBuilder(buildTestClientWithDummyCguObject()),
-			expectedError: fmt.Errorf("CGU 'nsname' cannot be empty"),
+			expectedError: errInvalidCguMaxConcurrency,
 		},
 	}
 
 	for _, testCase := range testCases {
-		err := testCase.testCgu.WaitUntilDeleted(time.Second)
-		assert.Equal(t, testCase.expectedError, err)
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 
-		if testCase.expectedError == nil {
-			assert.Nil(t, testCase.testCgu.Object)
-		}
+			err := testCase.testCgu.WaitUntilDeleted(time.Second)
+
+			if testCase.expectedError == nil {
+				assert.NoError(t, err)
+				assert.Nil(t, testCase.testCgu.Object)
+			} else {
+				assert.ErrorIs(t, err, testCase.expectedError)
+			}
+		})
 	}
 }
 
 func TestCguWaitForCondition(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
+		name          string
 		condition     metav1.Condition
 		exists        bool
 		conditionMet  bool
@@ -451,6 +326,7 @@ func TestCguWaitForCondition(t *testing.T) {
 		expectedError error
 	}{
 		{
+			name:          "condition met",
 			condition:     defaultCguCondition,
 			exists:        true,
 			conditionMet:  true,
@@ -458,13 +334,15 @@ func TestCguWaitForCondition(t *testing.T) {
 			expectedError: nil,
 		},
 		{
+			name:          "cgu does not exist",
 			condition:     defaultCguCondition,
 			exists:        false,
 			conditionMet:  true,
 			valid:         true,
-			expectedError: fmt.Errorf("cgu object %s does not exist in namespace %s", defaultCguName, defaultCguNsName),
+			expectedError: errCguObjectNotExists(defaultCguName, defaultCguNsName),
 		},
 		{
+			name:          "condition not met times out",
 			condition:     defaultCguCondition,
 			exists:        true,
 			conditionMet:  false,
@@ -472,82 +350,107 @@ func TestCguWaitForCondition(t *testing.T) {
 			expectedError: context.DeadlineExceeded,
 		},
 		{
+			name:          "invalid builder returns validation error",
 			condition:     defaultCguCondition,
 			exists:        true,
 			conditionMet:  true,
 			valid:         false,
-			expectedError: fmt.Errorf("CGU 'nsname' cannot be empty"),
+			expectedError: errInvalidCguMaxConcurrency,
 		},
 	}
 
 	for _, testCase := range testCases {
-		var (
-			runtimeObjects []runtime.Object
-			cguBuilder     *CguBuilder
-		)
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 
-		if testCase.exists {
-			cgu := buildDummyCgu(defaultCguName, defaultCguNsName, defaultCguMaxConcurrency)
+			var runtimeObjects []runtime.Object
 
-			if testCase.conditionMet {
-				cgu.Status.Conditions = append(cgu.Status.Conditions, testCase.condition)
+			if testCase.exists {
+				cgu := buildDummyCgu(defaultCguName, defaultCguNsName, defaultCguMaxConcurrency)
+
+				if testCase.conditionMet {
+					cgu.Status.Conditions = append(cgu.Status.Conditions, testCase.condition)
+				}
+
+				runtimeObjects = append(runtimeObjects, cgu)
 			}
 
-			runtimeObjects = append(runtimeObjects, cgu)
-		}
+			testSettings := clients.GetTestClients(clients.TestClientParams{
+				K8sMockObjects:  runtimeObjects,
+				SchemeAttachers: []clients.SchemeAttacher{v1alpha1.AddToScheme},
+			})
 
-		testSettings := clients.GetTestClients(clients.TestClientParams{
-			K8sMockObjects:  runtimeObjects,
-			SchemeAttachers: testSchemes,
+			var cguBuilder *CguBuilder
+			if testCase.valid {
+				cguBuilder = buildValidCguTestBuilder(testSettings)
+			} else {
+				cguBuilder = buildInvalidCguTestBuilder(testSettings)
+			}
+
+			_, err := cguBuilder.WaitForCondition(testCase.condition, time.Second)
+
+			if testCase.expectedError == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorIs(t, err, testCase.expectedError)
+			}
 		})
-
-		if testCase.valid {
-			cguBuilder = buildValidCguTestBuilder(testSettings)
-		} else {
-			cguBuilder = buildInvalidCguTestBuilder(testSettings)
-		}
-
-		_, err := cguBuilder.WaitForCondition(testCase.condition, time.Second)
-		assert.Equal(t, testCase.expectedError, err)
 	}
 }
 
 func TestCguWaitUntilComplete(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
+		name          string
 		complete      bool
 		expectedError error
 	}{
 		{
+			name:          "cgu complete",
 			complete:      true,
 			expectedError: nil,
 		},
 		{
+			name:          "cgu not complete times out",
 			complete:      false,
 			expectedError: context.DeadlineExceeded,
 		},
 	}
 
 	for _, testCase := range testCases {
-		cgu := buildDummyCgu(defaultCguName, defaultCguNsName, defaultCguMaxConcurrency)
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 
-		if testCase.complete {
-			cgu.Status.Conditions = append(cgu.Status.Conditions, conditionComplete)
-		}
+			cgu := buildDummyCgu(defaultCguName, defaultCguNsName, defaultCguMaxConcurrency)
 
-		testSettings := clients.GetTestClients(clients.TestClientParams{
-			K8sMockObjects:  []runtime.Object{cgu},
-			SchemeAttachers: testSchemes,
+			if testCase.complete {
+				cgu.Status.Conditions = append(cgu.Status.Conditions, conditionComplete)
+			}
+
+			testSettings := clients.GetTestClients(clients.TestClientParams{
+				K8sMockObjects:  []runtime.Object{cgu},
+				SchemeAttachers: []clients.SchemeAttacher{v1alpha1.AddToScheme},
+			})
+
+			cguBuilder := buildValidCguTestBuilder(testSettings)
+			_, err := cguBuilder.WaitUntilComplete(time.Second)
+
+			if testCase.expectedError == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorIs(t, err, testCase.expectedError)
+			}
 		})
-
-		cguBuilder := buildValidCguTestBuilder(testSettings)
-		_, err := cguBuilder.WaitUntilComplete(time.Second)
-
-		assert.Equal(t, testCase.expectedError, err)
 	}
 }
 
+//nolint:funlen // table-driven test with multiple wait scenarios.
 func TestCguWaitUntilClusterInState(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
+		name          string
 		cluster       string
 		state         string
 		exists        bool
@@ -556,6 +459,7 @@ func TestCguWaitUntilClusterInState(t *testing.T) {
 		expectedError error
 	}{
 		{
+			name:          "cluster in state",
 			cluster:       defaultCguClusterName,
 			state:         defaultCguClusterState,
 			exists:        true,
@@ -564,30 +468,34 @@ func TestCguWaitUntilClusterInState(t *testing.T) {
 			expectedError: nil,
 		},
 		{
+			name:          "empty cluster name",
 			cluster:       "",
 			state:         defaultCguClusterState,
 			exists:        true,
 			inState:       true,
 			valid:         true,
-			expectedError: fmt.Errorf("cluster name cannot be empty"),
+			expectedError: errClusterNameEmpty,
 		},
 		{
+			name:          "empty state",
 			cluster:       defaultCguClusterName,
 			state:         "",
 			exists:        true,
 			inState:       true,
 			valid:         true,
-			expectedError: fmt.Errorf("state cannot be empty"),
+			expectedError: errStateEmpty,
 		},
 		{
+			name:          "cgu does not exist",
 			cluster:       defaultCguClusterName,
 			state:         defaultCguClusterState,
 			exists:        false,
 			inState:       true,
 			valid:         true,
-			expectedError: fmt.Errorf("cgu object %s does not exist in namespace %s", defaultCguName, defaultCguNsName),
+			expectedError: errCguObjectNotExists(defaultCguName, defaultCguNsName),
 		},
 		{
+			name:          "cluster not in state times out",
 			cluster:       defaultCguClusterName,
 			state:         defaultCguClusterState,
 			exists:        true,
@@ -596,220 +504,181 @@ func TestCguWaitUntilClusterInState(t *testing.T) {
 			expectedError: context.DeadlineExceeded,
 		},
 		{
+			name:          "invalid builder returns validation error",
 			cluster:       defaultCguClusterName,
 			state:         defaultCguClusterState,
 			exists:        true,
 			inState:       true,
 			valid:         false,
-			expectedError: fmt.Errorf("CGU 'nsname' cannot be empty"),
+			expectedError: errInvalidCguMaxConcurrency,
 		},
 	}
 
 	for _, testCase := range testCases {
-		var (
-			runtimeObjects []runtime.Object
-			cguBuilder     *CguBuilder
-		)
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 
-		if testCase.exists {
-			cgu := buildDummyCgu(defaultCguName, defaultCguNsName, defaultCguMaxConcurrency)
+			var runtimeObjects []runtime.Object
 
-			if testCase.inState {
-				cgu.Status.Status.CurrentBatchRemediationProgress = map[string]*v1alpha1.ClusterRemediationProgress{
-					testCase.cluster: {State: testCase.state},
+			if testCase.exists {
+				cgu := buildDummyCgu(defaultCguName, defaultCguNsName, defaultCguMaxConcurrency)
+
+				if testCase.inState {
+					cgu.Status.Status.CurrentBatchRemediationProgress = map[string]*v1alpha1.ClusterRemediationProgress{
+						testCase.cluster: {State: testCase.state},
+					}
 				}
+
+				runtimeObjects = append(runtimeObjects, cgu)
 			}
 
-			runtimeObjects = append(runtimeObjects, cgu)
-		}
+			testSettings := clients.GetTestClients(clients.TestClientParams{
+				K8sMockObjects:  runtimeObjects,
+				SchemeAttachers: []clients.SchemeAttacher{v1alpha1.AddToScheme},
+			})
 
-		testSettings := clients.GetTestClients(clients.TestClientParams{
-			K8sMockObjects:  runtimeObjects,
-			SchemeAttachers: testSchemes,
+			var cguBuilder *CguBuilder
+			if testCase.valid {
+				cguBuilder = buildValidCguTestBuilder(testSettings)
+			} else {
+				cguBuilder = buildInvalidCguTestBuilder(testSettings)
+			}
+
+			_, err := cguBuilder.WaitUntilClusterInState(testCase.cluster, testCase.state, time.Second)
+
+			if testCase.expectedError == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorIs(t, err, testCase.expectedError)
+			}
 		})
-
-		if testCase.valid {
-			cguBuilder = buildValidCguTestBuilder(testSettings)
-		} else {
-			cguBuilder = buildInvalidCguTestBuilder(testSettings)
-		}
-
-		_, err := cguBuilder.WaitUntilClusterInState(testCase.cluster, testCase.state, time.Second)
-		assert.Equal(t, testCase.expectedError, err)
 	}
 }
 
 func TestCguWaitUntilClusterComplete(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
+		name          string
 		complete      bool
 		expectedError error
 	}{
 		{
+			name:          "cluster complete",
 			complete:      true,
 			expectedError: nil,
 		},
 		{
+			name:          "cluster not complete times out",
 			complete:      false,
 			expectedError: context.DeadlineExceeded,
 		},
 	}
 
 	for _, testCase := range testCases {
-		cgu := buildDummyCgu(defaultCguName, defaultCguNsName, defaultCguMaxConcurrency)
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 
-		if testCase.complete {
-			cgu.Status.Status.CurrentBatchRemediationProgress = map[string]*v1alpha1.ClusterRemediationProgress{
-				defaultCguClusterName: {State: v1alpha1.Completed},
+			cgu := buildDummyCgu(defaultCguName, defaultCguNsName, defaultCguMaxConcurrency)
+
+			if testCase.complete {
+				cgu.Status.Status.CurrentBatchRemediationProgress = map[string]*v1alpha1.ClusterRemediationProgress{
+					defaultCguClusterName: {State: v1alpha1.Completed},
+				}
 			}
-		}
 
-		testSettings := clients.GetTestClients(clients.TestClientParams{
-			K8sMockObjects:  []runtime.Object{cgu},
-			SchemeAttachers: testSchemes,
+			testSettings := clients.GetTestClients(clients.TestClientParams{
+				K8sMockObjects:  []runtime.Object{cgu},
+				SchemeAttachers: []clients.SchemeAttacher{v1alpha1.AddToScheme},
+			})
+
+			cguBuilder := buildValidCguTestBuilder(testSettings)
+			_, err := cguBuilder.WaitUntilClusterComplete(defaultCguClusterName, time.Second)
+
+			if testCase.expectedError == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorIs(t, err, testCase.expectedError)
+			}
 		})
-
-		cguBuilder := buildValidCguTestBuilder(testSettings)
-		_, err := cguBuilder.WaitUntilClusterComplete(defaultCguClusterName, time.Second)
-
-		assert.Equal(t, testCase.expectedError, err)
 	}
 }
 
 func TestCguWaitUntilClusterInProgress(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
+		name          string
 		inProgress    bool
 		expectedError error
 	}{
 		{
+			name:          "cluster in progress",
 			inProgress:    true,
 			expectedError: nil,
 		},
 		{
+			name:          "cluster not in progress times out",
 			inProgress:    false,
 			expectedError: context.DeadlineExceeded,
 		},
 	}
 
 	for _, testCase := range testCases {
-		cgu := buildDummyCgu(defaultCguName, defaultCguNsName, defaultCguMaxConcurrency)
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 
-		if testCase.inProgress {
-			cgu.Status.Status.CurrentBatchRemediationProgress = map[string]*v1alpha1.ClusterRemediationProgress{
-				defaultCguClusterName: {State: v1alpha1.InProgress},
+			cgu := buildDummyCgu(defaultCguName, defaultCguNsName, defaultCguMaxConcurrency)
+
+			if testCase.inProgress {
+				cgu.Status.Status.CurrentBatchRemediationProgress = map[string]*v1alpha1.ClusterRemediationProgress{
+					defaultCguClusterName: {State: v1alpha1.InProgress},
+				}
 			}
-		}
 
-		testSettings := clients.GetTestClients(clients.TestClientParams{
-			K8sMockObjects:  []runtime.Object{cgu},
-			SchemeAttachers: testSchemes,
+			testSettings := clients.GetTestClients(clients.TestClientParams{
+				K8sMockObjects:  []runtime.Object{cgu},
+				SchemeAttachers: []clients.SchemeAttacher{v1alpha1.AddToScheme},
+			})
+
+			cguBuilder := buildValidCguTestBuilder(testSettings)
+			_, err := cguBuilder.WaitUntilClusterInProgress(defaultCguClusterName, time.Second)
+
+			if testCase.expectedError == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorIs(t, err, testCase.expectedError)
+			}
 		})
-
-		cguBuilder := buildValidCguTestBuilder(testSettings)
-		_, err := cguBuilder.WaitUntilClusterInProgress(defaultCguClusterName, time.Second)
-
-		assert.Equal(t, testCase.expectedError, err)
 	}
 }
 
 func TestWaitUntilBackupStarts(t *testing.T) {
+	t.Parallel()
+
 	cguObject := buildDummyCgu(defaultCguName, defaultCguNsName, defaultCguMaxConcurrency)
 	cguObject.Status.Backup = &v1alpha1.BackupStatus{}
 
 	cguBuilder := buildValidCguTestBuilder(clients.GetTestClients(clients.TestClientParams{
 		K8sMockObjects:  []runtime.Object{cguObject},
-		SchemeAttachers: testSchemes,
+		SchemeAttachers: []clients.SchemeAttacher{v1alpha1.AddToScheme},
 	}))
 	cguBuilder, err := cguBuilder.WaitUntilBackupStarts(5 * time.Second)
 
 	assert.Nil(t, err)
-	assert.Equal(t, cguBuilder.Object.Name, defaultCguName)
-	assert.Equal(t, cguBuilder.Object.Namespace, defaultCguNsName)
-}
-
-func TestCguBuilderValidate(t *testing.T) {
-	testCases := []struct {
-		builderNil    bool
-		definitionNil bool
-		apiClientNil  bool
-		expectedError error
-		builderErrMsg string
-	}{
-		{
-			builderNil:    false,
-			definitionNil: false,
-			apiClientNil:  false,
-			expectedError: nil,
-			builderErrMsg: "",
-		},
-		{
-			builderNil:    true,
-			definitionNil: false,
-			apiClientNil:  false,
-			expectedError: fmt.Errorf("error: received nil cgu builder"),
-			builderErrMsg: "",
-		},
-		{
-			builderNil:    false,
-			definitionNil: true,
-			apiClientNil:  false,
-			expectedError: fmt.Errorf("can not redefine the undefined cgu"),
-			builderErrMsg: "",
-		},
-		{
-			builderNil:    false,
-			definitionNil: false,
-			apiClientNil:  true,
-			expectedError: fmt.Errorf("cgu builder cannot have nil apiClient"),
-			builderErrMsg: "",
-		},
-		{
-			builderNil:    false,
-			definitionNil: false,
-			apiClientNil:  false,
-			builderErrMsg: "test error",
-			expectedError: fmt.Errorf("test error"),
-		},
-	}
-
-	for _, testCase := range testCases {
-		testBuilder := buildValidCguTestBuilder(clients.GetTestClients(clients.TestClientParams{}))
-
-		if testCase.builderNil {
-			testBuilder = nil
-		}
-
-		if testCase.definitionNil {
-			testBuilder.Definition = nil
-		}
-
-		if testCase.apiClientNil {
-			testBuilder.apiClient = nil
-		}
-
-		if testCase.builderErrMsg != "" {
-			testBuilder.errorMsg = testCase.builderErrMsg
-		}
-
-		valid, err := testBuilder.validate()
-		if testCase.expectedError != nil {
-			assert.False(t, valid)
-			assert.Equal(t, testCase.expectedError, err)
-		} else {
-			assert.True(t, valid)
-			assert.Nil(t, err)
-		}
-	}
+	assert.Equal(t, defaultCguName, cguBuilder.Object.Name)
+	assert.Equal(t, defaultCguNsName, cguBuilder.Object.Namespace)
 }
 
 func buildTestClientWithDummyCguObject() *clients.Settings {
 	return clients.GetTestClients(clients.TestClientParams{
 		K8sMockObjects:  buildDummyCguObject(),
-		SchemeAttachers: testSchemes,
+		SchemeAttachers: []clients.SchemeAttacher{v1alpha1.AddToScheme},
 	})
 }
 
 func buildDummyCguObject() []runtime.Object {
-	return append([]runtime.Object{}, buildDummyCgu(defaultCguName, defaultCguNsName, defaultCguMaxConcurrency))
+	return []runtime.Object{buildDummyCgu(defaultCguName, defaultCguNsName, defaultCguMaxConcurrency)}
 }
 
 func buildDummyCgu(name, namespace string, maxConcurrency int) *v1alpha1.ClusterGroupUpgrade {
@@ -826,20 +695,10 @@ func buildDummyCgu(name, namespace string, maxConcurrency int) *v1alpha1.Cluster
 	}
 }
 
-// buildValidCguTestBuilder returns a valid CguBuilder for testing purposes.
 func buildValidCguTestBuilder(apiClient *clients.Settings) *CguBuilder {
-	return NewCguBuilder(
-		apiClient,
-		defaultCguName,
-		defaultCguNsName,
-		defaultCguMaxConcurrency)
+	return NewCguBuilder(apiClient, defaultCguName, defaultCguNsName, defaultCguMaxConcurrency)
 }
 
-// buildinInvalidCguTestBuilder returns an invalid CguBuilder for testing purposes.
 func buildInvalidCguTestBuilder(apiClient *clients.Settings) *CguBuilder {
-	return NewCguBuilder(
-		apiClient,
-		defaultCguName,
-		"",
-		defaultCguMaxConcurrency)
+	return NewCguBuilder(apiClient, defaultCguName, defaultCguNsName, 0)
 }

--- a/pkg/cgu/cgulist.go
+++ b/pkg/cgu/cgulist.go
@@ -1,67 +1,16 @@
 package cgu
 
 import (
-	"fmt"
+	"context"
 
 	"github.com/openshift-kni/cluster-group-upgrades-operator/pkg/api/clustergroupupgrades/v1alpha1"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/logging"
-	"k8s.io/klog/v2"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // ListInAllNamespaces returns a cluster-wide cgu inventory.
 func ListInAllNamespaces(apiClient *clients.Settings, options ...client.ListOptions) ([]*CguBuilder, error) {
-	logMessage := "Listing CGUS in all namespaces"
-	passedOptions := client.ListOptions{}
-
-	if apiClient == nil {
-		klog.V(100).Info("CGUs 'apiClient' parameter can not be empty")
-
-		return nil, fmt.Errorf("failed to list cgu objects, 'apiClient' parameter is empty")
-	}
-
-	err := apiClient.AttachScheme(v1alpha1.AddToScheme)
-	if err != nil {
-		klog.V(100).Info("Failed to add cgu v1alpha1 scheme to client schemes")
-
-		return nil, err
-	}
-
-	if len(options) > 1 {
-		klog.V(100).Info("'options' parameter must be empty or single-valued")
-
-		return nil, fmt.Errorf("error: more than one ListOptions was passed")
-	}
-
-	if len(options) == 1 {
-		passedOptions = options[0]
-		logMessage += fmt.Sprintf(" with the options %v", passedOptions)
-	}
-
-	klog.V(100).Infof("%v", logMessage)
-
-	cguList := &v1alpha1.ClusterGroupUpgradeList{}
-
-	err = apiClient.List(logging.DiscardContext(), cguList, &passedOptions)
-	if err != nil {
-		klog.V(100).Infof("Failed to list all CGUs in all namespaces due to %s", err.Error())
-
-		return nil, err
-	}
-
-	var cguObjects []*CguBuilder
-
-	for _, policy := range cguList.Items {
-		copiedCgu := policy
-		cguBuilder := &CguBuilder{
-			apiClient:  apiClient.Client,
-			Object:     &copiedCgu,
-			Definition: &copiedCgu,
-		}
-
-		cguObjects = append(cguObjects, cguBuilder)
-	}
-
-	return cguObjects, nil
+	return common.List[v1alpha1.ClusterGroupUpgrade, v1alpha1.ClusterGroupUpgradeList, CguBuilder](
+		context.TODO(), apiClient, v1alpha1.AddToScheme, common.ConvertListOptionsToOptions(options)...)
 }

--- a/pkg/cgu/cgulist_test.go
+++ b/pkg/cgu/cgulist_test.go
@@ -1,62 +1,18 @@
 package cgu
 
 import (
-	"fmt"
 	"testing"
 
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
-	"github.com/stretchr/testify/assert"
+	"github.com/openshift-kni/cluster-group-upgrades-operator/pkg/api/clustergroupupgrades/v1alpha1"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common/testhelper"
 )
 
-func TestCguListInAllNamespaces(t *testing.T) {
-	testCases := []struct {
-		testCGU       []*CguBuilder
-		listOptions   []client.ListOptions
-		expectedError error
-		client        bool
-	}{
-		{
-			testCGU:       []*CguBuilder{buildValidCguTestBuilder(buildTestClientWithDummyCguObject())},
-			listOptions:   nil,
-			expectedError: nil,
-			client:        true,
-		},
-		{
-			testCGU:       []*CguBuilder{buildValidCguTestBuilder(buildTestClientWithDummyCguObject())},
-			listOptions:   []client.ListOptions{{Namespace: "test"}},
-			expectedError: nil,
-			client:        true,
-		},
-		{
-			testCGU:       []*CguBuilder{buildValidCguTestBuilder(buildTestClientWithDummyCguObject())},
-			listOptions:   []client.ListOptions{{Namespace: "test"}, {Continue: "true"}},
-			expectedError: fmt.Errorf("error: more than one ListOptions was passed"),
-			client:        true,
-		},
-		{
-			testCGU:       []*CguBuilder{buildValidCguTestBuilder(buildTestClientWithDummyCguObject())},
-			listOptions:   nil,
-			expectedError: fmt.Errorf("failed to list cgu objects, 'apiClient' parameter is empty"),
-			client:        false,
-		},
-	}
-	for _, testCase := range testCases {
-		var testSettings *clients.Settings
+func TestListInAllNamespaces(t *testing.T) {
+	t.Parallel()
 
-		if testCase.client {
-			testSettings = clients.GetTestClients(clients.TestClientParams{
-				K8sMockObjects:  buildDummyCguObject(),
-				SchemeAttachers: testSchemes,
-			})
-		}
-
-		cguBuilders, err := ListInAllNamespaces(testSettings, testCase.listOptions...)
-		assert.Equal(t, testCase.expectedError, err)
-
-		if testCase.expectedError == nil && len(testCase.listOptions) == 0 {
-			assert.Equal(t, len(cguBuilders), len(testCase.testCGU))
-		}
-	}
+	testhelper.NewListTestConfig(
+		ListInAllNamespaces,
+		v1alpha1.AddToScheme,
+		cguGVK,
+	).ExecuteTests(t)
 }

--- a/pkg/cgu/precachingconfig.go
+++ b/pkg/cgu/precachingconfig.go
@@ -1,29 +1,34 @@
 package cgu
 
 import (
-	"fmt"
+	"context"
 
 	"github.com/openshift-kni/cluster-group-upgrades-operator/pkg/api/clustergroupupgrades/v1alpha1"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/logging"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/msg"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog/v2"
-	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // PreCachingConfigBuilder provides a struct for the PreCachingConfig object containing a connection to the cluster and
 // the PreCachingConfig definition.
 type PreCachingConfigBuilder struct {
-	// Definition of the PreCachingConfig used to create the object.
-	Definition *v1alpha1.PreCachingConfig
-	// Object of the PreCachingConfig as it is on the cluster.
-	Object *v1alpha1.PreCachingConfig
-	// api client to interact with the cluster.
-	apiClient runtimeclient.Client
-	// used to store latest error message upon defining or mutating application definition.
-	errorMsg string
+	common.EmbeddableBuilder[v1alpha1.PreCachingConfig, *v1alpha1.PreCachingConfig]
+	common.EmbeddableCreator[v1alpha1.PreCachingConfig, PreCachingConfigBuilder, *v1alpha1.PreCachingConfig, *PreCachingConfigBuilder]
+	common.EmbeddableDeleter[v1alpha1.PreCachingConfig, *v1alpha1.PreCachingConfig]
+	common.EmbeddableForceUpdater[v1alpha1.PreCachingConfig, PreCachingConfigBuilder, *v1alpha1.PreCachingConfig, *PreCachingConfigBuilder]
+}
+
+// AttachMixins wires the embedded CRUD mixins to this builder instance.
+func (builder *PreCachingConfigBuilder) AttachMixins() {
+	builder.EmbeddableCreator.SetBase(builder)
+	builder.EmbeddableDeleter.SetBase(builder)
+	builder.EmbeddableForceUpdater.SetBase(builder)
+}
+
+// GetGVK returns the PreCachingConfig GVK for this builder.
+func (builder *PreCachingConfigBuilder) GetGVK() schema.GroupVersionKind {
+	return v1alpha1.SchemeGroupVersion.WithKind("PreCachingConfig")
 }
 
 // NewPreCachingConfigBuilder creates a new instance of PreCachingConfig.
@@ -31,240 +36,14 @@ func NewPreCachingConfigBuilder(apiClient *clients.Settings, name, nsname string
 	klog.V(100).Infof(
 		"Initializing new PreCachingConfig structure with the following params: name: %s, nsname: %s", name, nsname)
 
-	if apiClient == nil {
-		klog.V(100).Info("The apiClient for the PreCachingConfig is nil")
-
-		return nil
-	}
-
-	err := apiClient.AttachScheme(v1alpha1.AddToScheme)
-	if err != nil {
-		klog.V(100).Info("Failed to add cgu v1alpha1 scheme to client schemes")
-
-		return nil
-	}
-
-	builder := &PreCachingConfigBuilder{
-		apiClient: apiClient.Client,
-		Definition: &v1alpha1.PreCachingConfig{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: nsname,
-			},
-		}}
-
-	if name == "" {
-		klog.V(100).Info("The name of the PreCachingConfig is empty")
-
-		builder.errorMsg = "preCachingConfig 'name' cannot be empty"
-
-		return builder
-	}
-
-	if nsname == "" {
-		klog.V(100).Info("The namespace of the PreCachingConfig is empty")
-
-		builder.errorMsg = "preCachingConfig 'nsname' cannot be empty"
-
-		return builder
-	}
-
-	return builder
+	return common.NewNamespacedBuilder[v1alpha1.PreCachingConfig, PreCachingConfigBuilder](
+		apiClient, v1alpha1.AddToScheme, name, nsname)
 }
 
 // PullPreCachingConfig pulls an existing PreCachingConfig into a PreCachingConfigBuilder struct.
 func PullPreCachingConfig(apiClient *clients.Settings, name, nsname string) (*PreCachingConfigBuilder, error) {
 	klog.V(100).Infof("Pulling existing PreCachingConfig %s under namespace %s from cluster", name, nsname)
 
-	if apiClient == nil {
-		klog.V(100).Info("The apiClient is empty")
-
-		return nil, fmt.Errorf("preCachingConfig 'apiClient' cannot be empty")
-	}
-
-	err := apiClient.AttachScheme(v1alpha1.AddToScheme)
-	if err != nil {
-		klog.V(100).Info("Failed to add cgu v1alpha1 scheme to client schemes")
-
-		return nil, err
-	}
-
-	builder := PreCachingConfigBuilder{
-		apiClient: apiClient.Client,
-		Definition: &v1alpha1.PreCachingConfig{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: nsname,
-			},
-		},
-	}
-
-	if name == "" {
-		klog.V(100).Info("The name of the PreCachingConfig is empty")
-
-		return nil, fmt.Errorf("preCachingConfig 'name' cannot be empty")
-	}
-
-	if nsname == "" {
-		klog.V(100).Info("The namespace of the PreCachingConfig is empty")
-
-		return nil, fmt.Errorf("preCachingConfig 'nsname' cannot be empty")
-	}
-
-	if !builder.Exists() {
-		return nil, fmt.Errorf("preCachingConfig object %s does not exist in namespace %s", name, nsname)
-	}
-
-	builder.Definition = builder.Object
-
-	return &builder, nil
-}
-
-// Exists checks whether the given PreCachingConfig exists on the apiClient.
-func (builder *PreCachingConfigBuilder) Exists() bool {
-	if valid, _ := builder.validate(); !valid {
-		return false
-	}
-
-	klog.V(100).Infof(
-		"Checking if preCachingConfig %s exists in namespace %s", builder.Definition.Name, builder.Definition.Namespace)
-
-	var err error
-
-	builder.Object, err = builder.Get()
-
-	return err == nil || !k8serrors.IsNotFound(err)
-}
-
-// Get pulls the PreCachingConfig from the apiClient into the PreCachingConfigBuilder.
-func (builder *PreCachingConfigBuilder) Get() (*v1alpha1.PreCachingConfig, error) {
-	if valid, err := builder.validate(); !valid {
-		return nil, err
-	}
-
-	klog.V(100).Infof("Getting PreCachingConfig %s in namespace %s", builder.Definition.Name, builder.Definition.Namespace)
-
-	preCachingConfig := &v1alpha1.PreCachingConfig{}
-
-	err := builder.apiClient.Get(logging.DiscardContext(), runtimeclient.ObjectKey{
-		Name:      builder.Definition.Name,
-		Namespace: builder.Definition.Namespace,
-	}, preCachingConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	return preCachingConfig, nil
-}
-
-// Create makes a PreCachingConfig on the apiClient if it does not already exist.
-func (builder *PreCachingConfigBuilder) Create() (*PreCachingConfigBuilder, error) {
-	if valid, err := builder.validate(); !valid {
-		return nil, err
-	}
-
-	klog.V(100).Infof(
-		"Creating the PreCachingConfig %s in namespace %s", builder.Definition.Name, builder.Definition.Namespace)
-
-	if builder.Exists() {
-		return builder, nil
-	}
-
-	err := builder.apiClient.Create(logging.DiscardContext(), builder.Definition)
-	if err != nil {
-		return nil, err
-	}
-
-	builder.Object = builder.Definition
-
-	return builder, nil
-}
-
-// Delete removes a PreCachingConfig from the apiClient if it exists.
-func (builder *PreCachingConfigBuilder) Delete() error {
-	if valid, err := builder.validate(); !valid {
-		return err
-	}
-
-	klog.V(100).Infof(
-		"Deleting the PreCachingConfig %s in namespace %s", builder.Definition.Name, builder.Definition.Namespace)
-
-	if !builder.Exists() {
-		builder.Object = nil
-
-		return nil
-	}
-
-	err := builder.apiClient.Delete(logging.DiscardContext(), builder.Definition)
-	if err != nil {
-		return err
-	}
-
-	builder.Object = nil
-
-	return nil
-}
-
-// Update changes the existing PreCachingConfig object on the apiClient, falling back to deleting and recreating it if
-// force is set.
-func (builder *PreCachingConfigBuilder) Update(force bool) (*PreCachingConfigBuilder, error) {
-	if valid, err := builder.validate(); !valid {
-		return nil, err
-	}
-
-	klog.V(100).Infof(
-		"Updating the PreCachingConfig %s in namespace %s", builder.Definition.Name, builder.Definition.Namespace)
-
-	err := builder.apiClient.Update(logging.DiscardContext(), builder.Definition)
-	if err != nil {
-		if force {
-			klog.V(100).Infof("%v", msg.FailToUpdateNotification("preCachingConfig", builder.Definition.Name))
-
-			err := builder.Delete()
-			if err != nil {
-				klog.V(100).Infof("%v", msg.FailToUpdateError("preCachingConfig", builder.Definition.Name))
-
-				return nil, err
-			}
-
-			return builder.Create()
-		}
-
-		return nil, err
-	}
-
-	builder.Object = builder.Definition
-
-	return builder, nil
-}
-
-// validate checks that the builder, definition, and apiClient are properly initialized and there is no errorMsg.
-func (builder *PreCachingConfigBuilder) validate() (bool, error) {
-	resourceCRD := "preCachingConfig"
-
-	if builder == nil {
-		klog.V(100).Infof("The %s builder is uninitialized", resourceCRD)
-
-		return false, fmt.Errorf("error received nil %s builder", resourceCRD)
-	}
-
-	if builder.Definition == nil {
-		klog.V(100).Infof("The %s is uninitialized", resourceCRD)
-
-		return false, fmt.Errorf("%s", msg.UndefinedCrdObjectErrString(resourceCRD))
-	}
-
-	if builder.apiClient == nil {
-		klog.V(100).Infof("The %s builder apiClient is nil", resourceCRD)
-
-		return false, fmt.Errorf("%s builder cannot have nil apiClient", resourceCRD)
-	}
-
-	if builder.errorMsg != "" {
-		klog.V(100).Infof("The %s builder has error message %s", resourceCRD, builder.errorMsg)
-
-		return false, fmt.Errorf("%s", builder.errorMsg)
-	}
-
-	return true, nil
+	return common.PullNamespacedBuilder[v1alpha1.PreCachingConfig, PreCachingConfigBuilder](
+		context.TODO(), apiClient, v1alpha1.AddToScheme, name, nsname)
 }

--- a/pkg/cgu/precachingconfig_test.go
+++ b/pkg/cgu/precachingconfig_test.go
@@ -1,390 +1,48 @@
 package cgu
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/openshift-kni/cluster-group-upgrades-operator/pkg/api/clustergroupupgrades/v1alpha1"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
-	"github.com/stretchr/testify/assert"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common/testhelper"
 )
 
-var (
-	defaultPreCachingConfigName   = "precachingconfig-test"
-	defaultPreCachingConfigNsName = "test-ns"
-)
+var preCachingConfigGVK = v1alpha1.SchemeGroupVersion.WithKind("PreCachingConfig")
 
 func TestNewPreCachingConfigBuilder(t *testing.T) {
-	testCases := []struct {
-		preCachingConfigName      string
-		preCachingConfigNamespace string
-		expectedErrorText         string
-	}{
-		{
-			preCachingConfigName:      defaultPreCachingConfigName,
-			preCachingConfigNamespace: defaultPreCachingConfigNsName,
-			expectedErrorText:         "",
-		},
-		{
-			preCachingConfigName:      "",
-			preCachingConfigNamespace: defaultPreCachingConfigNsName,
-			expectedErrorText:         "preCachingConfig 'name' cannot be empty",
-		},
-		{
-			preCachingConfigName:      defaultPreCachingConfigName,
-			preCachingConfigNamespace: "",
-			expectedErrorText:         "preCachingConfig 'nsname' cannot be empty",
-		},
-	}
+	t.Parallel()
 
-	for _, testCase := range testCases {
-		testSettings := clients.GetTestClients(clients.TestClientParams{})
-		preCachingConfigBuilder := NewPreCachingConfigBuilder(
-			testSettings, testCase.preCachingConfigName, testCase.preCachingConfigNamespace)
-		assert.NotNil(t, preCachingConfigBuilder)
-		assert.Equal(t, testCase.expectedErrorText, preCachingConfigBuilder.errorMsg)
-	}
+	testhelper.NewNamespacedBuilderTestConfig(
+		NewPreCachingConfigBuilder,
+		v1alpha1.AddToScheme,
+		preCachingConfigGVK,
+	).ExecuteTests(t)
 }
 
 func TestPullPreCachingConfig(t *testing.T) {
-	testCases := []struct {
-		preCachingConfigName      string
-		preCachingConfigNamespace string
-		addToRuntimeObjects       bool
-		client                    bool
-		expectedErrorText         string
-	}{
-		{
-			preCachingConfigName:      defaultPreCachingConfigName,
-			preCachingConfigNamespace: defaultPreCachingConfigNsName,
-			addToRuntimeObjects:       true,
-			client:                    true,
-			expectedErrorText:         "",
-		},
-		{
-			preCachingConfigName:      defaultPreCachingConfigName,
-			preCachingConfigNamespace: defaultPreCachingConfigNsName,
-			addToRuntimeObjects:       false,
-			client:                    true,
-			expectedErrorText: fmt.Sprintf(
-				"preCachingConfig object %s does not exist in namespace %s",
-				defaultPreCachingConfigName, defaultPreCachingConfigNsName),
-		},
-		{
-			preCachingConfigName:      "",
-			preCachingConfigNamespace: defaultPreCachingConfigNsName,
-			addToRuntimeObjects:       false,
-			client:                    true,
-			expectedErrorText:         "preCachingConfig 'name' cannot be empty",
-		},
-		{
-			preCachingConfigName:      defaultPreCachingConfigName,
-			preCachingConfigNamespace: "",
-			addToRuntimeObjects:       false,
-			client:                    true,
-			expectedErrorText:         "preCachingConfig 'nsname' cannot be empty",
-		},
-		{
-			preCachingConfigName:      defaultPreCachingConfigName,
-			preCachingConfigNamespace: defaultPreCachingConfigNsName,
-			addToRuntimeObjects:       false,
-			client:                    false,
-			expectedErrorText:         "preCachingConfig 'apiClient' cannot be empty",
-		},
-	}
+	t.Parallel()
 
-	for _, testCase := range testCases {
-		var (
-			runtimeObjects []runtime.Object
-			testSettings   *clients.Settings
-		)
-
-		testPreCachingConfig := buildDummyPreCachingConfig(testCase.preCachingConfigName, testCase.preCachingConfigNamespace)
-
-		if testCase.addToRuntimeObjects {
-			runtimeObjects = append(runtimeObjects, testPreCachingConfig)
-		}
-
-		if testCase.client {
-			testSettings = clients.GetTestClients(clients.TestClientParams{
-				K8sMockObjects:  runtimeObjects,
-				SchemeAttachers: testSchemes,
-			})
-		}
-
-		preCachingConfigBuilder, err := PullPreCachingConfig(
-			testSettings, testPreCachingConfig.Name, testPreCachingConfig.Namespace)
-
-		if testCase.expectedErrorText != "" {
-			assert.NotNil(t, err)
-			assert.Equal(t, testCase.expectedErrorText, err.Error())
-		} else {
-			assert.Nil(t, err)
-			assert.Equal(t, testPreCachingConfig.Name, preCachingConfigBuilder.Object.Name)
-			assert.Equal(t, testPreCachingConfig.Namespace, preCachingConfigBuilder.Object.Namespace)
-		}
-	}
+	testhelper.NewNamespacedPullTestConfig(
+		PullPreCachingConfig,
+		v1alpha1.AddToScheme,
+		preCachingConfigGVK,
+	).ExecuteTests(t)
 }
 
-func TestPreCachingConfigExists(t *testing.T) {
-	testCases := []struct {
-		testBuilder *PreCachingConfigBuilder
-		exists      bool
-	}{
-		{
-			testBuilder: buildValidPreCachingConfigTestBuilder(buildTestClientWithDummyPreCachingConfig()),
-			exists:      true,
-		},
-		{
-			testBuilder: buildInvalidPreCachingConfigTestBuilder(buildTestClientWithDummyPreCachingConfig()),
-			exists:      false,
-		},
-	}
+func TestPreCachingConfigBuilderMethods(t *testing.T) {
+	t.Parallel()
 
-	for _, testCase := range testCases {
-		exists := testCase.testBuilder.Exists()
-		assert.Equal(t, testCase.exists, exists)
-	}
-}
+	commonTestConfig := testhelper.NewCommonTestConfig[v1alpha1.PreCachingConfig, PreCachingConfigBuilder](
+		v1alpha1.AddToScheme,
+		preCachingConfigGVK,
+		testhelper.ResourceScopeNamespaced,
+	)
 
-func TestPreCachingConfigGet(t *testing.T) {
-	testCases := []struct {
-		testBuilder              *PreCachingConfigBuilder
-		expectedPreCachingConfig *v1alpha1.PreCachingConfig
-	}{
-		{
-			testBuilder:              buildValidPreCachingConfigTestBuilder(buildTestClientWithDummyPreCachingConfig()),
-			expectedPreCachingConfig: buildDummyPreCachingConfig(defaultPreCachingConfigName, defaultPreCachingConfigNsName),
-		},
-		{
-			testBuilder:              buildValidPreCachingConfigTestBuilder(clients.GetTestClients(clients.TestClientParams{})),
-			expectedPreCachingConfig: nil,
-		},
-	}
-
-	for _, testCase := range testCases {
-		preCachingConfig, err := testCase.testBuilder.Get()
-
-		if testCase.expectedPreCachingConfig == nil {
-			assert.Nil(t, preCachingConfig)
-			assert.True(t, k8serrors.IsNotFound(err))
-		} else {
-			assert.Nil(t, err)
-			assert.Equal(t, testCase.expectedPreCachingConfig.Name, preCachingConfig.Name)
-			assert.Equal(t, testCase.expectedPreCachingConfig.Namespace, preCachingConfig.Namespace)
-		}
-	}
-}
-
-func TestPreCachingConfigCreate(t *testing.T) {
-	testCases := []struct {
-		testBuilder   *PreCachingConfigBuilder
-		expectedError error
-	}{
-		{
-			testBuilder:   buildValidPreCachingConfigTestBuilder(clients.GetTestClients(clients.TestClientParams{})),
-			expectedError: nil,
-		},
-		{
-			testBuilder:   buildInvalidPreCachingConfigTestBuilder(clients.GetTestClients(clients.TestClientParams{})),
-			expectedError: fmt.Errorf("preCachingConfig 'nsname' cannot be empty"),
-		},
-	}
-
-	for _, testCase := range testCases {
-		preCachingConfigBuilder, err := testCase.testBuilder.Create()
-		assert.Equal(t, testCase.expectedError, err)
-
-		if testCase.expectedError == nil {
-			assert.Equal(t, preCachingConfigBuilder.Definition, preCachingConfigBuilder.Object)
-		}
-	}
-}
-
-func TestPreCachingConfigDelete(t *testing.T) {
-	testCases := []struct {
-		testBuilder   *PreCachingConfigBuilder
-		expectedError error
-	}{
-		{
-			testBuilder:   buildValidPreCachingConfigTestBuilder(buildTestClientWithDummyPreCachingConfig()),
-			expectedError: nil,
-		},
-		{
-			testBuilder:   buildInvalidPreCachingConfigTestBuilder(buildTestClientWithDummyPreCachingConfig()),
-			expectedError: fmt.Errorf("preCachingConfig 'nsname' cannot be empty"),
-		},
-	}
-
-	for _, testCase := range testCases {
-		err := testCase.testBuilder.Delete()
-		assert.Equal(t, testCase.expectedError, err)
-
-		if testCase.expectedError == nil {
-			assert.Nil(t, testCase.testBuilder.Object)
-		}
-	}
-}
-
-func TestPreCachingConfigUpdate(t *testing.T) {
-	testCases := []struct {
-		alreadyExists bool
-		force         bool
-	}{
-		{
-			alreadyExists: false,
-			force:         false,
-		},
-		{
-			alreadyExists: true,
-			force:         false,
-		},
-		{
-			alreadyExists: false,
-			force:         true,
-		},
-		{
-			alreadyExists: true,
-			force:         true,
-		},
-	}
-
-	for _, testCase := range testCases {
-		testBuilder := buildValidPreCachingConfigTestBuilder(clients.GetTestClients(clients.TestClientParams{}))
-
-		// Create the builder rather than just adding it to the client so that the proper metadata is added and
-		// the update will not fail.
-		if testCase.alreadyExists {
-			var err error
-
-			testBuilder = buildValidPreCachingConfigTestBuilder(clients.GetTestClients(clients.TestClientParams{}))
-			testBuilder, err = testBuilder.Create()
-			assert.Nil(t, err)
-		}
-
-		assert.NotNil(t, testBuilder.Definition)
-		assert.Empty(t, testBuilder.Definition.Spec.SpaceRequired)
-
-		testBuilder.Definition.Spec.SpaceRequired = "10 GiB"
-
-		preCachingConfigBuilder, err := testBuilder.Update(testCase.force)
-		assert.NotNil(t, testBuilder.Definition)
-
-		if testCase.alreadyExists || testCase.force {
-			assert.Nil(t, err)
-			assert.Equal(t, testBuilder.Definition.Name, preCachingConfigBuilder.Definition.Name)
-			assert.Equal(t, testBuilder.Definition.Spec.SpaceRequired, preCachingConfigBuilder.Definition.Spec.SpaceRequired)
-		} else {
-			assert.NotNil(t, err)
-		}
-	}
-}
-
-func TestPreCachingConfigValidate(t *testing.T) {
-	testCases := []struct {
-		builderNil    bool
-		definitionNil bool
-		apiClientNil  bool
-		expectedError error
-		builderErrMsg string
-	}{
-		{
-			builderNil:    false,
-			definitionNil: false,
-			apiClientNil:  false,
-			expectedError: nil,
-			builderErrMsg: "",
-		},
-		{
-			builderNil:    true,
-			definitionNil: false,
-			apiClientNil:  false,
-			expectedError: fmt.Errorf("error received nil preCachingConfig builder"),
-			builderErrMsg: "",
-		},
-		{
-			builderNil:    false,
-			definitionNil: true,
-			apiClientNil:  false,
-			expectedError: fmt.Errorf("can not redefine the undefined preCachingConfig"),
-			builderErrMsg: "",
-		},
-		{
-			builderNil:    false,
-			definitionNil: false,
-			apiClientNil:  true,
-			expectedError: fmt.Errorf("preCachingConfig builder cannot have nil apiClient"),
-			builderErrMsg: "",
-		},
-		{
-			builderNil:    false,
-			definitionNil: false,
-			apiClientNil:  false,
-			builderErrMsg: "test error",
-			expectedError: fmt.Errorf("test error"),
-		},
-	}
-
-	for _, testCase := range testCases {
-		testBuilder := buildValidPreCachingConfigTestBuilder(clients.GetTestClients(clients.TestClientParams{}))
-
-		if testCase.builderNil {
-			testBuilder = nil
-		}
-
-		if testCase.definitionNil {
-			testBuilder.Definition = nil
-		}
-
-		if testCase.apiClientNil {
-			testBuilder.apiClient = nil
-		}
-
-		if testCase.builderErrMsg != "" {
-			testBuilder.errorMsg = testCase.builderErrMsg
-		}
-
-		valid, err := testBuilder.validate()
-
-		if testCase.expectedError != nil {
-			assert.False(t, valid)
-			assert.Equal(t, testCase.expectedError, err)
-		} else {
-			assert.True(t, valid)
-			assert.Nil(t, err)
-		}
-	}
-}
-
-// buildDummyPreCachingConfig returns a PreCachingConfig with the provided name and namespace.
-func buildDummyPreCachingConfig(name, nsname string) *v1alpha1.PreCachingConfig {
-	return &v1alpha1.PreCachingConfig{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: nsname,
-		},
-	}
-}
-
-// buildTestClientWithDummyPreCachingConfig returns a client with a mock dummy PreCachingConfig.
-func buildTestClientWithDummyPreCachingConfig() *clients.Settings {
-	return clients.GetTestClients(clients.TestClientParams{
-		K8sMockObjects: []runtime.Object{
-			buildDummyPreCachingConfig(defaultPreCachingConfigName, defaultPreCachingConfigNsName),
-		},
-		SchemeAttachers: testSchemes,
-	})
-}
-
-// buildValidPreCachingConfigTestBuilder returns a valid PreCachingConfigBuilder for testing.
-func buildValidPreCachingConfigTestBuilder(apiClient *clients.Settings) *PreCachingConfigBuilder {
-	return NewPreCachingConfigBuilder(apiClient, defaultPreCachingConfigName, defaultPreCachingConfigNsName)
-}
-
-// buildInvalidPreCachingConfigTestBuilder returns an invalid PreCachingConfigBuilder for testing.
-func buildInvalidPreCachingConfigTestBuilder(apiClient *clients.Settings) *PreCachingConfigBuilder {
-	return NewPreCachingConfigBuilder(apiClient, defaultPreCachingConfigName, "")
+	testhelper.NewTestSuite().
+		With(testhelper.NewGetTestConfig(commonTestConfig)).
+		With(testhelper.NewExistsTestConfig(commonTestConfig)).
+		With(testhelper.NewCreateTestConfig(commonTestConfig)).
+		With(testhelper.NewDeleterTestConfig(commonTestConfig)).
+		With(testhelper.NewForceUpdateTestConfig(commonTestConfig)).
+		Run(t)
 }


### PR DESCRIPTION
Migrate CguBuilder and PreCachingConfigBuilder to EmbeddableBuilder
mixins, common List/Pull/NewBuilder helpers, and testhelper CRUD tests.

Closes: #1357 

Co-authored-by: Cursor <cursoragent@cursor.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated CGU and PreCachingConfig builders to use shared, composition-based builder/list utilities.
  * Simplified CGU cluster-wide listing by delegating to a shared listing helper.
* **Bug Fixes**
  * Improved and standardized validation and “object not found” error handling across builder and wait flows.
* **Tests**
  * Refactored CGU/PreCachingConfig and CGU listing tests to use shared test harnesses.
  * Expanded wait-until-cluster-in-state coverage and aligned assertions to stable error types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->