### PR TITLE
lca: add IBI installation config helper for preinstall tests

### DIFF
--- a/pkg/lca/ibiconfig.go
+++ b/pkg/lca/ibiconfig.go
@@ -1,0 +1,170 @@
+package lca
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	assistedv1 "github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/assisted/api/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/yaml"
+)
+
+const (
+	// ImageBasedInstallationConfigVersion is the apiVersion for image-based-installation-config.yaml.
+	ImageBasedInstallationConfigVersion = "v1beta1"
+
+	ibiConfigFileName = "image-based-installation-config.yaml"
+)
+
+// ImageDigestSource defines a source repository and optional mirrors for release-image content
+// in image-based-installation-config.yaml (aligned with openshift/installer/pkg/types.ImageDigestSource).
+type ImageDigestSource struct {
+	Source  string   `json:"source"`
+	Mirrors []string `json:"mirrors,omitempty"`
+}
+
+// InstallationConfig is the API for image-based-installation-config.yaml consumed by openshift-install.
+type InstallationConfig struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	AdditionalTrustBundle  string                `json:"additionalTrustBundle,omitempty"`
+	Architecture           string                `json:"architecture,omitempty"`
+	ExtraPartitionLabel    string                `json:"extraPartitionLabel,omitempty"`
+	IgnitionConfigOverride string                `json:"ignitionConfigOverride,omitempty"`
+	ImageDigestSources     []ImageDigestSource   `json:"imageDigestSources,omitempty"`
+	InstallationDisk       string                `json:"installationDisk"`
+	NetworkConfig          *assistedv1.NetConfig `json:"networkConfig,omitempty"`
+	PullSecret             string                `json:"pullSecret"`
+	SeedImage              string                `json:"seedImage"`
+	SeedVersion            string                `json:"seedVersion"`
+	SSHKey                 string                `json:"sshKey,omitempty"`
+}
+
+// InstallationConfigInput holds values used to build image-based-installation-config.yaml.
+type InstallationConfigInput struct {
+	Architecture           string
+	SeedImage              string
+	SeedVersion            string
+	AdditionalTrustBundle  string
+	ImageDigestSources     []ImageDigestSource
+	PullSecret             string
+	InstallationDisk       string
+	SSHKey                 string
+	NetworkConfig          *assistedv1.NetConfig
+	IgnitionConfigOverride string
+	ExtraPartitionLabel    string
+}
+
+// NormalizeIgnitionConfigOverrideForIBI validates ignition JSON and returns a single-line compact form,
+// matching Ansible `ignition_config | to_json` for use in image-based-installation-config.yaml.
+func NormalizeIgnitionConfigOverrideForIBI(raw string) (string, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", nil
+	}
+
+	var buf bytes.Buffer
+
+	err := json.Compact(&buf, []byte(trimmed))
+	if err != nil {
+		return "", fmt.Errorf("ignitionConfigOverride is not valid JSON: %w", err)
+	}
+
+	return buf.String(), nil
+}
+
+// SeedVersionFromSeedImage derives seedVersion from seedImage for ImageBasedInstallationConfig.
+// Digest-pinned refs (anything after "@") are ignored when extracting a tag: only the repository
+// side of "@" is considered. The tag is the substring after the last ':' only when that ':'
+// follows the last '/' (so digest hex after sha256 is not used as seedVersion, and host:port
+// before the path is not mistaken for a tag).
+func SeedVersionFromSeedImage(seedImage string) string {
+	ref := strings.TrimSpace(seedImage)
+	if ref == "" {
+		return ""
+	}
+
+	if i := strings.Index(ref, "@"); i >= 0 {
+		ref = strings.TrimSpace(ref[:i])
+	}
+
+	if ref == "" {
+		return ""
+	}
+
+	lastSlash := strings.LastIndex(ref, "/")
+
+	lastColon := strings.LastIndex(ref, ":")
+	if lastColon <= lastSlash {
+		return ""
+	}
+
+	return ref[lastColon+1:]
+}
+
+// WriteInstallationConfig writes image-based-installation-config.yaml to destDir.
+func WriteInstallationConfig(data InstallationConfigInput, destDir string) error {
+	klog.V(100).Infof("Generating %s in %s", ibiConfigFileName, destDir)
+
+	ignition := strings.TrimSpace(data.IgnitionConfigOverride)
+	if ignition != "" {
+		normalized, err := NormalizeIgnitionConfigOverrideForIBI(ignition)
+		if err != nil {
+			return fmt.Errorf("ignitionConfigOverride: %w", err)
+		}
+
+		ignition = normalized
+	}
+
+	cfg := InstallationConfig{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: ImageBasedInstallationConfigVersion,
+			Kind:       "ImageBasedInstallationConfig",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "image-based-installation-config",
+		},
+		AdditionalTrustBundle: data.AdditionalTrustBundle,
+		PullSecret:            data.PullSecret,
+		InstallationDisk:      data.InstallationDisk,
+		SSHKey:                data.SSHKey,
+		SeedImage:             data.SeedImage,
+		SeedVersion:           data.SeedVersion,
+		NetworkConfig:         data.NetworkConfig,
+		ImageDigestSources:    data.ImageDigestSources,
+	}
+
+	if data.Architecture != "" {
+		cfg.Architecture = data.Architecture
+	}
+
+	if ignition != "" {
+		cfg.IgnitionConfigOverride = ignition
+	}
+
+	if data.ExtraPartitionLabel != "" {
+		cfg.ExtraPartitionLabel = data.ExtraPartitionLabel
+	}
+
+	out, err := yaml.Marshal(&cfg)
+	if err != nil {
+		return fmt.Errorf("marshal InstallationConfig: %w", err)
+	}
+
+	destPath := filepath.Join(destDir, ibiConfigFileName)
+
+	err = os.WriteFile(destPath, out, 0o600)
+	if err != nil {
+		return fmt.Errorf("failed to write config file: %w", err)
+	}
+
+	klog.V(100).Infof("Successfully generated %s", destPath)
+
+	return nil
+}

