### PR TITLE
bmc: allow enforcing secure TLS and SSH

### DIFF
--- a/pkg/bmc/bmc.go
+++ b/pkg/bmc/bmc.go
@@ -65,6 +65,13 @@ type BMC struct {
 	sshPort     uint16
 	timeOuts    TimeOuts
 
+	// insecureSkipVerify determines whether to skip redfish TLS certificate verification. The default is true for
+	// backwards compatibility.
+	insecureSkipVerify bool
+	// sshHostKeyCallback is the callback function for SSH host key verification. It is set to nil by default,
+	// meaning SSH host key verification is skipped.
+	sshHostKeyCallback ssh.HostKeyCallback
+
 	systemIndex       int
 	powerControlIndex int
 
@@ -86,6 +93,9 @@ func New(host string) *BMC {
 		timeOuts:          DefaultTimeOuts,
 		systemIndex:       0,
 		powerControlIndex: 0,
+
+		// insecureSkipVerify is set to true by default for backwards compatibility.
+		insecureSkipVerify: true,
 	}
 
 	if host == "" {
@@ -262,6 +272,34 @@ func (bmc *BMC) WithSSHTimeout(timeout time.Duration) *BMC {
 	return bmc
 }
 
+// WithInsecureConnections allows setting whether to skip TLS certificate verification for Redfish connections. The
+// default of true means Redfish TLS verification is skipped.
+func (bmc *BMC) WithInsecureConnections(insecure bool) *BMC {
+	if valid, _ := bmc.validate(); !valid {
+		return bmc
+	}
+
+	bmc.insecureSkipVerify = insecure
+
+	klog.V(100).Infof("Setting insecure redfish connections to %t", insecure)
+
+	return bmc
+}
+
+// WithSSHHostKeyCallback provides a callback to verify the BMC's SSH host key. If no callback is set, host key
+// verification is skipped.
+func (bmc *BMC) WithSSHHostKeyCallback(callback ssh.HostKeyCallback) *BMC {
+	if valid, _ := bmc.validate(); !valid {
+		return bmc
+	}
+
+	bmc.sshHostKeyCallback = callback
+
+	klog.V(100).Info("Setting SSH host key callback")
+
+	return bmc
+}
+
 // SystemManufacturer gets system's manufacturer from the BMC's RedFish API endpoint.
 func (bmc *BMC) SystemManufacturer() (string, error) {
 	if valid, err := bmc.validateRedfish(); !valid {
@@ -274,7 +312,8 @@ func (bmc *BMC) SystemManufacturer() (string, error) {
 		bmc.host,
 		bmc.redfishUser.Name,
 		bmc.redfishUser.Password,
-		bmc.timeOuts.Redfish)
+		bmc.timeOuts.Redfish,
+		bmc.insecureSkipVerify)
 	if err != nil {
 		klog.V(100).Infof("Redfish connection error: %v", err)
 
@@ -308,7 +347,8 @@ func (bmc *BMC) IsSecureBootEnabled() (bool, error) {
 		bmc.host,
 		bmc.redfishUser.Name,
 		bmc.redfishUser.Password,
-		bmc.timeOuts.Redfish)
+		bmc.timeOuts.Redfish,
+		bmc.insecureSkipVerify)
 	if err != nil {
 		klog.V(100).Infof("Redfish connection error: %v", err)
 
@@ -342,7 +382,8 @@ func (bmc *BMC) SecureBootEnable() error {
 		bmc.host,
 		bmc.redfishUser.Name,
 		bmc.redfishUser.Password,
-		bmc.timeOuts.Redfish)
+		bmc.timeOuts.Redfish,
+		bmc.insecureSkipVerify)
 	if err != nil {
 		klog.V(100).Infof("Redfish connection error: %v", err)
 
@@ -391,7 +432,8 @@ func (bmc *BMC) SecureBootDisable() error {
 		bmc.host,
 		bmc.redfishUser.Name,
 		bmc.redfishUser.Password,
-		bmc.timeOuts.Redfish)
+		bmc.timeOuts.Redfish,
+		bmc.insecureSkipVerify)
 	if err != nil {
 		klog.V(100).Infof("Redfish connection error: %v", err)
 
@@ -440,7 +482,8 @@ func (bmc *BMC) SystemResetAction(action redfish.ResetType) error {
 		bmc.host,
 		bmc.redfishUser.Name,
 		bmc.redfishUser.Password,
-		bmc.timeOuts.Redfish)
+		bmc.timeOuts.Redfish,
+		bmc.insecureSkipVerify)
 	if err != nil {
 		klog.V(100).Infof("Redfish connection error: %v", err)
 
@@ -567,7 +610,8 @@ func (bmc *BMC) SystemPowerState() (string, error) {
 		bmc.host,
 		bmc.redfishUser.Name,
 		bmc.redfishUser.Password,
-		bmc.timeOuts.Redfish)
+		bmc.timeOuts.Redfish,
+		bmc.insecureSkipVerify)
 	if err != nil {
 		klog.V(100).Infof("Redfish connection error: %v", err)
 
@@ -623,7 +667,8 @@ func (bmc *BMC) PowerUsage() (float32, error) {
 		bmc.host,
 		bmc.redfishUser.Name,
 		bmc.redfishUser.Password,
-		bmc.timeOuts.Redfish)
+		bmc.timeOuts.Redfish,
+		bmc.insecureSkipVerify)
 	if err != nil {
 		klog.V(100).Infof("Redfish connection error: %v", err)
 
@@ -656,7 +701,8 @@ func (bmc *BMC) SystemBootOptions() (map[string]string, error) {
 		bmc.host,
 		bmc.redfishUser.Name,
 		bmc.redfishUser.Password,
-		bmc.timeOuts.Redfish)
+		bmc.timeOuts.Redfish,
+		bmc.insecureSkipVerify)
 	if err != nil {
 		klog.V(100).Infof("Redfish connection error: %v", err)
 
@@ -704,7 +750,8 @@ func (bmc *BMC) SystemBootOrderReferences() ([]string, error) {
 		bmc.host,
 		bmc.redfishUser.Name,
 		bmc.redfishUser.Password,
-		bmc.timeOuts.Redfish)
+		bmc.timeOuts.Redfish,
+		bmc.insecureSkipVerify)
 	if err != nil {
 		klog.V(100).Infof("Redfish connection error: %v", err)
 
@@ -743,7 +790,8 @@ func (bmc *BMC) SetSystemBootOrderReferences(bootOrderReferences []string) error
 		bmc.host,
 		bmc.redfishUser.Name,
 		bmc.redfishUser.Password,
-		bmc.timeOuts.Redfish)
+		bmc.timeOuts.Redfish,
+		bmc.insecureSkipVerify)
 	if err != nil {
 		klog.V(100).Infof("Redfish connection error: %v", err)
 
@@ -792,7 +840,8 @@ func (bmc *BMC) BootFromCD(isoURL, virtualMediaID string) error {
 		bmc.host,
 		bmc.redfishUser.Name,
 		bmc.redfishUser.Password,
-		bmc.timeOuts.Redfish)
+		bmc.timeOuts.Redfish,
+		bmc.insecureSkipVerify)
 	if err != nil {
 		klog.V(100).Infof("Redfish connection error: %v", err)
 
@@ -1046,15 +1095,16 @@ func (bmc *BMC) CloseSerialConsole() error {
 	return nil
 }
 
-// redfishConnect uses the provided host, credentials, and timeout to produce a gofish APIClient for accessing the
-// Redfish API.
+// redfishConnect uses the provided host, credentials, timeout, and TLS verification setting to produce a gofish
+// APIClient for accessing the Redfish API.
 func redfishConnect(
-	host, user, password string, sessionTimeout time.Duration) (*gofish.APIClient, context.CancelFunc, error) {
+	host, user, password string, sessionTimeout time.Duration, insecureSkipVerify bool) (
+	*gofish.APIClient, context.CancelFunc, error) {
 	gofishConfig := gofish.ClientConfig{
 		Endpoint: "https://" + host,
 		Username: user,
 		Password: password,
-		Insecure: true,
+		Insecure: insecureSkipVerify,
 	}
 
 	ctx, cancel := context.WithTimeout(context.TODO(), sessionTimeout)
@@ -1189,7 +1239,8 @@ func (bmc *BMC) getSupportedResetTypes() ([]redfish.ResetType, error) {
 		bmc.host,
 		bmc.redfishUser.Name,
 		bmc.redfishUser.Password,
-		bmc.timeOuts.Redfish)
+		bmc.timeOuts.Redfish,
+		bmc.insecureSkipVerify)
 	if err != nil {
 		klog.V(100).Infof("Redfish connection error: %v", err)
 
@@ -1211,15 +1262,18 @@ func (bmc *BMC) getSupportedResetTypes() ([]redfish.ResetType, error) {
 	return system.SupportedResetTypes, nil
 }
 
-// createCLISSHClient creates a ssh Session to the host.
-func (bmc *BMC) createCLISSHClient() (*ssh.Client, error) {
+// sshClientConfig builds the SSH client configuration for BMC CLI access.
+func (bmc *BMC) sshClientConfig() (*ssh.ClientConfig, error) {
 	if valid, err := bmc.validateSSH(); !valid {
 		return nil, err
 	}
 
-	klog.V(100).Info("Creating SSH session to run commands in the BMC's CLI.")
+	hostKeyCallback := bmc.sshHostKeyCallback
+	if hostKeyCallback == nil {
+		hostKeyCallback = ssh.InsecureIgnoreHostKey()
+	}
 
-	config := &ssh.ClientConfig{
+	return &ssh.ClientConfig{
 		User: bmc.sshUser.Name,
 		Auth: []ssh.AuthMethod{
 			ssh.Password(bmc.sshUser.Password),
@@ -1235,7 +1289,17 @@ func (bmc *BMC) createCLISSHClient() (*ssh.Client, error) {
 			}),
 		},
 		Timeout:         bmc.timeOuts.SSH,
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		HostKeyCallback: hostKeyCallback,
+	}, nil
+}
+
+// createCLISSHClient creates a ssh Session to the host.
+func (bmc *BMC) createCLISSHClient() (*ssh.Client, error) {
+	klog.V(100).Info("Creating SSH session to run commands in the BMC's CLI.")
+
+	config, err := bmc.sshClientConfig()
+	if err != nil {
+		return nil, err
 	}
 
 	// Establish SSH connection

--- a/pkg/bmc/bmc_test.go
+++ b/pkg/bmc/bmc_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"regexp"
 	"strings"
 	"time"
@@ -16,6 +17,7 @@ import (
 
 	"github.com/stmcginnis/gofish/redfish"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/crypto/ssh"
 )
 
 //go:embed testdata/redfish_v1.json
@@ -117,6 +119,8 @@ func TestBMCNew(t *testing.T) {
 
 			if testCase.expectedErrMsg == "" {
 				assert.Equal(t, testCase.host, bmc.host)
+				assert.True(t, bmc.insecureSkipVerify)
+				assert.Nil(t, bmc.sshHostKeyCallback)
 			}
 		})
 	}
@@ -375,6 +379,147 @@ func TestBMCWithSSHTimeout(t *testing.T) {
 
 			if testCase.expectedErrMsg == "" {
 				assert.Equal(t, testCase.timeout, bmc.timeOuts.Redfish)
+			}
+		})
+	}
+}
+
+func TestBMCWithInsecureConnections(t *testing.T) {
+	testCases := []struct {
+		name     string
+		insecure bool
+	}{
+		{
+			name:     "insecure connections enabled",
+			insecure: true,
+		},
+		{
+			name:     "insecure connections disabled",
+			insecure: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			bmc := New(defaultHost).WithInsecureConnections(testCase.insecure)
+
+			assert.Equal(t, testCase.insecure, bmc.insecureSkipVerify)
+		})
+	}
+}
+
+func TestBMCWithSSHHostKeyCallback(t *testing.T) {
+	customCallback := ssh.HostKeyCallback(func(hostname string, remote net.Addr, key ssh.PublicKey) error {
+		return nil
+	})
+
+	testCases := []struct {
+		name                 string
+		callback             ssh.HostKeyCallback
+		expectCallbackStored bool
+	}{
+		{
+			name:                 "nil callback",
+			callback:             nil,
+			expectCallbackStored: false,
+		},
+		{
+			name:                 "custom callback",
+			callback:             customCallback,
+			expectCallbackStored: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			bmc := New(defaultHost).WithSSHHostKeyCallback(testCase.callback)
+
+			if testCase.expectCallbackStored {
+				assert.NotNil(t, bmc.sshHostKeyCallback)
+			} else {
+				assert.Nil(t, bmc.sshHostKeyCallback)
+			}
+		})
+	}
+}
+
+func TestBMCSSHClientConfigHostKeyCallback(t *testing.T) {
+	customCallback := ssh.HostKeyCallback(func(hostname string, remote net.Addr, key ssh.PublicKey) error {
+		return nil
+	})
+
+	testCases := []struct {
+		name                 string
+		callback             ssh.HostKeyCallback
+		expectCallbackStored bool
+	}{
+		{
+			name:                 "default callback when none configured",
+			callback:             nil,
+			expectCallbackStored: false,
+		},
+		{
+			name:                 "custom callback when configured",
+			callback:             customCallback,
+			expectCallbackStored: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			bmc := New(defaultHost).
+				WithSSHUser(defaultUsername, defaultPassword).
+				WithSSHHostKeyCallback(testCase.callback)
+
+			config, err := bmc.sshClientConfig()
+			assert.NoError(t, err)
+			assert.NotNil(t, config.HostKeyCallback)
+
+			if testCase.expectCallbackStored {
+				assert.NotNil(t, bmc.sshHostKeyCallback)
+			} else {
+				assert.Nil(t, bmc.sshHostKeyCallback)
+			}
+		})
+	}
+}
+
+func TestRedfishConnectTLSVerification(t *testing.T) {
+	redfishServer := createFakeRedfishLocalServer(false, redfishAPIResponseCallbacks{})
+	defer redfishServer.Close()
+
+	host := strings.Split(redfishServer.URL, "//")[1]
+
+	testCases := []struct {
+		name          string
+		insecure      bool
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name:     "insecure connections succeed",
+			insecure: true,
+		},
+		{
+			name:          "secure connections reject self-signed certificate",
+			insecure:      false,
+			expectError:   true,
+			errorContains: "x509",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			bmc := New(host).
+				WithRedfishUser(defaultUsername, defaultPassword).
+				WithInsecureConnections(testCase.insecure)
+
+			_, err := bmc.SystemManufacturer()
+			if testCase.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), testCase.errorContains)
+			} else {
+				assert.NoError(t, err)
 			}
 		})
 	}


### PR DESCRIPTION
This commit adds options for enforcing the verification of TLS certificates when connecting to Redfish and of SSH host keys when connecting to the BMC via SSH. Some basic unit tests are included.

Though the default is left insecure for backwards compatibility, these changes at least allow callers to enable secure connections.

Assisted-by: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added options to control connection security for both TLS and SSH.
  * You can now choose whether certificate checks are enforced and provide a custom SSH host key check.

* **Bug Fixes**
  * Improved connection handling for secure environments while keeping the previous default behavior for existing setups.
  * Updated connection setup so SSH and Redfish sessions use the configured verification settings consistently.

* **Tests**
  * Added coverage for the new connection security options and their default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->