### PR TITLE
Add config.openshift.io/v1 APIServer builder to pkg/apiservers

### DIFF
--- a/pkg/apiservers/apiserver.go
+++ b/pkg/apiservers/apiserver.go
@@ -7,7 +7,6 @@ import (
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/logging"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/msg"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 	goclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -95,8 +94,11 @@ func (builder *APIServerBuilder) Exists() bool {
 	var err error
 
 	builder.Object, err = builder.Get()
+	if err != nil {
+		klog.V(100).Infof("Failed to collect APIServer object due to %s", err.Error())
+	}
 
-	return err == nil || !k8serrors.IsNotFound(err)
+	return err == nil
 }
 
 // Update renovates the existing APIServer object with the APIServer definition in builder.

--- a/pkg/apiservers/apiserver.go
+++ b/pkg/apiservers/apiserver.go
@@ -1,0 +1,193 @@
+package apiservers
+
+import (
+	"fmt"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/logging"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/msg"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	goclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const apiServerName = "cluster"
+
+// APIServerBuilder provides a struct for the config.openshift.io/v1 APIServer object.
+type APIServerBuilder struct {
+	// APIServer definition. Used to define the APIServer object.
+	Definition *configv1.APIServer
+	// Created APIServer object.
+	Object *configv1.APIServer
+	// apiClient opens api connection to the cluster.
+	apiClient goclient.Client
+	// Used in functions that define or mutate APIServer definition. errorMsg is processed before the
+	// APIServer object is created.
+	errorMsg string
+}
+
+// PullAPIServer pulls the existing config.openshift.io/v1 APIServer singleton from the cluster.
+func PullAPIServer(apiClient *clients.Settings) (*APIServerBuilder, error) {
+	klog.V(100).Infof("Pulling existing APIServer name: %s", apiServerName)
+
+	if apiClient == nil {
+		klog.V(100).Info("The apiClient of the APIServer is nil")
+
+		return nil, fmt.Errorf("apiserver 'apiClient' cannot be nil")
+	}
+
+	err := apiClient.AttachScheme(configv1.Install)
+	if err != nil {
+		klog.V(100).Info("Failed to add config v1 scheme to client schemes")
+
+		return nil, err
+	}
+
+	builder := APIServerBuilder{
+		apiClient: apiClient.Client,
+		Definition: &configv1.APIServer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: apiServerName,
+			},
+		},
+	}
+
+	if !builder.Exists() {
+		return nil, fmt.Errorf("apiserver object %s does not exist", apiServerName)
+	}
+
+	builder.Definition = builder.Object
+
+	return &builder, nil
+}
+
+// Get returns the APIServer object from the cluster if it exists.
+func (builder *APIServerBuilder) Get() (*configv1.APIServer, error) {
+	if valid, err := builder.validate(); !valid {
+		return nil, err
+	}
+
+	klog.V(100).Infof("Getting APIServer object %s", builder.Definition.Name)
+
+	apiServerObject := &configv1.APIServer{}
+
+	err := builder.apiClient.Get(logging.DiscardContext(),
+		goclient.ObjectKey{Name: builder.Definition.Name}, apiServerObject)
+	if err != nil {
+		klog.V(100).Infof("Failed to get APIServer %s: %s", builder.Definition.Name, err)
+
+		return nil, err
+	}
+
+	return apiServerObject, nil
+}
+
+// Exists checks whether the given APIServer exists.
+func (builder *APIServerBuilder) Exists() bool {
+	if valid, _ := builder.validate(); !valid {
+		return false
+	}
+
+	klog.V(100).Infof("Checking if APIServer %s exists", builder.Definition.Name)
+
+	var err error
+
+	builder.Object, err = builder.Get()
+
+	return err == nil || !k8serrors.IsNotFound(err)
+}
+
+// Update renovates the existing APIServer object with the APIServer definition in builder.
+func (builder *APIServerBuilder) Update() (*APIServerBuilder, error) {
+	if valid, err := builder.validate(); !valid {
+		return builder, err
+	}
+
+	klog.V(100).Infof("Updating APIServer %s", builder.Definition.Name)
+
+	if !builder.Exists() {
+		return nil, fmt.Errorf("apiserver object %s does not exist", builder.Definition.Name)
+	}
+
+	builder.Definition.ResourceVersion = builder.Object.ResourceVersion
+	builder.Definition.CreationTimestamp = metav1.Time{}
+
+	err := builder.apiClient.Update(logging.DiscardContext(), builder.Definition)
+	if err != nil {
+		klog.V(100).Infof("Failed to update APIServer %s: %s", builder.Definition.Name, err)
+
+		return nil, err
+	}
+
+	builder.Object = builder.Definition
+
+	return builder, nil
+}
+
+// WithTLSAdherence sets the TLS adherence policy on the APIServer definition.
+func (builder *APIServerBuilder) WithTLSAdherence(
+	policy configv1.TLSAdherencePolicy) *APIServerBuilder {
+	if valid, _ := builder.validate(); !valid {
+		return builder
+	}
+
+	klog.V(100).Infof("Setting TLS adherence policy %q on APIServer %s", policy, builder.Definition.Name)
+
+	builder.Definition.Spec.TLSAdherence = policy
+
+	return builder
+}
+
+// WithTLSSecurityProfile sets the TLS security profile on the APIServer definition.
+func (builder *APIServerBuilder) WithTLSSecurityProfile(
+	profile *configv1.TLSSecurityProfile) *APIServerBuilder {
+	if valid, _ := builder.validate(); !valid {
+		return builder
+	}
+
+	klog.V(100).Infof("Setting TLS security profile on APIServer %s", builder.Definition.Name)
+
+	if profile == nil {
+		builder.errorMsg = "apiserver TLS security profile cannot be nil"
+
+		return builder
+	}
+
+	builder.Definition.Spec.TLSSecurityProfile = profile
+
+	return builder
+}
+
+// validate will check that the builder and builder definition are properly initialized before
+// accessing any member fields.
+func (builder *APIServerBuilder) validate() (bool, error) {
+	resourceCRD := "apiservers.config.openshift.io"
+
+	if builder == nil {
+		klog.V(100).Infof("The %s builder is uninitialized", resourceCRD)
+
+		return false, fmt.Errorf("error: received nil %s builder", resourceCRD)
+	}
+
+	if builder.Definition == nil {
+		klog.V(100).Infof("The %s is undefined", resourceCRD)
+
+		return false, fmt.Errorf("%s", msg.UndefinedCrdObjectErrString(resourceCRD))
+	}
+
+	if builder.apiClient == nil {
+		klog.V(100).Infof("The %s builder apiclient is nil", resourceCRD)
+
+		return false, fmt.Errorf("%s builder cannot have nil apiClient", resourceCRD)
+	}
+
+	if builder.errorMsg != "" {
+		klog.V(100).Infof("The %s builder has error message: %s", resourceCRD, builder.errorMsg)
+
+		return false, fmt.Errorf("%s", builder.errorMsg)
+	}
+
+	return true, nil
+}

