### PR TITLE
common,ptp: broaden ListInAllNamespacesFunc

### DIFF
--- a/pkg/internal/common/testhelper/listhelper.go
+++ b/pkg/internal/common/testhelper/listhelper.go
@@ -16,10 +16,15 @@ import (
 )
 
 // ListInAllNamespacesFunc is a List function signature for listing resources in all namespaces (e.g.,
-// ListInAllNamespaces).
-type ListInAllNamespacesFunc[SB any] func(
+// ListInAllNamespaces). In addition to a type parameter representing a pointer to the builder type (SB), it also takes
+// a type parameter representing the list option type (LO). This allows representing functions that take ListOption and
+// ListOptions with the same type.
+//
+// Since only *ListOptions implements ListOption, but most functions take ListOptions, we cannot constrain LO to
+// anything more specific than any. Ideally, we would constrain LO to ListOption.
+type ListInAllNamespacesFunc[SB any, LO any] func(
 	apiClient *clients.Settings,
-	options ...runtimeclient.ListOptions,
+	options ...LO,
 ) ([]SB, error)
 
 // NamespacedListFunc is a List function signature for listing resources in a specific namespace (e.g., List with
@@ -68,8 +73,8 @@ type ListTestConfig[O, B any, SO common.ObjectPointer[O], SB common.BuilderPoint
 }
 
 // NewListTestConfig creates a new ListTestConfig for ListInAllNamespaces-style functions.
-func NewListTestConfig[O, B any, SO common.ObjectPointer[O], SB common.BuilderPointer[B, O, SO]](
-	listFunc ListInAllNamespacesFunc[SB],
+func NewListTestConfig[LO any, O, B any, SO common.ObjectPointer[O], SB common.BuilderPointer[B, O, SO]](
+	listFunc ListInAllNamespacesFunc[SB, LO],
 	schemeAttacher clients.SchemeAttacher,
 	expectedGVK schema.GroupVersionKind,
 ) ListTestConfig[O, B, SO, SB] {

--- a/pkg/oran/hardwareprofile_test.go
+++ b/pkg/oran/hardwareprofile_test.go
@@ -4,9 +4,7 @@ import (
 	"testing"
 
 	hardwaremanagementv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common/testhelper"
-	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var hardwareProfileGVK = hardwaremanagementv1alpha1.GroupVersion.WithKind("HardwareProfile")
@@ -24,14 +22,8 @@ func TestPullHardwareProfile(t *testing.T) {
 func TestListHardwareProfiles(t *testing.T) {
 	t.Parallel()
 
-	testhelper.NewListTestConfig[hardwaremanagementv1alpha1.HardwareProfile, HardwareProfileBuilder](
-		func(apiClient *clients.Settings, options ...runtimeclient.ListOptions) ([]*HardwareProfileBuilder, error) {
-			if len(options) == 0 {
-				return ListHardwareProfiles(apiClient)
-			}
-
-			return ListHardwareProfiles(apiClient, &options[0])
-		},
+	testhelper.NewListTestConfig(
+		ListHardwareProfiles,
 		hardwaremanagementv1alpha1.AddToScheme,
 		hardwareProfileGVK,
 	).ExecuteTests(t)

--- a/pkg/ptp/hardwareconfig_test.go
+++ b/pkg/ptp/hardwareconfig_test.go
@@ -3,10 +3,8 @@ package ptp
 import (
 	"testing"
 
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common/testhelper"
 	ptpv2alpha1 "github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/ptp/v2alpha1"
-	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var hardwareConfigGVK = ptpv2alpha1.GroupVersion.WithKind("HardwareConfig")
@@ -24,14 +22,8 @@ func TestPullHardwareConfig(t *testing.T) {
 func TestListHardwareConfigs(t *testing.T) {
 	t.Parallel()
 
-	testhelper.NewListTestConfig[ptpv2alpha1.HardwareConfig, HardwareConfigBuilder](
-		func(apiClient *clients.Settings, options ...runtimeclient.ListOptions) ([]*HardwareConfigBuilder, error) {
-			if len(options) == 0 {
-				return ListHardwareConfigs(apiClient)
-			}
-
-			return ListHardwareConfigs(apiClient, &options[0])
-		},
+	testhelper.NewListTestConfig(
+		ListHardwareConfigs,
 		ptpv2alpha1.AddToScheme,
 		hardwareConfigGVK,
 	).ExecuteTests(t)


### PR DESCRIPTION
Previously, the ListInAllNamespacesFunc only represented types which
accepted the runtimeclient.ListOptions struct. However, the
ListHardwareConfigs function in the ptp package accepts
runtimeclient.ListOption, which is the interface that
*runtimeclient.ListOptions implements.

This commit solves the issue by adding an extra generic parameter to the
ListInAllNamespacesFunc type which allows for specifying the options
type. That way, both forms may be provided to NewListTestConfig.

Assisted-by: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated shared test utilities for list test configuration to support caller-supplied list option types, enabling more flexible generic list handling.
  * Simplified list-test wiring in hardware configuration/profile tests by directly passing the list functions instead of wrapper logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->