### PR TITLE
argocd: convert to common builder

### DIFF
--- a/pkg/argocd/applications.go
+++ b/pkg/argocd/applications.go
@@ -12,218 +12,55 @@ import (
 	"time"
 
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/logging"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/msg"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common"
 	argocdtypes "github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/argocd/argocdtypes/v1alpha1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
-	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // ApplicationBuilder provides a struct for an application object from the cluster and a definition.
 type ApplicationBuilder struct {
-	// application Definition, used to create the application object.
-	Definition *argocdtypes.Application
-	// created application object.
-	Object *argocdtypes.Application
-	// api client to interact with the cluster.
-	apiClient runtimeclient.Client
-	// used to store latest error message upon defining or mutating application definition.
-	errorMsg string
+	common.EmbeddableBuilder[argocdtypes.Application, *argocdtypes.Application]
+	common.EmbeddableCreator[argocdtypes.Application, ApplicationBuilder, *argocdtypes.Application, *ApplicationBuilder]
+	common.EmbeddableDeleteReturner[argocdtypes.Application, ApplicationBuilder, *argocdtypes.Application, *ApplicationBuilder]
+	common.EmbeddableForceUpdater[argocdtypes.Application, ApplicationBuilder, *argocdtypes.Application, *ApplicationBuilder]
+}
+
+// AttachMixins wires the embedded CRUD mixins to this builder instance.
+func (builder *ApplicationBuilder) AttachMixins() {
+	builder.EmbeddableCreator.SetBase(builder)
+	builder.EmbeddableDeleteReturner.SetBase(builder)
+	builder.EmbeddableForceUpdater.SetBase(builder)
+}
+
+// GetGVK returns the Application GVK for this builder.
+func (builder *ApplicationBuilder) GetGVK() schema.GroupVersionKind {
+	return argocdtypes.ApplicationSchemaGroupVersionKind
+}
+
+// NewApplicationBuilder creates a new ApplicationBuilder instance.
+func NewApplicationBuilder(apiClient *clients.Settings, name, nsname string) *ApplicationBuilder {
+	return common.NewNamespacedBuilder[argocdtypes.Application, ApplicationBuilder](
+		apiClient, argocdtypes.AddToScheme, name, nsname)
 }
 
 // PullApplication pulls existing application into ApplicationBuilder struct.
 func PullApplication(apiClient *clients.Settings, name, nsname string) (*ApplicationBuilder, error) {
-	klog.V(100).Infof("Pulling existing Application name %s under namespace %s from cluster", name, nsname)
-
-	if apiClient == nil {
-		klog.V(100).Info("The apiClient is empty")
-
-		return nil, fmt.Errorf("application 'apiClient' cannot be empty")
-	}
-
-	err := apiClient.AttachScheme(argocdtypes.AddToScheme)
-	if err != nil {
-		klog.V(100).Info("Failed to add argocd Application scheme to client schemes")
-
-		return nil, err
-	}
-
-	builder := &ApplicationBuilder{
-		apiClient: apiClient.Client,
-		Definition: &argocdtypes.Application{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: nsname,
-			},
-		},
-	}
-
-	if name == "" {
-		klog.V(100).Info("The name of the Application is empty")
-
-		return nil, fmt.Errorf("application 'name' cannot be empty")
-	}
-
-	if nsname == "" {
-		klog.V(100).Info("The namespace of the Application is empty")
-
-		return nil, fmt.Errorf("application 'namespace' cannot be empty")
-	}
-
-	if !builder.Exists() {
-		return nil, fmt.Errorf("application object %s does not exist in namespace %s", name, nsname)
-	}
-
-	builder.Definition = builder.Object
-
-	return builder, nil
-}
-
-// Exists checks whether the given argocd application exists.
-func (builder *ApplicationBuilder) Exists() bool {
-	if valid, _ := builder.validate(); !valid {
-		return false
-	}
-
-	klog.V(100).Infof("Checking if argocd app %s exists in namespace %s",
-		builder.Definition.Name, builder.Definition.Namespace)
-
-	var err error
-
-	builder.Object, err = builder.Get()
-
-	return err == nil || !k8serrors.IsNotFound(err)
-}
-
-// Get returns argocd application object if found.
-func (builder *ApplicationBuilder) Get() (*argocdtypes.Application, error) {
-	if valid, err := builder.validate(); !valid {
-		return nil, err
-	}
-
-	klog.V(100).Infof("Getting argocd app %s in namespace %s",
-		builder.Definition.Name, builder.Definition.Namespace)
-
-	application := &argocdtypes.Application{}
-
-	err := builder.apiClient.Get(logging.DiscardContext(), runtimeclient.ObjectKey{
-		Name:      builder.Definition.Name,
-		Namespace: builder.Definition.Namespace,
-	}, application)
-	if err != nil {
-		klog.V(100).Infof(
-			"Failed to Get Application %s in namespace %s", builder.Definition.Name, builder.Definition.Namespace)
-
-		return nil, err
-	}
-
-	return application, nil
-}
-
-// Update renovates the existing argocd application object with the argocd application definition in builder.
-func (builder *ApplicationBuilder) Update(force bool) (*ApplicationBuilder, error) {
-	if valid, err := builder.validate(); !valid {
-		return builder, err
-	}
-
-	klog.V(100).Infof("Updating the argocd application object %s in namespace %s", builder.Definition.Name,
-		builder.Definition.Namespace)
-
-	if !builder.Exists() {
-		klog.V(100).Infof(
-			"Application %s does not exist in namespace %s", builder.Definition.Name, builder.Definition.Namespace)
-
-		return nil, fmt.Errorf("cannot update non-existent Application")
-	}
-
-	builder.Definition.ResourceVersion = builder.Object.ResourceVersion
-
-	err := builder.apiClient.Update(logging.DiscardContext(), builder.Definition)
-	if err != nil {
-		if force {
-			klog.V(100).Infof("%v", msg.FailToUpdateNotification("Application", builder.Definition.Name, builder.Definition.Namespace))
-
-			builder, err := builder.Delete()
-			builder.Definition.ResourceVersion = ""
-
-			if err != nil {
-				klog.V(100).Infof("%v", msg.FailToUpdateError("Application", builder.Definition.Name, builder.Definition.Namespace))
-
-				return nil, err
-			}
-
-			return builder.Create()
-		}
-
-		return nil, err
-	}
-
-	builder.Object = builder.Definition
-
-	return builder, nil
-}
-
-// Delete removes the argocd application object from a cluster.
-func (builder *ApplicationBuilder) Delete() (*ApplicationBuilder, error) {
-	if valid, err := builder.validate(); !valid {
-		return builder, err
-	}
-
-	klog.V(100).Infof("Deleting the argocd application object %s from namespace: %s", builder.Definition.Name,
-		builder.Definition.Namespace)
-
-	if !builder.Exists() {
-		klog.V(100).Infof("application %s in namespace %s cannot be deleted because it does not exist",
-			builder.Definition.Name, builder.Definition.Namespace)
-
-		builder.Object = nil
-
-		return builder, nil
-	}
-
-	err := builder.apiClient.Delete(logging.DiscardContext(), builder.Object)
-	if err != nil {
-		return builder, fmt.Errorf("can not delete argocd application: %w", err)
-	}
-
-	builder.Object = nil
-
-	return builder, nil
-}
-
-// Create makes an argocd application in the cluster and stores the created object in a struct.
-func (builder *ApplicationBuilder) Create() (*ApplicationBuilder, error) {
-	if valid, err := builder.validate(); !valid {
-		return builder, err
-	}
-
-	klog.V(100).Infof("Creating argocd application %s in namespace: %s", builder.Definition.Name,
-		builder.Definition.Namespace)
-
-	var err error
-	if !builder.Exists() {
-		err = builder.apiClient.Create(logging.DiscardContext(), builder.Definition)
-		if err == nil {
-			builder.Object = builder.Definition
-		}
-	}
-
-	return builder, err
+	return common.PullNamespacedBuilder[argocdtypes.Application, ApplicationBuilder](
+		context.TODO(), apiClient, argocdtypes.AddToScheme, name, nsname)
 }
 
 // WithGitDetails applies git details to application definition.
 func (builder *ApplicationBuilder) WithGitDetails(gitRepo, gitBranch, gitPath string) *ApplicationBuilder {
-	if valid, _ := builder.validate(); !valid {
+	if err := common.Validate(builder); err != nil {
 		return builder
 	}
 
 	if gitRepo == "" {
 		klog.V(100).Info("The 'gitRepo' of the argocd application is empty")
 
-		builder.errorMsg = "'gitRepo' parameter is empty"
+		builder.SetError(fmt.Errorf("'gitRepo' parameter is empty"))
 
 		return builder
 	}
@@ -231,7 +68,7 @@ func (builder *ApplicationBuilder) WithGitDetails(gitRepo, gitBranch, gitPath st
 	if gitBranch == "" {
 		klog.V(100).Info("The 'gitBranch' of the argocd application is empty")
 
-		builder.errorMsg = "'gitBranch' parameter is empty"
+		builder.SetError(fmt.Errorf("'gitBranch' parameter is empty"))
 
 		return builder
 	}
@@ -239,7 +76,7 @@ func (builder *ApplicationBuilder) WithGitDetails(gitRepo, gitBranch, gitPath st
 	if gitPath == "" {
 		klog.V(100).Info("The 'gitPath' of the argocd application is empty")
 
-		builder.errorMsg = "'gitPath' parameter is empty"
+		builder.SetError(fmt.Errorf("'gitPath' parameter is empty"))
 
 		return builder
 	}
@@ -249,6 +86,10 @@ func (builder *ApplicationBuilder) WithGitDetails(gitRepo, gitBranch, gitPath st
 			"RepoURL: %s,TargetRevision: %s, Path: %s", builder.Definition.Name, builder.Definition.Namespace,
 		gitRepo, gitBranch, gitPath,
 	)
+
+	if builder.Definition.Spec.Source == nil {
+		builder.Definition.Spec.Source = &argocdtypes.ApplicationSource{}
+	}
 
 	builder.Definition.Spec.Source.RepoURL = gitRepo
 	builder.Definition.Spec.Source.TargetRevision = gitBranch
@@ -261,14 +102,14 @@ func (builder *ApplicationBuilder) WithGitDetails(gitRepo, gitBranch, gitPath st
 // [WithGitDetails] but does not change the RepoURL or TargetRevision and only appends the elements to the Path field,
 // rather than replaces it.
 func (builder *ApplicationBuilder) WithGitPathAppended(elements ...string) *ApplicationBuilder {
-	if valid, _ := builder.validate(); !valid {
+	if err := common.Validate(builder); err != nil {
 		return builder
 	}
 
 	if builder.Definition.Spec.Source == nil {
 		klog.V(100).Info("The source of the argocd application is nil")
 
-		builder.errorMsg = "cannot append to git path because the source is nil"
+		builder.SetError(fmt.Errorf("cannot append to git path because the source is nil"))
 
 		return builder
 	}
@@ -283,7 +124,7 @@ func (builder *ApplicationBuilder) WithGitPathAppended(elements ...string) *Appl
 // expected condition are ignored.
 func (builder *ApplicationBuilder) WaitForCondition(
 	expected argocdtypes.ApplicationCondition, timeout time.Duration) (*ApplicationBuilder, error) {
-	if valid, err := builder.validate(); !valid {
+	if err := common.Validate(builder); err != nil {
 		return nil, err
 	}
 
@@ -337,7 +178,7 @@ func (builder *ApplicationBuilder) WaitForCondition(
 // An expected use of this function may be checking `appBuilder.DoesGitPathExist("ztp-test", "ztp-test-case")` to know
 // if the application source can have the path `ztp-test/ztp-test-case` appended.
 func (builder *ApplicationBuilder) DoesGitPathExist(elements ...string) bool {
-	if valid, _ := builder.validate(); !valid {
+	if err := common.Validate(builder); err != nil {
 		return false
 	}
 
@@ -406,7 +247,7 @@ func (builder *ApplicationBuilder) DoesGitPathExist(elements ...string) bool {
 // WaitForSourceUpdate waits up to timeout until the Application has a source that matches the expected, checking only
 // the RepoURL, Path, and TargetRevision fields. If synced is true, it will also wait until the Application is synced.
 func (builder *ApplicationBuilder) WaitForSourceUpdate(synced bool, timeout time.Duration) error {
-	if valid, err := builder.validate(); !valid {
+	if err := common.Validate(builder); err != nil {
 		return err
 	}
 
@@ -453,36 +294,4 @@ func (builder *ApplicationBuilder) WaitForSourceUpdate(synced bool, timeout time
 
 			return true, nil
 		})
-}
-
-// validate will check that the builder and builder definition are properly initialized before
-// accessing any member fields.
-func (builder *ApplicationBuilder) validate() (bool, error) {
-	resourceCRD := "Application"
-
-	if builder == nil {
-		klog.V(100).Infof("The %s builder is uninitialized", resourceCRD)
-
-		return false, fmt.Errorf("error: received nil %s builder", resourceCRD)
-	}
-
-	if builder.Definition == nil {
-		klog.V(100).Infof("The %s is undefined", resourceCRD)
-
-		return false, fmt.Errorf("%s", msg.UndefinedCrdObjectErrString(resourceCRD))
-	}
-
-	if builder.apiClient == nil {
-		klog.V(100).Infof("The %s builder apiclient is nil", resourceCRD)
-
-		return false, fmt.Errorf("%s builder cannot have nil apiClient", resourceCRD)
-	}
-
-	if builder.errorMsg != "" {
-		klog.V(100).Infof("The %s builder has error message: %s", resourceCRD, builder.errorMsg)
-
-		return false, fmt.Errorf("%s", builder.errorMsg)
-	}
-
-	return true, nil
 }

--- a/pkg/argocd/applications_test.go
+++ b/pkg/argocd/applications_test.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	commonerrors "github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common/errors"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common/testhelper"
 	argocdtypes "github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/argocd/argocdtypes/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,317 +27,163 @@ var (
 		Type:    argocdtypes.ApplicationConditionSyncError,
 		Message: "test-message",
 	}
-	appsTestSchemes = []clients.SchemeAttacher{
-		argocdtypes.AddToScheme,
-	}
+	applicationGVK = argocdtypes.ApplicationSchemaGroupVersionKind
 )
 
+func TestNewApplicationBuilder(t *testing.T) {
+	t.Parallel()
+
+	testhelper.NewNamespacedBuilderTestConfig[argocdtypes.Application, ApplicationBuilder](
+		NewApplicationBuilder, argocdtypes.AddToScheme, applicationGVK,
+	).ExecuteTests(t)
+}
+
 func TestPullApplication(t *testing.T) {
-	generateApplication := func(name, namespace string) *argocdtypes.Application {
-		return &argocdtypes.Application{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: namespace,
-			},
-			Spec: argocdtypes.ApplicationSpec{},
-		}
-	}
+	t.Parallel()
 
-	testCases := []struct {
-		name                string
-		namespace           string
-		addToRuntimeObjects bool
-		expectedError       error
-		client              bool
-	}{
-		{
-			name:                "applicationdtest",
-			namespace:           defaultArgoCdNSName,
-			addToRuntimeObjects: true,
-			expectedError:       nil,
-			client:              true,
-		},
-		{
-			name:                "",
-			namespace:           defaultArgoCdNSName,
-			addToRuntimeObjects: true,
-			expectedError:       fmt.Errorf("application 'name' cannot be empty"),
-			client:              true,
-		},
-		{
-			name:                "applicationtest",
-			namespace:           "",
-			addToRuntimeObjects: true,
-			expectedError:       fmt.Errorf("application 'namespace' cannot be empty"),
-			client:              true,
-		},
-		{
-			name:                "applicationtest",
-			namespace:           defaultArgoCdNSName,
-			addToRuntimeObjects: false,
-			expectedError:       fmt.Errorf("application object applicationtest does not exist in namespace test-namespace"),
-			client:              true,
-		},
-		{
-			name:                "applicationtest",
-			namespace:           defaultArgoCdNSName,
-			addToRuntimeObjects: true,
-			expectedError:       fmt.Errorf("application 'apiClient' cannot be empty"),
-			client:              false,
-		},
-	}
-
-	for _, testCase := range testCases {
-		// Pre-populate the runtime objects
-		var (
-			runtimeObjects []runtime.Object
-			testSettings   *clients.Settings
-		)
-
-		testApplication := generateApplication(testCase.name, testCase.namespace)
-		if testCase.addToRuntimeObjects {
-			runtimeObjects = append(runtimeObjects, testApplication)
-		}
-
-		if testCase.client {
-			testSettings = clients.GetTestClients(clients.TestClientParams{
-				K8sMockObjects:  runtimeObjects,
-				SchemeAttachers: appsTestSchemes,
-			})
-		}
-
-		builderResult, err := PullApplication(testSettings, testCase.name, testCase.namespace)
-		assert.Equal(t, testCase.expectedError, err)
-
-		if testCase.expectedError == nil {
-			assert.Equal(t, testCase.name, builderResult.Object.Name)
-			assert.Equal(t, testCase.namespace, builderResult.Object.Namespace)
-		}
-	}
+	testhelper.NewNamespacedPullTestConfig[argocdtypes.Application, ApplicationBuilder](
+		PullApplication, argocdtypes.AddToScheme, applicationGVK,
+	).ExecuteTests(t)
 }
 
-func TestApplicationExist(t *testing.T) {
-	testCases := []struct {
-		testApplicationBuilder *ApplicationBuilder
-		expectedStatus         bool
-	}{
-		{
-			testApplicationBuilder: buildValidApplicationBuilder(buildApplicationTestClientWithDummyObject()),
-			expectedStatus:         true,
-		},
-		{
-			testApplicationBuilder: buildValidApplicationBuilder(buildApplicationTestClientWithScheme()),
-			expectedStatus:         false,
-		},
-	}
+func TestApplicationBuilderMethods(t *testing.T) {
+	t.Parallel()
 
-	for _, testCase := range testCases {
-		exist := testCase.testApplicationBuilder.Exists()
-		assert.Equal(t, testCase.expectedStatus, exist)
-	}
-}
+	commonTestConfig := testhelper.NewCommonTestConfig[argocdtypes.Application, ApplicationBuilder](
+		argocdtypes.AddToScheme,
+		applicationGVK,
+		testhelper.ResourceScopeNamespaced,
+	)
 
-func TestApplicationGet(t *testing.T) {
-	testCases := []struct {
-		testApplicationBuilder *ApplicationBuilder
-		expectedError          error
-	}{
-		{
-			testApplicationBuilder: buildValidApplicationBuilder(buildApplicationTestClientWithDummyObject()),
-			expectedError:          nil,
-		},
-		{
-			testApplicationBuilder: buildValidApplicationBuilder(buildApplicationTestClientWithScheme()),
-			expectedError:          fmt.Errorf("applications.argoproj.io \"application-name\" not found"),
-		},
-	}
-
-	for _, testCase := range testCases {
-		application, err := testCase.testApplicationBuilder.Get()
-		if testCase.expectedError != nil {
-			assert.Equal(t, testCase.expectedError.Error(), err.Error())
-		}
-
-		if testCase.expectedError == nil {
-			assert.Equal(t, application.Name, testCase.testApplicationBuilder.Definition.Name)
-			assert.Equal(t, application.Namespace, testCase.testApplicationBuilder.Definition.Namespace)
-		}
-	}
-}
-
-func TestApplicationUpdate(t *testing.T) {
-	testCases := []struct {
-		testApplicationBuilder *ApplicationBuilder
-		expectedError          error
-	}{
-		{
-			testApplicationBuilder: buildValidApplicationBuilder(buildApplicationTestClientWithDummyObject()),
-			expectedError:          nil,
-		},
-		{
-			testApplicationBuilder: buildValidApplicationBuilder(buildApplicationTestClientWithScheme()),
-			expectedError:          fmt.Errorf("cannot update non-existent Application"),
-		},
-	}
-
-	for _, testCase := range testCases {
-		assert.Equal(t, testCase.testApplicationBuilder.Definition.Spec.Project, "")
-		testCase.testApplicationBuilder.Definition.Spec.Project = "test"
-
-		application, err := testCase.testApplicationBuilder.Update(false)
-		assert.Equal(t, testCase.expectedError, err)
-
-		if testCase.expectedError == nil {
-			assert.Equal(t, application.Object.Spec.Project, "test")
-		}
-	}
-}
-
-func TestApplicationDelete(t *testing.T) {
-	testCases := []struct {
-		testApplicationBuilder *ApplicationBuilder
-		expectedError          error
-	}{
-		{
-			testApplicationBuilder: buildValidApplicationBuilder(buildApplicationTestClientWithDummyObject()),
-			expectedError:          nil,
-		},
-		{
-			testApplicationBuilder: buildValidApplicationBuilder(buildApplicationTestClientWithScheme()),
-			expectedError:          nil,
-		},
-	}
-
-	for _, testCase := range testCases {
-		_, err := testCase.testApplicationBuilder.Delete()
-
-		if testCase.expectedError != nil {
-			assert.Equal(t, testCase.expectedError.Error(), err.Error())
-		} else {
-			assert.Equal(t, testCase.expectedError, err)
-		}
-
-		assert.Nil(t, testCase.testApplicationBuilder.Object)
-	}
-}
-
-func TestApplicationCreate(t *testing.T) {
-	testCases := []struct {
-		testApplicationBuilder *ApplicationBuilder
-		expectedError          error
-	}{
-		{
-			testApplicationBuilder: buildValidApplicationBuilder(buildApplicationTestClientWithDummyObject()),
-			expectedError:          nil,
-		},
-		{
-			testApplicationBuilder: buildValidApplicationBuilder(buildApplicationTestClientWithScheme()),
-			expectedError:          nil,
-		},
-	}
-
-	for _, testCase := range testCases {
-		_, err := testCase.testApplicationBuilder.Create()
-
-		if testCase.expectedError != nil {
-			assert.Equal(t, testCase.expectedError.Error(), err.Error())
-		} else {
-			assert.Equal(t, testCase.expectedError, err)
-		}
-
-		if testCase.expectedError == nil {
-			assert.Equal(t, testCase.testApplicationBuilder.Definition.Name, testCase.testApplicationBuilder.Object.Name)
-			assert.Equal(
-				t, testCase.testApplicationBuilder.Definition.Namespace, testCase.testApplicationBuilder.Object.Namespace)
-		}
-	}
+	testhelper.NewTestSuite().
+		With(testhelper.NewGetTestConfig(commonTestConfig)).
+		With(testhelper.NewExistsTestConfig(commonTestConfig)).
+		With(testhelper.NewCreateTestConfig(commonTestConfig)).
+		With(testhelper.NewDeleteReturnerTestConfig(commonTestConfig)).
+		With(testhelper.NewForceUpdateTestConfig(commonTestConfig)).
+		Run(t)
 }
 
 func TestApplicationWithGitDetails(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
-		testApplicationBuilder *ApplicationBuilder
-		gitRepo                string
-		gitBranch              string
-		gitPath                string
-		expectedError          string
+		name           string
+		testBuilder    *ApplicationBuilder
+		gitRepo        string
+		gitBranch      string
+		gitPath        string
+		expectedError  error
+		invalidBuilder bool
 	}{
 		{
-			testApplicationBuilder: buildValidApplicationBuilder(buildApplicationTestClientWithDummyObject()),
-			gitRepo:                "http://test.git",
-			gitBranch:              "main",
-			gitPath:                "./dir/www/repo",
-			expectedError:          "",
+			name:          "valid-git-details",
+			testBuilder:   buildValidApplicationBuilder(getApplicationTestClient()),
+			gitRepo:       "http://test.git",
+			gitBranch:     "main",
+			gitPath:       "./dir/www/repo",
+			expectedError: nil,
 		},
 		{
-			testApplicationBuilder: buildValidApplicationBuilder(buildApplicationTestClientWithDummyObject()),
-			gitRepo:                "",
-			gitBranch:              "main",
-			gitPath:                "./dir/www/repo",
-			expectedError:          "'gitRepo' parameter is empty",
+			name:          "empty-git-repo",
+			testBuilder:   buildValidApplicationBuilder(getApplicationTestClient()),
+			gitRepo:       "",
+			gitBranch:     "main",
+			gitPath:       "./dir/www/repo",
+			expectedError: fmt.Errorf("'gitRepo' parameter is empty"),
 		},
 		{
-			testApplicationBuilder: buildValidApplicationBuilder(buildApplicationTestClientWithDummyObject()),
-			gitRepo:                "http://test.git",
-			gitBranch:              "",
-			gitPath:                "./dir/www/repo",
-			expectedError:          "'gitBranch' parameter is empty",
+			name:          "empty-git-branch",
+			testBuilder:   buildValidApplicationBuilder(getApplicationTestClient()),
+			gitRepo:       "http://test.git",
+			gitBranch:     "",
+			gitPath:       "./dir/www/repo",
+			expectedError: fmt.Errorf("'gitBranch' parameter is empty"),
 		},
 		{
-			testApplicationBuilder: buildValidApplicationBuilder(buildApplicationTestClientWithDummyObject()),
-			gitRepo:                "http://test.git",
-			gitBranch:              "main",
-			gitPath:                "",
-			expectedError:          "'gitPath' parameter is empty",
+			name:          "empty-git-path",
+			testBuilder:   buildValidApplicationBuilder(getApplicationTestClient()),
+			gitRepo:       "http://test.git",
+			gitBranch:     "main",
+			gitPath:       "",
+			expectedError: fmt.Errorf("'gitPath' parameter is empty"),
+		},
+		{
+			name:           "invalid-builder",
+			testBuilder:    buildInvalidApplicationBuilder(getApplicationTestClient()),
+			gitRepo:        "http://test.git",
+			gitBranch:      "main",
+			gitPath:        "./dir/www/repo",
+			invalidBuilder: true,
 		},
 	}
 
 	for _, testCase := range testCases {
-		applicationBuilder := testCase.testApplicationBuilder.WithGitDetails(
-			testCase.gitRepo, testCase.gitBranch, testCase.gitPath)
-		assert.Equal(t, testCase.expectedError, applicationBuilder.errorMsg)
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 
-		if testCase.expectedError == "" {
-			assert.Equal(t, applicationBuilder.Definition.Spec.Source.Path, testCase.gitPath)
-			assert.Equal(t, applicationBuilder.Definition.Spec.Source.RepoURL, testCase.gitRepo)
-			assert.Equal(t, applicationBuilder.Definition.Spec.Source.Path, testCase.gitPath)
-		}
+			applicationBuilder := testCase.testBuilder.WithGitDetails(
+				testCase.gitRepo, testCase.gitBranch, testCase.gitPath)
+
+			switch {
+			case testCase.invalidBuilder:
+				assert.True(t, commonerrors.IsBuilderNameEmpty(applicationBuilder.GetError()))
+			case testCase.expectedError != nil:
+				assert.Equal(t, testCase.expectedError, applicationBuilder.GetError())
+			default:
+				assert.NoError(t, applicationBuilder.GetError())
+				assert.Equal(t, testCase.gitPath, applicationBuilder.Definition.Spec.Source.Path)
+				assert.Equal(t, testCase.gitRepo, applicationBuilder.Definition.Spec.Source.RepoURL)
+				assert.Equal(t, testCase.gitBranch, applicationBuilder.Definition.Spec.Source.TargetRevision)
+			}
+		})
 	}
 }
 
 func TestApplicationWithGitPathAppended(t *testing.T) {
+	t.Parallel()
+
 	const testPath = "test/path"
 
 	testCases := []struct {
-		name                   string
-		testApplicationBuilder *ApplicationBuilder
-		hasSource              bool
-		elements               []string
-		expectedPath           string
-		expectedError          string
+		name           string
+		testBuilder    *ApplicationBuilder
+		hasSource      bool
+		elements       []string
+		expectedPath   string
+		expectedError  error
+		invalidBuilder bool
 	}{
 		{
-			name:                   "valid-builder-with-source",
-			testApplicationBuilder: buildValidApplicationBuilder(buildApplicationTestClientWithScheme()),
-			hasSource:              true,
-			elements:               []string{"element1", "element2"},
-			expectedPath:           fmt.Sprintf("%s/%s/%s", testPath, "element1", "element2"),
-			expectedError:          "",
+			name:          "valid-builder-with-source",
+			testBuilder:   buildValidApplicationBuilder(getApplicationTestClient()),
+			hasSource:     true,
+			elements:      []string{"element1", "element2"},
+			expectedPath:  fmt.Sprintf("%s/%s/%s", testPath, "element1", "element2"),
+			expectedError: nil,
 		},
 		{
-			name:                   "no-source",
-			testApplicationBuilder: buildValidApplicationBuilder(buildApplicationTestClientWithScheme()),
-			hasSource:              false,
-			elements:               []string{"element"},
-			expectedPath:           "",
-			expectedError:          "cannot append to git path because the source is nil",
+			name:          "no-source",
+			testBuilder:   buildValidApplicationBuilder(getApplicationTestClient()),
+			hasSource:     false,
+			elements:      []string{"element"},
+			expectedPath:  "",
+			expectedError: fmt.Errorf("cannot append to git path because the source is nil"),
 		},
 		{
-			name:                   "no-elements",
-			testApplicationBuilder: buildValidApplicationBuilder(buildApplicationTestClientWithScheme()),
-			hasSource:              true,
-			elements:               []string{},
-			expectedPath:           testPath,
-			expectedError:          "",
+			name:          "no-elements",
+			testBuilder:   buildValidApplicationBuilder(getApplicationTestClient()),
+			hasSource:     true,
+			elements:      []string{},
+			expectedPath:  testPath,
+			expectedError: nil,
+		},
+		{
+			name:           "invalid-builder",
+			testBuilder:    buildInvalidApplicationBuilder(getApplicationTestClient()),
+			hasSource:      true,
+			elements:       []string{"element"},
+			invalidBuilder: true,
 		},
 	}
 
@@ -344,18 +192,22 @@ func TestApplicationWithGitPathAppended(t *testing.T) {
 			t.Parallel()
 
 			if testCase.hasSource {
-				testCase.testApplicationBuilder.Definition.Spec.Source = &argocdtypes.ApplicationSource{
+				testCase.testBuilder.Definition.Spec.Source = &argocdtypes.ApplicationSource{
 					Path: testPath,
 				}
 			} else {
-				// buildDummyAppplication already sets the source so we must reset it to nil.
-				testCase.testApplicationBuilder.Definition.Spec.Source = nil
+				testCase.testBuilder.Definition.Spec.Source = nil
 			}
 
-			applicationBuilder := testCase.testApplicationBuilder.WithGitPathAppended(testCase.elements...)
-			assert.Equal(t, testCase.expectedError, applicationBuilder.errorMsg)
+			applicationBuilder := testCase.testBuilder.WithGitPathAppended(testCase.elements...)
 
-			if testCase.expectedError == "" {
+			switch {
+			case testCase.invalidBuilder:
+				assert.True(t, commonerrors.IsBuilderNameEmpty(applicationBuilder.GetError()))
+			case testCase.expectedError != nil:
+				assert.Equal(t, testCase.expectedError, applicationBuilder.GetError())
+			default:
+				assert.NoError(t, applicationBuilder.GetError())
 				assert.Equal(t, testCase.expectedPath, applicationBuilder.Definition.Spec.Source.Path)
 			}
 		})
@@ -363,23 +215,29 @@ func TestApplicationWithGitPathAppended(t *testing.T) {
 }
 
 func TestApplicationWaitForCondition(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
+		name          string
 		exists        bool
 		conditionMet  bool
 		expectedError error
 	}{
 		{
+			name:          "condition-met",
 			exists:        true,
 			conditionMet:  true,
 			expectedError: nil,
 		},
 		{
+			name:         "application-does-not-exist",
 			exists:       false,
 			conditionMet: true,
 			expectedError: fmt.Errorf(
 				"application object %s in namespace %s does not exist", defaultApplicationName, defaultApplicationNsName),
 		},
 		{
+			name:          "condition-not-met",
 			exists:        true,
 			conditionMet:  false,
 			expectedError: context.DeadlineExceeded,
@@ -387,31 +245,37 @@ func TestApplicationWaitForCondition(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		var runtimeObjects []runtime.Object
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 
-		if testCase.exists {
-			application := buildDummyApplication(defaultApplicationName, defaultApplicationNsName)
+			var runtimeObjects []runtime.Object
 
-			if testCase.conditionMet {
-				application.Status.Conditions = append(application.Status.Conditions, defaultApplicationCondition)
+			if testCase.exists {
+				application := buildDummyApplication(defaultApplicationName, defaultApplicationNsName)
+
+				if testCase.conditionMet {
+					application.Status.Conditions = append(application.Status.Conditions, defaultApplicationCondition)
+				}
+
+				runtimeObjects = append(runtimeObjects, application)
 			}
 
-			runtimeObjects = append(runtimeObjects, application)
-		}
+			testSettings := clients.GetTestClients(clients.TestClientParams{
+				K8sMockObjects:  runtimeObjects,
+				SchemeAttachers: []clients.SchemeAttacher{argocdtypes.AddToScheme},
+			})
 
-		testSettings := clients.GetTestClients(clients.TestClientParams{
-			K8sMockObjects:  runtimeObjects,
-			SchemeAttachers: appsTestSchemes,
+			testBuilder := buildValidApplicationBuilder(testSettings)
+
+			_, err := testBuilder.WaitForCondition(defaultApplicationCondition, time.Second)
+			assert.Equal(t, testCase.expectedError, err)
 		})
-
-		testBuilder := buildValidApplicationBuilder(testSettings)
-
-		_, err := testBuilder.WaitForCondition(defaultApplicationCondition, time.Second)
-		assert.Equal(t, testCase.expectedError, err)
 	}
 }
 
 func TestApplicationDoesGitPathExist(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		name      string
 		hasSource bool
@@ -475,7 +339,7 @@ func TestApplicationDoesGitPathExist(t *testing.T) {
 				serverURL = "invalid-url"
 			}
 
-			testBuilder := buildValidApplicationBuilder(buildApplicationTestClientWithScheme())
+			testBuilder := buildValidApplicationBuilder(getApplicationTestClient())
 
 			if testCase.hasSource {
 				testBuilder.Definition.Spec.Source = &argocdtypes.ApplicationSource{
@@ -500,6 +364,8 @@ func TestApplicationDoesGitPathExist(t *testing.T) {
 }
 
 func TestApplicationWaitForSourceUpdate(t *testing.T) {
+	t.Parallel()
+
 	var expectedSource = argocdtypes.ApplicationSource{
 		TargetRevision: "main",
 	}
@@ -576,7 +442,7 @@ func TestApplicationWaitForSourceUpdate(t *testing.T) {
 
 			testBuilder := buildValidApplicationBuilder(clients.GetTestClients(clients.TestClientParams{
 				K8sMockObjects:  []runtime.Object{testApp},
-				SchemeAttachers: appsTestSchemes,
+				SchemeAttachers: []clients.SchemeAttacher{argocdtypes.AddToScheme},
 			}))
 
 			err := testBuilder.WaitForSourceUpdate(testCase.expectSynced, time.Second)
@@ -586,33 +452,19 @@ func TestApplicationWaitForSourceUpdate(t *testing.T) {
 }
 
 func buildValidApplicationBuilder(apiClient *clients.Settings) *ApplicationBuilder {
-	return &ApplicationBuilder{
-		apiClient:  apiClient.Client,
-		Definition: buildDummyApplication(defaultApplicationName, defaultApplicationNsName),
-	}
+	builder := NewApplicationBuilder(apiClient, defaultApplicationName, defaultApplicationNsName)
+	builder.Definition.Spec.Source = &argocdtypes.ApplicationSource{}
+
+	return builder
 }
 
-func buildApplicationTestClientWithDummyObject() *clients.Settings {
+func buildInvalidApplicationBuilder(apiClient *clients.Settings) *ApplicationBuilder {
+	return NewApplicationBuilder(apiClient, "", defaultApplicationNsName)
+}
+
+func getApplicationTestClient() *clients.Settings {
 	return clients.GetTestClients(clients.TestClientParams{
-		K8sMockObjects:  buildDummyApplicationRuntime(),
-		SchemeAttachers: appsTestSchemes,
-	})
-}
-
-func buildApplicationTestClientWithScheme() *clients.Settings {
-	return clients.GetTestClients(clients.TestClientParams{
-		SchemeAttachers: appsTestSchemes,
-	})
-}
-
-func buildDummyApplicationRuntime() []runtime.Object {
-	return append([]runtime.Object{}, &argocdtypes.Application{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      defaultApplicationName,
-			Namespace: defaultApplicationNsName,
-		},
-
-		Spec: argocdtypes.ApplicationSpec{},
+		SchemeAttachers: []clients.SchemeAttacher{argocdtypes.AddToScheme},
 	})
 }
 

--- a/pkg/argocd/argocd.go
+++ b/pkg/argocd/argocd.go
@@ -1,269 +1,43 @@
 package argocd
 
 import (
-	"fmt"
+	"context"
 
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/logging"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/msg"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common"
 	argocdoperator "github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/argocd/argocdoperator"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog/v2"
-	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // Builder provides struct for the argocd object containing connection to
 // the cluster and the argocd definitions.
 type Builder struct {
-	// argocd Definition, used to create the argocd object.
-	Definition *argocdoperator.ArgoCD
-	// created argocd object.
-	Object *argocdoperator.ArgoCD
-	// api client to interact with the cluster.
-	apiClient runtimeclient.Client
-	// used to store latest error message upon defining the argocd definition.
-	errorMsg string
+	common.EmbeddableBuilder[argocdoperator.ArgoCD, *argocdoperator.ArgoCD]
+	common.EmbeddableCreator[argocdoperator.ArgoCD, Builder, *argocdoperator.ArgoCD, *Builder]
+	common.EmbeddableDeleteReturner[argocdoperator.ArgoCD, Builder, *argocdoperator.ArgoCD, *Builder]
+	common.EmbeddableForceUpdater[argocdoperator.ArgoCD, Builder, *argocdoperator.ArgoCD, *Builder]
+}
+
+// AttachMixins wires the embedded CRUD mixins to this builder instance.
+func (builder *Builder) AttachMixins() {
+	builder.EmbeddableCreator.SetBase(builder)
+	builder.EmbeddableDeleteReturner.SetBase(builder)
+	builder.EmbeddableForceUpdater.SetBase(builder)
+}
+
+// GetGVK returns the ArgoCD GVK for this builder.
+func (builder *Builder) GetGVK() schema.GroupVersionKind {
+	return argocdoperator.GroupVersion.WithKind("ArgoCD")
 }
 
 // NewBuilder creates a new instance of Builder.
 func NewBuilder(apiClient *clients.Settings, name, nsname string) *Builder {
-	klog.V(100).Infof("Initializing new ArgoCD structure with the following params: name: %s, nsname: %s", name, nsname)
-
-	if apiClient == nil {
-		klog.V(100).Info("The apiClient is empty")
-
-		return nil
-	}
-
-	err := apiClient.AttachScheme(argocdoperator.AddToScheme)
-	if err != nil {
-		klog.V(100).Info("Failed to add ArgoCD scheme to client schemes")
-
-		return nil
-	}
-
-	builder := &Builder{
-		apiClient: apiClient.Client,
-		Definition: &argocdoperator.ArgoCD{
-			Spec: argocdoperator.ArgoCDSpec{},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: nsname,
-			},
-		},
-	}
-
-	if name == "" {
-		klog.V(100).Info("The name of the argocd is empty")
-
-		builder.errorMsg = "argocd 'name' cannot be empty"
-
-		return builder
-	}
-
-	if nsname == "" {
-		klog.V(100).Info("The namespace of the argocd is empty")
-
-		builder.errorMsg = "argocd 'nsname' cannot be empty"
-
-		return builder
-	}
-
-	return builder
+	return common.NewNamespacedBuilder[argocdoperator.ArgoCD, Builder](
+		apiClient, argocdoperator.AddToScheme, name, nsname)
 }
 
 // Pull pulls existing argocd from cluster.
 func Pull(apiClient *clients.Settings, name, nsname string) (*Builder, error) {
-	klog.V(100).Infof("Pulling existing argocd name %s under namespace %s from cluster", name, nsname)
-
-	if apiClient == nil {
-		klog.V(100).Info("The apiClient is empty")
-
-		return nil, fmt.Errorf("argocd 'apiClient' cannot be empty")
-	}
-
-	err := apiClient.AttachScheme(argocdoperator.AddToScheme)
-	if err != nil {
-		klog.V(100).Info("Failed to add ArgoCD scheme to client schemes")
-
-		return nil, err
-	}
-
-	builder := Builder{
-		apiClient: apiClient.Client,
-		Definition: &argocdoperator.ArgoCD{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: nsname,
-			},
-		},
-	}
-
-	if name == "" {
-		klog.V(100).Info("The name of the argocd is empty")
-
-		return nil, fmt.Errorf("argocd 'name' cannot be empty")
-	}
-
-	if nsname == "" {
-		klog.V(100).Info("The namespace of the argocd is empty")
-
-		return nil, fmt.Errorf("argocd 'namespace' cannot be empty")
-	}
-
-	if !builder.Exists() {
-		return nil, fmt.Errorf("argocd object %s does not exist in namespace %s", name, nsname)
-	}
-
-	builder.Definition = builder.Object
-
-	return &builder, nil
-}
-
-// Exists checks whether the given argocd exists.
-func (builder *Builder) Exists() bool {
-	if valid, _ := builder.validate(); !valid {
-		return false
-	}
-
-	klog.V(100).Infof("Checking if argocd %s exists in namespace %s",
-		builder.Definition.Name, builder.Definition.Namespace)
-
-	var err error
-
-	builder.Object, err = builder.Get()
-
-	return err == nil || !k8serrors.IsNotFound(err)
-}
-
-// Get returns argocd object if found.
-func (builder *Builder) Get() (*argocdoperator.ArgoCD, error) {
-	if valid, err := builder.validate(); !valid {
-		return nil, err
-	}
-
-	klog.V(100).Infof("Getting argocd %s in namespace %s",
-		builder.Definition.Name, builder.Definition.Namespace)
-
-	argocd := &argocdoperator.ArgoCD{}
-
-	err := builder.apiClient.Get(logging.DiscardContext(), runtimeclient.ObjectKey{
-		Name:      builder.Definition.Name,
-		Namespace: builder.Definition.Namespace,
-	}, argocd)
-	if err != nil {
-		return nil, err
-	}
-
-	return argocd, err
-}
-
-// Create makes an argocd in the cluster and stores the created object in struct.
-func (builder *Builder) Create() (*Builder, error) {
-	if valid, err := builder.validate(); !valid {
-		return builder, err
-	}
-
-	klog.V(100).Infof("Creating the argocd %s in namespace %s",
-		builder.Definition.Name, builder.Definition.Namespace)
-
-	var err error
-	if !builder.Exists() {
-		err = builder.apiClient.Create(logging.DiscardContext(), builder.Definition)
-		if err == nil {
-			builder.Object = builder.Definition
-		}
-	}
-
-	return builder, err
-}
-
-// Delete removes argocd from a cluster.
-func (builder *Builder) Delete() (*Builder, error) {
-	if valid, err := builder.validate(); !valid {
-		return builder, err
-	}
-
-	klog.V(100).Infof("Deleting the argocd %s in namespace %s",
-		builder.Definition.Name, builder.Definition.Namespace)
-
-	if !builder.Exists() {
-		builder.Object = nil
-
-		klog.V(100).Infof("argocd %s in namespace %s cannot be deleted because it does not exist",
-			builder.Definition.Name, builder.Definition.Namespace)
-
-		return builder, nil
-	}
-
-	err := builder.apiClient.Delete(logging.DiscardContext(), builder.Definition)
-	if err != nil {
-		return builder, fmt.Errorf("can not delete argocd: %w", err)
-	}
-
-	builder.Object = nil
-
-	return builder, nil
-}
-
-// Update renovates the existing argocd object with the argocd definition in builder.
-func (builder *Builder) Update(force bool) (*Builder, error) {
-	if valid, err := builder.validate(); !valid {
-		return builder, err
-	}
-
-	klog.V(100).Infof("Updating the argocd object %s", builder.Definition.Name)
-
-	err := builder.apiClient.Update(logging.DiscardContext(), builder.Definition)
-	if err != nil {
-		if force {
-			klog.V(100).Infof("%v", msg.FailToUpdateNotification("argocd", builder.Definition.Name))
-
-			builder, err := builder.Delete()
-			if err != nil {
-				klog.V(100).Infof("%v", msg.FailToUpdateError("argocd", builder.Definition.Name))
-
-				return nil, err
-			}
-
-			return builder.Create()
-		}
-	}
-
-	builder.Object = builder.Definition
-
-	return builder, err
-}
-
-// validate will check that the builder and builder definition are properly initialized before
-// accessing any member fields.
-func (builder *Builder) validate() (bool, error) {
-	resourceCRD := "argocds"
-
-	if builder == nil {
-		klog.V(100).Infof("The %s builder is uninitialized", resourceCRD)
-
-		return false, fmt.Errorf("error: received nil %s builder", resourceCRD)
-	}
-
-	if builder.Definition == nil {
-		klog.V(100).Infof("The %s is undefined", resourceCRD)
-
-		return false, fmt.Errorf("%s", msg.UndefinedCrdObjectErrString(resourceCRD))
-	}
-
-	if builder.apiClient == nil {
-		klog.V(100).Infof("The %s builder apiclient is nil", resourceCRD)
-
-		return false, fmt.Errorf("error: received nil %s builder apiClient", resourceCRD)
-	}
-
-	if builder.errorMsg != "" {
-		klog.V(100).Infof("The %s builder has error message: %s", resourceCRD, builder.errorMsg)
-
-		return false, fmt.Errorf("%s", builder.errorMsg)
-	}
-
-	return true, nil
+	return common.PullNamespacedBuilder[argocdoperator.ArgoCD, Builder](
+		context.TODO(), apiClient, argocdoperator.AddToScheme, name, nsname)
 }

--- a/pkg/argocd/argocd_test.go
+++ b/pkg/argocd/argocd_test.go
@@ -1,324 +1,44 @@
 package argocd
 
 import (
-	"fmt"
 	"testing"
 
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common/testhelper"
 	argocdoperator "github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/argocd/argocdoperator"
-	"github.com/stretchr/testify/assert"
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
-const (
-	defaultArgoCdName   = "argocd"
-	defaultArgoCdNSName = "test-namespace"
-)
+var argoCdGVK = argocdoperator.GroupVersion.WithKind("ArgoCD")
 
-var argoCdTestSchemes = []clients.SchemeAttacher{
-	argocdoperator.AddToScheme,
+func TestNewBuilder(t *testing.T) {
+	t.Parallel()
+
+	testhelper.NewNamespacedBuilderTestConfig[argocdoperator.ArgoCD, Builder](
+		NewBuilder, argocdoperator.AddToScheme, argoCdGVK,
+	).ExecuteTests(t)
 }
 
-func TestArgoCdPull(t *testing.T) {
-	generateArgoCd := func(name, namespace string) *argocdoperator.ArgoCD {
-		return &argocdoperator.ArgoCD{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: namespace,
-			},
-			Spec: argocdoperator.ArgoCDSpec{},
-		}
-	}
+func TestPull(t *testing.T) {
+	t.Parallel()
 
-	testCases := []struct {
-		name                string
-		namespace           string
-		addToRuntimeObjects bool
-		expectedError       error
-		client              bool
-	}{
-		{
-			name:                "argocdtest",
-			namespace:           defaultArgoCdNSName,
-			addToRuntimeObjects: true,
-			expectedError:       nil,
-			client:              true,
-		},
-		{
-			name:                "",
-			namespace:           defaultArgoCdNSName,
-			addToRuntimeObjects: true,
-			expectedError:       fmt.Errorf("argocd 'name' cannot be empty"),
-			client:              true,
-		},
-		{
-			name:                "argocdtest",
-			namespace:           "",
-			addToRuntimeObjects: true,
-			expectedError:       fmt.Errorf("argocd 'namespace' cannot be empty"),
-			client:              true,
-		},
-		{
-			name:                "argocdtest",
-			namespace:           defaultArgoCdNSName,
-			addToRuntimeObjects: false,
-			expectedError:       fmt.Errorf("argocd object argocdtest does not exist in namespace test-namespace"),
-			client:              true,
-		},
-		{
-			name:                "argocdtest",
-			namespace:           defaultArgoCdNSName,
-			addToRuntimeObjects: true,
-			expectedError:       fmt.Errorf("argocd 'apiClient' cannot be empty"),
-			client:              false,
-		},
-	}
-
-	for _, testCase := range testCases {
-		// Pre-populate the runtime objects
-		var runtimeObjects []runtime.Object
-
-		var testSettings *clients.Settings
-
-		testArgoCd := generateArgoCd(testCase.name, testCase.namespace)
-
-		if testCase.addToRuntimeObjects {
-			runtimeObjects = append(runtimeObjects, testArgoCd)
-		}
-
-		if testCase.client {
-			testSettings = clients.GetTestClients(clients.TestClientParams{
-				K8sMockObjects:  runtimeObjects,
-				SchemeAttachers: argoCdTestSchemes,
-			})
-		}
-
-		builderResult, err := Pull(testSettings, testCase.name, testCase.namespace)
-		assert.Equal(t, testCase.expectedError, err)
-
-		if testCase.expectedError == nil {
-			assert.Equal(t, testCase.name, builderResult.Object.Name)
-			assert.Equal(t, testCase.namespace, builderResult.Object.Namespace)
-		}
-	}
+	testhelper.NewNamespacedPullTestConfig[argocdoperator.ArgoCD, Builder](
+		Pull, argocdoperator.AddToScheme, argoCdGVK,
+	).ExecuteTests(t)
 }
 
-func TestArgoCdNewBuilder(t *testing.T) {
-	testCases := []struct {
-		name          string
-		namespace     string
-		expectedError string
-	}{
-		{
-			name:          "argocdtest",
-			namespace:     defaultArgoCdNSName,
-			expectedError: "",
-		},
-		{
-			name:          "",
-			namespace:     defaultArgoCdNSName,
-			expectedError: "argocd 'name' cannot be empty",
-		},
-		{
-			name:          "argocd",
-			namespace:     "",
-			expectedError: "argocd 'nsname' cannot be empty",
-		},
-	}
+func TestBuilderMethods(t *testing.T) {
+	t.Parallel()
 
-	for _, testCase := range testCases {
-		testSettings := buildArgoCdTestClientWithScheme()
-		testArgoCdBuilder := NewBuilder(testSettings, testCase.name, testCase.namespace)
-		assert.Equal(t, testCase.expectedError, testArgoCdBuilder.errorMsg)
-		assert.NotNil(t, testArgoCdBuilder.Definition)
+	commonTestConfig := testhelper.NewCommonTestConfig[argocdoperator.ArgoCD, Builder](
+		argocdoperator.AddToScheme,
+		argoCdGVK,
+		testhelper.ResourceScopeNamespaced,
+	)
 
-		if testCase.expectedError == "" {
-			assert.Equal(t, testCase.name, testArgoCdBuilder.Definition.Name)
-			assert.Equal(t, testCase.namespace, testArgoCdBuilder.Definition.Namespace)
-		}
-	}
-}
-
-func TestArgoCdGet(t *testing.T) {
-	testCases := []struct {
-		testArgoCd    *Builder
-		expectedError error
-	}{
-		{
-			testArgoCd:    buildValidArgoCdBuilder(buildArgoCdTestClientWithDummyObject()),
-			expectedError: nil,
-		},
-		{
-			testArgoCd:    buildInValidArgoCdBuilder(buildArgoCdTestClientWithDummyObject()),
-			expectedError: fmt.Errorf("argocd 'nsname' cannot be empty"),
-		},
-	}
-
-	for _, testCase := range testCases {
-		argoCd, err := testCase.testArgoCd.Get()
-		assert.Equal(t, testCase.expectedError, err)
-
-		if testCase.expectedError == nil {
-			assert.Equal(t, argoCd.Name, testCase.testArgoCd.Definition.Name)
-			assert.Equal(t, argoCd.Namespace, testCase.testArgoCd.Definition.Namespace)
-		}
-	}
-}
-
-func TestArgoCdExist(t *testing.T) {
-	testCases := []struct {
-		testArgoCd     *Builder
-		expectedStatus bool
-	}{
-		{
-			testArgoCd:     buildValidArgoCdBuilder(buildArgoCdTestClientWithDummyObject()),
-			expectedStatus: true,
-		},
-		{
-			testArgoCd:     buildInValidArgoCdBuilder(buildArgoCdTestClientWithDummyObject()),
-			expectedStatus: false,
-		},
-		{
-			testArgoCd:     buildInValidArgoCdBuilder(buildArgoCdTestClientWithScheme()),
-			expectedStatus: false,
-		},
-	}
-
-	for _, testCase := range testCases {
-		exist := testCase.testArgoCd.Exists()
-		assert.Equal(t, testCase.expectedStatus, exist)
-	}
-}
-
-func TestArgoCdCreate(t *testing.T) {
-	testCases := []struct {
-		testArgoCd    *Builder
-		expectedError error
-	}{
-		{
-			testArgoCd:    buildValidArgoCdBuilder(buildArgoCdTestClientWithScheme()),
-			expectedError: nil,
-		},
-		{
-			testArgoCd:    buildInValidArgoCdBuilder(buildArgoCdTestClientWithScheme()),
-			expectedError: fmt.Errorf("argocd 'nsname' cannot be empty"),
-		},
-	}
-
-	for _, testCase := range testCases {
-		testArgoCdBuilder, err := testCase.testArgoCd.Create()
-		assert.Equal(t, testCase.expectedError, err)
-
-		if testCase.expectedError == nil {
-			assert.Equal(t, testArgoCdBuilder.Definition, testArgoCdBuilder.Object)
-		}
-	}
-}
-
-func TestArgoCdDelete(t *testing.T) {
-	testCases := []struct {
-		testArgoCd    *Builder
-		expectedError error
-	}{
-		{
-			testArgoCd:    buildValidArgoCdBuilder(buildArgoCdTestClientWithDummyObject()),
-			expectedError: nil,
-		},
-		{
-			testArgoCd:    buildInValidArgoCdBuilder(buildArgoCdTestClientWithDummyObject()),
-			expectedError: fmt.Errorf("argocd 'nsname' cannot be empty"),
-		},
-		{
-			testArgoCd:    buildValidArgoCdBuilder(buildArgoCdTestClientWithScheme()),
-			expectedError: nil,
-		},
-	}
-
-	for _, testCase := range testCases {
-		_, err := testCase.testArgoCd.Delete()
-		assert.Equal(t, testCase.expectedError, err)
-
-		if testCase.expectedError == nil {
-			assert.Nil(t, testCase.testArgoCd.Object)
-		}
-	}
-}
-
-func TestArgoCdUpdate(t *testing.T) {
-	testCases := []struct {
-		testArgoCd    *Builder
-		expectedError error
-		image         string
-	}{
-		{
-			testArgoCd:    buildValidArgoCdBuilder(buildArgoCdTestClientWithDummyObject()),
-			expectedError: nil,
-			image:         "testimage",
-		},
-		{
-			testArgoCd:    buildInValidArgoCdBuilder(buildArgoCdTestClientWithDummyObject()),
-			expectedError: fmt.Errorf("argocd 'nsname' cannot be empty"),
-			image:         "testimage",
-		},
-		{
-			testArgoCd:    buildValidArgoCdBuilder(buildArgoCdTestClientWithScheme()),
-			expectedError: fmt.Errorf("argocds.argoproj.io \"argocd\" not found"),
-		},
-	}
-
-	for _, testCase := range testCases {
-		assert.Equal(t, "", testCase.testArgoCd.Definition.Spec.Image)
-		testCase.testArgoCd.Definition.ResourceVersion = "999"
-		assert.Equal(t, "", testCase.testArgoCd.Definition.Spec.Image)
-		testCase.testArgoCd.Definition.Spec.Image = testCase.image
-		_, err := testCase.testArgoCd.Update(false)
-
-		if errors.IsNotFound(err) {
-			assert.Equal(t, testCase.expectedError.Error(), err.Error())
-		} else {
-			assert.Equal(t, testCase.expectedError, err)
-		}
-
-		if testCase.expectedError == nil {
-			assert.Equal(t, testCase.image, testCase.testArgoCd.Object.Spec.Image)
-			assert.Equal(t, testCase.testArgoCd.Object, testCase.testArgoCd.Definition)
-		}
-	}
-}
-
-func buildValidArgoCdBuilder(apiClient *clients.Settings) *Builder {
-	return NewBuilder(apiClient, defaultArgoCdName, defaultArgoCdNSName)
-}
-
-func buildInValidArgoCdBuilder(apiClient *clients.Settings) *Builder {
-	return NewBuilder(apiClient, defaultArgoCdName, "")
-}
-
-func buildArgoCdTestClientWithDummyObject() *clients.Settings {
-	return clients.GetTestClients(clients.TestClientParams{
-		K8sMockObjects:  buildDummyArgoCd(),
-		SchemeAttachers: argoCdTestSchemes,
-	})
-}
-
-func buildArgoCdTestClientWithScheme() *clients.Settings {
-	return clients.GetTestClients(clients.TestClientParams{
-		SchemeAttachers: argoCdTestSchemes,
-	})
-}
-
-func buildDummyArgoCd() []runtime.Object {
-	return append([]runtime.Object{}, &argocdoperator.ArgoCD{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:            defaultArgoCdName,
-			Namespace:       defaultArgoCdNSName,
-			ResourceVersion: "999",
-		},
-
-		Spec: argocdoperator.ArgoCDSpec{
-			Image: "",
-		},
-	})
+	testhelper.NewTestSuite().
+		With(testhelper.NewGetTestConfig(commonTestConfig)).
+		With(testhelper.NewExistsTestConfig(commonTestConfig)).
+		With(testhelper.NewCreateTestConfig(commonTestConfig)).
+		With(testhelper.NewDeleteReturnerTestConfig(commonTestConfig)).
+		With(testhelper.NewForceUpdateTestConfig(commonTestConfig)).
+		Run(t)
 }


### PR DESCRIPTION
This commit converts the argocd package, containing both the ArgoCD and the Application resources, to the common builder. There are some methods for the ApplicationBuilder which cannot be replaced with common methods, so they largely remain the same. Their tests are updated slightly to align with the rest of the changes though.

Closes #1355.

Assisted-by: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified Argo CD resource handling to use a shared builder framework, making behavior more consistent across operations.

* **Bug Fixes**
  * Improved validation and error handling when configuring Git source details and related checks.
  * Ensured source fields are initialized safely before use, reducing nil-related failures.

* **Tests**
  * Expanded and modernized test coverage for builder creation, pulling resources, and CRUD-style actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->