--- a/pkg/apiservers/apiserver_test.go
+++ b/pkg/apiservers/apiserver_test.go
@@ -1,0 +1,291 @@
+package apiservers
+
+import (
+	"fmt"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var apiServerTestSchemes = []clients.SchemeAttacher{
+	configv1.Install,
+}
+
+func TestPullAPIServer(t *testing.T) {
+	testCases := []struct {
+		addToRuntimeObjects bool
+		client              bool
+		expectedError       error
+	}{
+		{
+			addToRuntimeObjects: true,
+			client:              true,
+			expectedError:       nil,
+		},
+		{
+			addToRuntimeObjects: false,
+			client:              true,
+			expectedError:       fmt.Errorf("apiserver object %s does not exist", apiServerName),
+		},
+		{
+			addToRuntimeObjects: true,
+			client:              false,
+			expectedError:       fmt.Errorf("apiserver 'apiClient' cannot be nil"),
+		},
+	}
+
+	for _, testCase := range testCases {
+		var (
+			runtimeObjects []runtime.Object
+			testSettings   *clients.Settings
+		)
+
+		testAPIServer := buildDummyAPIServer()
+
+		if testCase.addToRuntimeObjects {
+			runtimeObjects = append(runtimeObjects, testAPIServer)
+		}
+
+		if testCase.client {
+			testSettings = clients.GetTestClients(clients.TestClientParams{
+				K8sMockObjects:  runtimeObjects,
+				SchemeAttachers: apiServerTestSchemes,
+			})
+		}
+
+		testBuilder, err := PullAPIServer(testSettings)
+		assert.Equal(t, testCase.expectedError, err)
+
+		if testCase.expectedError == nil {
+			assert.Equal(t, apiServerName, testBuilder.Definition.Name)
+		}
+	}
+}
+
+func TestAPIServerGet(t *testing.T) {
+	testCases := []struct {
+		testBuilder   *APIServerBuilder
+		expectedError string
+	}{
+		{
+			testBuilder:   newAPIServerBuilder(buildTestClientWithDummyAPIServer()),
+			expectedError: "",
+		},
+		{
+			testBuilder: newAPIServerBuilder(clients.GetTestClients(clients.TestClientParams{
+				SchemeAttachers: apiServerTestSchemes,
+			})),
+			expectedError: "apiservers.config.openshift.io \"cluster\" not found",
+		},
+	}
+
+	for _, testCase := range testCases {
+		apiServerObject, err := testCase.testBuilder.Get()
+
+		if testCase.expectedError == "" {
+			assert.Nil(t, err)
+			assert.Equal(t, testCase.testBuilder.Definition.Name, apiServerObject.Name)
+		} else {
+			assert.EqualError(t, err, testCase.expectedError)
+		}
+	}
+}
+
+func TestAPIServerExists(t *testing.T) {
+	testCases := []struct {
+		testBuilder *APIServerBuilder
+		exists      bool
+	}{
+		{
+			testBuilder: newAPIServerBuilder(buildTestClientWithDummyAPIServer()),
+			exists:      true,
+		},
+		{
+			testBuilder: newAPIServerBuilder(clients.GetTestClients(clients.TestClientParams{
+				SchemeAttachers: apiServerTestSchemes,
+			})),
+			exists: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		exists := testCase.testBuilder.Exists()
+		assert.Equal(t, testCase.exists, exists)
+	}
+}
+
+func TestAPIServerUpdate(t *testing.T) {
+	testCases := []struct {
+		testBuilder   *APIServerBuilder
+		expectedError error
+	}{
+		{
+			testBuilder:   newAPIServerBuilder(buildTestClientWithDummyAPIServer()),
+			expectedError: nil,
+		},
+		{
+			testBuilder: newAPIServerBuilder(clients.GetTestClients(clients.TestClientParams{
+				SchemeAttachers: apiServerTestSchemes,
+			})),
+			expectedError: fmt.Errorf("apiserver object %s does not exist", apiServerName),
+		},
+	}
+
+	for _, testCase := range testCases {
+		assert.Nil(t, testCase.testBuilder.Definition.Spec.TLSSecurityProfile)
+
+		testCase.testBuilder.Definition.Spec.TLSSecurityProfile = &configv1.TLSSecurityProfile{
+			Type: configv1.TLSProfileOldType,
+		}
+
+		testBuilder, err := testCase.testBuilder.Update()
+		assert.Equal(t, testCase.expectedError, err)
+
+		if testCase.expectedError == nil {
+			assert.Equal(t, configv1.TLSProfileOldType, testBuilder.Object.Spec.TLSSecurityProfile.Type)
+		}
+	}
+}
+
+func TestAPIServerWithTLSAdherence(t *testing.T) {
+	testCases := []struct {
+		policy   configv1.TLSAdherencePolicy
+		expected configv1.TLSAdherencePolicy
+	}{
+		{
+			policy:   configv1.TLSAdherencePolicyStrictAllComponents,
+			expected: configv1.TLSAdherencePolicyStrictAllComponents,
+		},
+		{
+			policy:   configv1.TLSAdherencePolicyLegacyAdheringComponentsOnly,
+			expected: configv1.TLSAdherencePolicyLegacyAdheringComponentsOnly,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testBuilder := newAPIServerBuilder(buildTestClientWithDummyAPIServer())
+		result := testBuilder.WithTLSAdherence(testCase.policy)
+
+		assert.Equal(t, testBuilder, result)
+		assert.Equal(t, testCase.expected, result.Definition.Spec.TLSAdherence)
+	}
+}
+
+func TestAPIServerWithTLSSecurityProfile(t *testing.T) {
+	testCases := []struct {
+		profile       *configv1.TLSSecurityProfile
+		expectedError string
+	}{
+		{
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileIntermediateType,
+			},
+			expectedError: "",
+		},
+		{
+			profile:       nil,
+			expectedError: "apiserver TLS security profile cannot be nil",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testBuilder := newAPIServerBuilder(buildTestClientWithDummyAPIServer())
+		result := testBuilder.WithTLSSecurityProfile(testCase.profile)
+
+		assert.Equal(t, testBuilder, result)
+
+		if testCase.expectedError == "" {
+			assert.Equal(t, testCase.profile, result.Definition.Spec.TLSSecurityProfile)
+		} else {
+			assert.Equal(t, testCase.expectedError, result.errorMsg)
+		}
+	}
+}
+
+func TestAPIServerBuilderValidate(t *testing.T) {
+	testCases := []struct {
+		builderNil    bool
+		definitionNil bool
+		apiClientNil  bool
+		builderErrMsg string
+		expectedError string
+	}{
+		{
+			builderNil:    true,
+			expectedError: "error: received nil apiservers.config.openshift.io builder",
+		},
+		{
+			definitionNil: true,
+			expectedError: "can not redefine the undefined apiservers.config.openshift.io",
+		},
+		{
+			apiClientNil:  true,
+			expectedError: "apiservers.config.openshift.io builder cannot have nil apiClient",
+		},
+		{
+			expectedError: "",
+		},
+		{
+			builderErrMsg: "test error",
+			expectedError: "test error",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testBuilder := newAPIServerBuilder(clients.GetTestClients(clients.TestClientParams{
+			SchemeAttachers: apiServerTestSchemes,
+		}))
+
+		if testCase.builderNil {
+			testBuilder = nil
+		}
+
+		if testCase.definitionNil {
+			testBuilder.Definition = nil
+		}
+
+		if testCase.apiClientNil {
+			testBuilder.apiClient = nil
+		}
+
+		if testCase.builderErrMsg != "" {
+			testBuilder.errorMsg = testCase.builderErrMsg
+		}
+
+		valid, err := testBuilder.validate()
+
+		if testCase.expectedError != "" {
+			assert.False(t, valid)
+			assert.Equal(t, testCase.expectedError, err.Error())
+		} else {
+			assert.True(t, valid)
+			assert.Nil(t, err)
+		}
+	}
+}
+
+func buildDummyAPIServer() *configv1.APIServer {
+	return &configv1.APIServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: apiServerName,
+		},
+	}
+}
+
+func buildTestClientWithDummyAPIServer() *clients.Settings {
+	return clients.GetTestClients(clients.TestClientParams{
+		K8sMockObjects:  []runtime.Object{buildDummyAPIServer()},
+		SchemeAttachers: apiServerTestSchemes,
+	})
+}
+
+func newAPIServerBuilder(apiClient *clients.Settings) *APIServerBuilder {
+	return &APIServerBuilder{
+		apiClient:  apiClient.Client,
+		Definition: buildDummyAPIServer(),
+	}
+}


### PR DESCRIPTION
The `config.openshift.io/v1` APIServer resource controls cluster-wide TLS settings (`spec.tlsSecurityProfile`) and the new `spec.tlsAdherence field` (TechPreview). Currently, consumers that need to manage these settings must use raw patches or unstructured client calls. This builder brings the same type-safe, fluent API that other config.openshift.io resources already have in eco-goinfra.

The `WithTLSAdherence` method leverages the typed `TLSAdherencePolicy` constants (`StrictAllComponents`, `LegacyAdheringComponentsOnly`) added in the recent openshift/api dependency update (#1506), avoiding the need for raw JSON patches against feature-gated fields.

- Add `APIServerBuilder` for the config.openshift.io/v1 APIServer singleton (apiservers/cluster), completing the set of APIServer builders alongside the existing KubeAPIServer (`operator.openshift.io/v1`) and OpenShiftAPIServer (`operator.openshift.io/v1`) builders

- Provide `PullAPIServer`, `Get`, `Exists`, `Update`, `WithTLSSecurityProfile`, and `WithTLSAdherence` methods following the standard eco-goinfra singleton builder pattern

- Add comprehensive unit tests covering all methods and validation paths



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced APIServer configuration management via a builder-style API, including fetching the current APIServer, checking whether it exists, updating it, and fluent TLS settings for adherence policies and security profiles.

* **Tests**
  * Added a comprehensive unit test suite covering successful and failure cases for pulling, getting, existence checks, updating, TLS option validation, and builder invariant/error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->