### PR TITLE
siteconfig: add ListClusterInstances helper

### DIFF
--- a/pkg/siteconfig/clusterinstancelist.go
+++ b/pkg/siteconfig/clusterinstancelist.go
@@ -1,0 +1,68 @@
+package siteconfig
+
+import (
+	"fmt"
+
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/logging"
+	siteconfigv1alpha1 "github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/siteconfig/v1alpha1"
+	"k8s.io/klog/v2"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ListClusterInstances returns a list of ClusterInstances in all namespaces, using the provided options.
+func ListClusterInstances(
+	apiClient *clients.Settings, options ...runtimeclient.ListOptions) ([]*CIBuilder, error) {
+	if apiClient == nil {
+		klog.V(100).Info("ClusterInstances 'apiClient' parameter cannot be nil")
+
+		return nil, fmt.Errorf("failed to list ClusterInstances, 'apiClient' parameter is nil")
+	}
+
+	err := apiClient.AttachScheme(siteconfigv1alpha1.AddToScheme)
+	if err != nil {
+		klog.V(100).Info("Failed to add siteconfig v1alpha1 scheme to client schemes")
+
+		return nil, err
+	}
+
+	logMessage := "Listing ClusterInstances in all namespaces"
+	passedOptions := runtimeclient.ListOptions{}
+
+	if len(options) > 1 {
+		klog.V(100).Info("ClusterInstances 'options' parameter must be empty or single-valued")
+
+		return nil, fmt.Errorf("error: more than one ListOptions was passed")
+	}
+
+	if len(options) == 1 {
+		passedOptions = options[0]
+		logMessage += fmt.Sprintf(" with the options %v", passedOptions)
+	}
+
+	klog.V(100).Info(logMessage)
+
+	clusterInstanceList := new(siteconfigv1alpha1.ClusterInstanceList)
+
+	err = apiClient.List(logging.DiscardContext(), clusterInstanceList, &passedOptions)
+	if err != nil {
+		klog.V(100).Infof("Failed to list ClusterInstances in all namespaces due to %v", err)
+
+		return nil, err
+	}
+
+	var clusterInstanceObjects []*CIBuilder
+
+	for _, clusterInstance := range clusterInstanceList.Items {
+		copiedClusterInstance := clusterInstance
+		clusterInstanceBuilder := &CIBuilder{
+			apiClient:  apiClient.Client,
+			Object:     &copiedClusterInstance,
+			Definition: &copiedClusterInstance,
+		}
+
+		clusterInstanceObjects = append(clusterInstanceObjects, clusterInstanceBuilder)
+	}
+
+	return clusterInstanceObjects, nil
+}

--- a/pkg/siteconfig/clusterinstancelist_test.go
+++ b/pkg/siteconfig/clusterinstancelist_test.go
@@ -1,0 +1,88 @@
+package siteconfig
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestListClusterInstances(t *testing.T) {
+	testCases := []struct {
+		clusterInstances []*CIBuilder
+		listOptions      []runtimeclient.ListOptions
+		client           bool
+		expectedError    error
+	}{
+		{
+			clusterInstances: []*CIBuilder{buildValidClusterInstanceTestBuilder(
+				buildClusterInstanceClientWithDummyObject())},
+			client:        true,
+			expectedError: nil,
+		},
+		{
+			clusterInstances: []*CIBuilder{buildValidClusterInstanceTestBuilder(
+				buildClusterInstanceClientWithDummyObject())},
+			listOptions:   []runtimeclient.ListOptions{{Continue: "test"}},
+			client:        true,
+			expectedError: nil,
+		},
+		{
+			clusterInstances: []*CIBuilder{buildValidClusterInstanceTestBuilder(
+				buildClusterInstanceClientWithDummyObject())},
+			listOptions: []runtimeclient.ListOptions{
+				{Namespace: "test"},
+				{Continue: "true"},
+			},
+			expectedError: fmt.Errorf("error: more than one ListOptions was passed"),
+			client:        true,
+		},
+		{
+			clusterInstances: []*CIBuilder{buildValidClusterInstanceTestBuilder(
+				buildClusterInstanceClientWithDummyObject())},
+			expectedError: fmt.Errorf("failed to list ClusterInstances, 'apiClient' parameter is nil"),
+			client:        false,
+		},
+		{
+			clusterInstances: nil,
+			client:           true,
+			expectedError:    nil,
+		},
+	}
+
+	for _, testCase := range testCases {
+		var testSettings *clients.Settings
+
+		if testCase.client {
+			if testCase.clusterInstances == nil {
+				testSettings = clients.GetTestClients(clients.TestClientParams{
+					SchemeAttachers: testSchemes,
+				})
+			} else {
+				testSettings = buildClusterInstanceClientWithDummyObject()
+			}
+		}
+
+		builders, err := ListClusterInstances(testSettings, testCase.listOptions...)
+		assert.Equal(t, testCase.expectedError, err)
+
+		if testCase.expectedError == nil {
+			expectedCount := 0
+			if testCase.clusterInstances != nil {
+				expectedCount = len(testCase.clusterInstances)
+			}
+
+			assert.Equal(t, expectedCount, len(builders))
+		}
+	}
+}
+
+func buildClusterInstanceClientWithDummyObject() *clients.Settings {
+	return clients.GetTestClients(clients.TestClientParams{
+		K8sMockObjects:  []runtime.Object{generateClusterInstance()},
+		SchemeAttachers: testSchemes,
+	})
+}


### PR DESCRIPTION
Add a list function for ClusterInstance resources following the existing PtpConfig and ClusterDeployment list patterns, with table-driven tests.

pkg/siteconfig/clusterinstancelist.go — follows the ListPtpConfigs / ListClusterDeploymentsInAllNamespaces pattern:
- Nil client check
- Attaches siteconfigv1alpha1 scheme
- Accepts 0 or 1 ListOptions
- Returns []*CIBuilder with Object and Definition set

pkg/siteconfig/clusterinstancelist_test.go — table-driven tests covering:
- Success with one ClusterInstance
- Single list option
- Too many list options (error)
- Nil client (error)
- Empty cluster (no instances)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to list ClusterInstance resources across all namespaces and return them as builder objects.
* **Bug Fixes**
  * Improved error handling for invalid client input, unsupported option counts, and listing failures.
  * Preserves item data when building returned results.
* **Tests**
  * Added unit coverage for successful listing, empty results, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->