### PR TITLE
Neuron: add In-Cluster build support to DeviceConfig builder

### DIFF
--- a/pkg/neuron/deviceconfig.go
+++ b/pkg/neuron/deviceconfig.go
@@ -29,6 +29,8 @@ type Builder struct {
 // AdditionalOptions additional options for DeviceConfig object.
 type AdditionalOptions func(builder *Builder) (*Builder, error)
 
+const errDriverVersionEmpty = "DeviceConfig 'driverVersion' cannot be empty"
+
 // NewBuilder creates a new instance of Builder.
 func NewBuilder(
 	apiClient *clients.Settings,
@@ -93,7 +95,7 @@ func NewBuilder(
 	if driverVersion == "" {
 		klog.V(100).Infof("The driverVersion of the DeviceConfig is empty")
 
-		builder.errorMsg = "DeviceConfig 'driverVersion' cannot be empty"
+		builder.errorMsg = errDriverVersionEmpty
 
 		return builder
 	}
@@ -166,7 +168,7 @@ func NewBuilderWithInClusterBuild(
 	if driverVersion == "" {
 		klog.V(100).Infof("The driverVersion of the DeviceConfig is empty")
 
-		builder.errorMsg = "DeviceConfig 'driverVersion' cannot be empty"
+		builder.errorMsg = errDriverVersionEmpty
 
 		return builder
 	}
@@ -276,7 +278,7 @@ func (builder *Builder) WithDriverVersion(version string) *Builder {
 	if version == "" {
 		klog.V(100).Infof("DeviceConfig 'driverVersion' cannot be empty")
 
-		builder.errorMsg = "DeviceConfig 'driverVersion' cannot be empty"
+		builder.errorMsg = errDriverVersionEmpty
 
 		return builder
 	}

--- a/pkg/neuron/deviceconfig.go
+++ b/pkg/neuron/deviceconfig.go
@@ -109,6 +109,79 @@ func NewBuilder(
 	return builder
 }
 
+// NewBuilderWithInClusterBuild creates a new instance of Builder for in-cluster build mode.
+// In this mode, DriversImage is left empty and the operator triggers KMM in-cluster builds
+// using a Dockerfile ConfigMap. Only driverVersion and devicePluginImage are required.
+func NewBuilderWithInClusterBuild(
+	apiClient *clients.Settings,
+	name, namespace string,
+	driverVersion, devicePluginImage string) *Builder {
+	klog.V(100).Infof(
+		"Initializing new DeviceConfig (in-cluster build) with name: %s, namespace: %s",
+		name, namespace)
+
+	if apiClient == nil {
+		klog.V(100).Infof("The apiClient is empty")
+
+		return nil
+	}
+
+	err := apiClient.AttachScheme(neuronv1beta1.AddToScheme)
+	if err != nil {
+		klog.V(100).Infof("Failed to add neuron v1beta1 scheme to client schemes")
+
+		return nil
+	}
+
+	builder := &Builder{
+		apiClient: apiClient,
+		Definition: &neuronv1beta1.DeviceConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Spec: neuronv1beta1.DeviceConfigSpec{
+				DriverVersion:     driverVersion,
+				DevicePluginImage: devicePluginImage,
+			},
+		},
+	}
+
+	if name == "" {
+		klog.V(100).Infof("The name of the DeviceConfig is empty")
+
+		builder.errorMsg = "DeviceConfig 'name' cannot be empty"
+
+		return builder
+	}
+
+	if namespace == "" {
+		klog.V(100).Infof("The namespace of the DeviceConfig is empty")
+
+		builder.errorMsg = "DeviceConfig 'namespace' cannot be empty"
+
+		return builder
+	}
+
+	if driverVersion == "" {
+		klog.V(100).Infof("The driverVersion of the DeviceConfig is empty")
+
+		builder.errorMsg = "DeviceConfig 'driverVersion' cannot be empty"
+
+		return builder
+	}
+
+	if devicePluginImage == "" {
+		klog.V(100).Infof("The devicePluginImage of the DeviceConfig is empty")
+
+		builder.errorMsg = "DeviceConfig 'devicePluginImage' cannot be empty"
+
+		return builder
+	}
+
+	return builder
+}
+
 // WithSelector sets the node selector for the DeviceConfig.
 func (builder *Builder) WithSelector(selector map[string]string) *Builder {
 	if valid, _ := builder.validate(); !valid {

--- a/pkg/neuron/deviceconfig.go
+++ b/pkg/neuron/deviceconfig.go
@@ -29,7 +29,10 @@ type Builder struct {
 // AdditionalOptions additional options for DeviceConfig object.
 type AdditionalOptions func(builder *Builder) (*Builder, error)
 
-const errDriverVersionEmpty = "DeviceConfig 'driverVersion' cannot be empty"
+const (
+	errDriverVersionEmpty     = "DeviceConfig 'driverVersion' cannot be empty"
+	errDevicePluginImageEmpty = "DeviceConfig 'devicePluginImage' cannot be empty"
+)
 
 // NewBuilder creates a new instance of Builder.
 func NewBuilder(
@@ -103,7 +106,7 @@ func NewBuilder(
 	if devicePluginImage == "" {
 		klog.V(100).Infof("The devicePluginImage of the DeviceConfig is empty")
 
-		builder.errorMsg = "DeviceConfig 'devicePluginImage' cannot be empty"
+		builder.errorMsg = errDevicePluginImageEmpty
 
 		return builder
 	}
@@ -176,7 +179,7 @@ func NewBuilderWithInClusterBuild(
 	if devicePluginImage == "" {
 		klog.V(100).Infof("The devicePluginImage of the DeviceConfig is empty")
 
-		builder.errorMsg = "DeviceConfig 'devicePluginImage' cannot be empty"
+		builder.errorMsg = errDevicePluginImageEmpty
 
 		return builder
 	}
@@ -276,7 +279,7 @@ func (builder *Builder) WithDriverVersion(version string) *Builder {
 		builder.Definition.Name, builder.Definition.Namespace, version)
 
 	if version == "" {
-		klog.V(100).Infof("DeviceConfig 'driverVersion' cannot be empty")
+		klog.V(100).Infof(errDriverVersionEmpty)
 
 		builder.errorMsg = errDriverVersionEmpty
 

--- a/pkg/schemes/neuron/v1beta1/deviceconfig_types.go
+++ b/pkg/schemes/neuron/v1beta1/deviceconfig_types.go
@@ -30,7 +30,9 @@ type DeviceConfigSpec struct {
 	// if the in-tree driver should be used instead of OOT drivers
 	UseInTreeDrivers bool `json:"useInTreeDrivers,omitempty"`
 
-	// defines image that includes drivers
+	// defines image that includes drivers. When empty, the operator triggers
+	// KMM in-cluster builds using a Dockerfile ConfigMap.
+	// +optional
 	DriversImage string `json:"driversImage,omitempty"`
 
 	// defines the Version of the neuron drivers. used for rolling upgrade


### PR DESCRIPTION
Add NewBuilderWithInClusterBuild() constructor that creates a DeviceConfig without DriversImage, triggering KMM in-cluster builds. Mark DriversImage as optional in the CRD types to match upstream operator changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added an in-cluster device configuration builder that sets required metadata and validates the provided driver version and device plugin image.
* **Bug Fixes**
  * Improved consistency of validation feedback for missing driver version and device plugin image inputs.
* **Refactor**
  * Consolidated internal validation messaging used across builder paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->