--- a/pkg/lca/ibiconfig.go
+++ b/pkg/lca/ibiconfig.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 
 	assistedv1 "github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/assisted/api/v1beta1"
+	"gopkg.in/yaml.v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
-	"sigs.k8s.io/yaml"
 )
 
 const (
@@ -108,6 +108,29 @@ func SeedVersionFromSeedImage(seedImage string) string {
 	return ref[lastColon+1:]
 }
 
+// marshalInstallationConfigYAML renders cfg as YAML using gopkg.in/yaml.v2.
+// JSON is used first so assisted NetConfig custom marshaling is applied.
+func marshalInstallationConfigYAML(cfg *InstallationConfig) ([]byte, error) {
+	jsonBytes, err := json.Marshal(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("marshal InstallationConfig to JSON: %w", err)
+	}
+
+	var doc any
+
+	err = yaml.Unmarshal(jsonBytes, &doc)
+	if err != nil {
+		return nil, fmt.Errorf("convert InstallationConfig JSON to YAML document: %w", err)
+	}
+
+	out, err := yaml.Marshal(doc)
+	if err != nil {
+		return nil, fmt.Errorf("marshal InstallationConfig YAML: %w", err)
+	}
+
+	return out, nil
+}
+
 // WriteInstallationConfig writes image-based-installation-config.yaml to destDir.
 func WriteInstallationConfig(data InstallationConfigInput, destDir string) error {
 	klog.V(100).Infof("Generating %s in %s", ibiConfigFileName, destDir)
@@ -152,7 +175,7 @@ func WriteInstallationConfig(data InstallationConfigInput, destDir string) error
 		cfg.ExtraPartitionLabel = data.ExtraPartitionLabel
 	}
 
-	out, err := yaml.Marshal(&cfg)
+	out, err := marshalInstallationConfigYAML(&cfg)
 	if err != nil {
 		return fmt.Errorf("marshal InstallationConfig: %w", err)
 	}

--- a/pkg/lca/ibiconfig_test.go
+++ b/pkg/lca/ibiconfig_test.go
@@ -3,13 +3,22 @@ package lca
 import (
 	"os"
 	"path/filepath"
-	"strings"
+	"runtime"
 	"testing"
 
 	assistedv1 "github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/assisted/api/v1beta1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func minimalInstallationConfigInput() InstallationConfigInput {
+	return InstallationConfigInput{
+		SeedImage:        "registry.example.com/ocp/release:4.16.0",
+		SeedVersion:      "4.16.0",
+		PullSecret:       `{"auths":{}}`,
+		InstallationDisk: "/dev/disk/by-id/wwn-123",
+	}
+}
 
 func TestNormalizeIgnitionConfigOverrideForIBI(t *testing.T) {
 	t.Parallel()
@@ -65,30 +74,98 @@ func TestSeedVersionFromSeedImage(t *testing.T) {
 func TestWriteInstallationConfig(t *testing.T) {
 	t.Parallel()
 
-	dir := t.TempDir()
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
 
-	err := WriteInstallationConfig(InstallationConfigInput{
-		SeedImage:          "registry.example.com/ocp/release:4.16.0",
-		SeedVersion:        "4.16.0",
-		PullSecret:         `{"auths":{}}`,
-		InstallationDisk:   "/dev/disk/by-id/wwn-123",
-		SSHKey:             "ssh-rsa AAA",
-		Architecture:       "amd64",
-		ExtraPartitionLabel: "var-lib-containers",
-		NetworkConfig:      &assistedv1.NetConfig{Raw: []byte("interfaces: []\n")},
-		ImageDigestSources: []ImageDigestSource{
-			{Source: "quay.io", Mirrors: []string{"mirror.example.com"}},
-		},
-	}, dir)
-	require.NoError(t, err)
+		dir := t.TempDir()
 
-	raw, err := os.ReadFile(filepath.Join(dir, ibiConfigFileName))
-	require.NoError(t, err)
+		err := WriteInstallationConfig(InstallationConfigInput{
+			SeedImage:           "registry.example.com/ocp/release:4.16.0",
+			SeedVersion:         "4.16.0",
+			PullSecret:          `{"auths":{}}`,
+			InstallationDisk:    "/dev/disk/by-id/wwn-123",
+			SSHKey:              "ssh-rsa AAA",
+			Architecture:        "amd64",
+			ExtraPartitionLabel: "var-lib-containers",
+			NetworkConfig:       &assistedv1.NetConfig{Raw: []byte("interfaces: []\n")},
+			ImageDigestSources: []ImageDigestSource{
+				{Source: "quay.io", Mirrors: []string{"mirror.example.com"}},
+			},
+		}, dir)
+		require.NoError(t, err)
 
-	content := string(raw)
-	assert.Contains(t, content, "apiVersion: v1beta1")
-	assert.Contains(t, content, "kind: ImageBasedInstallationConfig")
-	assert.Contains(t, content, "seedVersion: 4.16.0")
-	assert.Contains(t, content, "installationDisk: /dev/disk/by-id/wwn-123")
-	assert.True(t, strings.Contains(content, "interfaces: []") || strings.Contains(content, "interfaces: []"))
+		raw, err := os.ReadFile(filepath.Join(dir, ibiConfigFileName))
+		require.NoError(t, err)
+
+		content := string(raw)
+		assert.Contains(t, content, "apiVersion: v1beta1")
+		assert.Contains(t, content, "kind: ImageBasedInstallationConfig")
+		assert.Contains(t, content, "seedVersion: 4.16.0")
+		assert.Contains(t, content, "installationDisk: /dev/disk/by-id/wwn-123")
+		assert.Contains(t, content, "interfaces: []")
+	})
+
+	t.Run("includes normalized ignition override", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		input := minimalInstallationConfigInput()
+		input.IgnitionConfigOverride = `  {"ignition":{"version":"3.2.0"}}  `
+
+		err := WriteInstallationConfig(input, dir)
+		require.NoError(t, err)
+
+		raw, err := os.ReadFile(filepath.Join(dir, ibiConfigFileName))
+		require.NoError(t, err)
+
+		content := string(raw)
+		assert.Contains(t, content, "ignitionConfigOverride:")
+		assert.Contains(t, content, `{"ignition":{"version":"3.2.0"}}`)
+	})
+}
+
+func TestWriteInstallationConfigErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("invalid ignition override", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		input := minimalInstallationConfigInput()
+		input.IgnitionConfigOverride = "{not-json"
+
+		err := WriteInstallationConfig(input, dir)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ignitionConfigOverride:")
+		assert.Contains(t, err.Error(), "ignitionConfigOverride is not valid JSON")
+
+		_, statErr := os.Stat(filepath.Join(dir, ibiConfigFileName))
+		assert.True(t, os.IsNotExist(statErr))
+	})
+
+	t.Run("missing destination directory", func(t *testing.T) {
+		t.Parallel()
+
+		destDir := filepath.Join(t.TempDir(), "missing", "nested")
+
+		err := WriteInstallationConfig(minimalInstallationConfigInput(), destDir)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to write config file")
+	})
+
+	t.Run("unwritable destination directory", func(t *testing.T) {
+		t.Parallel()
+
+		if runtime.GOOS == "windows" {
+			t.Skip("directory permission modes are not portable on Windows")
+		}
+
+		dir := t.TempDir()
+		require.NoError(t, os.Chmod(dir, 0o500))
+		t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+
+		err := WriteInstallationConfig(minimalInstallationConfigInput(), dir)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to write config file")
+	})
 }

