### PR TITLE
oran: add HardwareProfile builder and tests

### DIFF
--- a/pkg/oran/hardwareprofile.go
+++ b/pkg/oran/hardwareprofile.go
@@ -1,0 +1,34 @@
+package oran
+
+import (
+	"context"
+
+	hardwaremanagementv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// HardwareProfileBuilder provides a struct for the HardwareProfile resource containing
+// a connection to the cluster and the HardwareProfile definition.
+type HardwareProfileBuilder struct {
+	common.EmbeddableBuilder[hardwaremanagementv1alpha1.HardwareProfile, *hardwaremanagementv1alpha1.HardwareProfile]
+}
+
+// GetGVK returns the HardwareProfile GVK for this builder.
+func (builder *HardwareProfileBuilder) GetGVK() schema.GroupVersionKind {
+	return hardwaremanagementv1alpha1.GroupVersion.WithKind("HardwareProfile")
+}
+
+// PullHardwareProfile fetches an existing HardwareProfile from the cluster by name and namespace.
+func PullHardwareProfile(apiClient *clients.Settings, name, nsname string) (*HardwareProfileBuilder, error) {
+	return common.PullNamespacedBuilder[hardwaremanagementv1alpha1.HardwareProfile, HardwareProfileBuilder](
+		context.TODO(), apiClient, hardwaremanagementv1alpha1.AddToScheme, name, nsname)
+}
+
+// ListHardwareProfiles returns all HardwareProfile CRs across all namespaces.
+func ListHardwareProfiles(apiClient *clients.Settings, options ...runtimeclient.ListOption) ([]*HardwareProfileBuilder, error) {
+	return common.List[hardwaremanagementv1alpha1.HardwareProfile, hardwaremanagementv1alpha1.HardwareProfileList, HardwareProfileBuilder](
+		context.TODO(), apiClient, hardwaremanagementv1alpha1.AddToScheme, options...)
+}

--- a/pkg/oran/hardwareprofile_test.go
+++ b/pkg/oran/hardwareprofile_test.go
@@ -1,0 +1,53 @@
+package oran
+
+import (
+	"testing"
+
+	hardwaremanagementv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common/testhelper"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var hardwareProfileGVK = hardwaremanagementv1alpha1.GroupVersion.WithKind("HardwareProfile")
+
+func TestPullHardwareProfile(t *testing.T) {
+	t.Parallel()
+
+	testhelper.NewNamespacedPullTestConfig(
+		PullHardwareProfile,
+		hardwaremanagementv1alpha1.AddToScheme,
+		hardwareProfileGVK,
+	).ExecuteTests(t)
+}
+
+func TestListHardwareProfiles(t *testing.T) {
+	t.Parallel()
+
+	testhelper.NewListTestConfig[hardwaremanagementv1alpha1.HardwareProfile, HardwareProfileBuilder](
+		func(apiClient *clients.Settings, options ...runtimeclient.ListOptions) ([]*HardwareProfileBuilder, error) {
+			if len(options) == 0 {
+				return ListHardwareProfiles(apiClient)
+			}
+
+			return ListHardwareProfiles(apiClient, &options[0])
+		},
+		hardwaremanagementv1alpha1.AddToScheme,
+		hardwareProfileGVK,
+	).ExecuteTests(t)
+}
+
+func TestHardwareProfileMethods(t *testing.T) {
+	t.Parallel()
+
+	commonTestConfig := testhelper.NewCommonTestConfig[hardwaremanagementv1alpha1.HardwareProfile, HardwareProfileBuilder](
+		hardwaremanagementv1alpha1.AddToScheme,
+		hardwareProfileGVK,
+		testhelper.ResourceScopeNamespaced,
+	)
+
+	testhelper.NewTestSuite().
+		With(testhelper.NewGetTestConfig(commonTestConfig)).
+		With(testhelper.NewExistsTestConfig(commonTestConfig)).
+		Run(t)
+}


### PR DESCRIPTION
This commit adds a builder and unit tests for the HardwareProfile resource to the oran package. It uses the common builder, similar to the HardwareConfig builder in the ptp package.

Assisted-by: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for working with Hardware Profile resources, including fetching a specific item and listing all available items.
  * Introduced a builder interface for Hardware Profile objects to make them easier to use in workflows.

* **Tests**
  * Added test coverage for retrieving, listing, and validating Hardware Profile behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->