--- a/pkg/lca/ibiconfig_test.go
+++ b/pkg/lca/ibiconfig_test.go
@@ -1,0 +1,94 @@
+package lca
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	assistedv1 "github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/assisted/api/v1beta1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeIgnitionConfigOverrideForIBI(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty", func(t *testing.T) {
+		t.Parallel()
+
+		out, err := NormalizeIgnitionConfigOverrideForIBI("  ")
+		require.NoError(t, err)
+		assert.Empty(t, out)
+	})
+
+	t.Run("valid json compacted", func(t *testing.T) {
+		t.Parallel()
+
+		out, err := NormalizeIgnitionConfigOverrideForIBI(`{"ignition":{"version":"3.2.0"}}`)
+		require.NoError(t, err)
+		assert.Equal(t, `{"ignition":{"version":"3.2.0"}}`, out)
+	})
+
+	t.Run("invalid json", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := NormalizeIgnitionConfigOverrideForIBI("{not-json")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ignitionConfigOverride is not valid JSON")
+	})
+}
+
+func TestSeedVersionFromSeedImage(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name      string
+		seedImage string
+		want      string
+	}{
+		{name: "empty", seedImage: "", want: ""},
+		{name: "tag", seedImage: "registry.example.com/ocp/release:4.16.0", want: "4.16.0"},
+		{name: "digest pinned", seedImage: "registry.example.com/ocp/release@sha256:abc123", want: ""},
+		{name: "host port not tag", seedImage: "registry.example.com:5000/ocp/release", want: ""},
+		{name: "tag after digest stripped", seedImage: "quay.io/foo/bar:4.17.1@sha256:deadbeef", want: "4.17.1"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, SeedVersionFromSeedImage(tc.seedImage))
+		})
+	}
+}
+
+func TestWriteInstallationConfig(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	err := WriteInstallationConfig(InstallationConfigInput{
+		SeedImage:          "registry.example.com/ocp/release:4.16.0",
+		SeedVersion:        "4.16.0",
+		PullSecret:         `{"auths":{}}`,
+		InstallationDisk:   "/dev/disk/by-id/wwn-123",
+		SSHKey:             "ssh-rsa AAA",
+		Architecture:       "amd64",
+		ExtraPartitionLabel: "var-lib-containers",
+		NetworkConfig:      &assistedv1.NetConfig{Raw: []byte("interfaces: []\n")},
+		ImageDigestSources: []ImageDigestSource{
+			{Source: "quay.io", Mirrors: []string{"mirror.example.com"}},
+		},
+	}, dir)
+	require.NoError(t, err)
+
+	raw, err := os.ReadFile(filepath.Join(dir, ibiConfigFileName))
+	require.NoError(t, err)
+
+	content := string(raw)
+	assert.Contains(t, content, "apiVersion: v1beta1")
+	assert.Contains(t, content, "kind: ImageBasedInstallationConfig")
+	assert.Contains(t, content, "seedVersion: 4.16.0")
+	assert.Contains(t, content, "installationDisk: /dev/disk/by-id/wwn-123")
+	assert.True(t, strings.Contains(content, "interfaces: []") || strings.Contains(content, "interfaces: []"))
+}


### PR DESCRIPTION
Expose installer-compatible image-based-installation-config.yaml generation through pkg/lca using assisted NetConfig from pkg/schemes, so eco-gotests can avoid direct openshift/assisted-service and openshift/installer imports.

Assisted by: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for generating image-based installation configuration files.
  * Included automatic handling for compacting ignition override data and deriving a seed version from an image reference.
  * Wrote the generated configuration to the expected output file with secure permissions.

* **Tests**
  * Added coverage for configuration normalization, seed version extraction, and end-to-end file generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->