### PR TITLE
secret: stop printing secret data

### DIFF
--- a/pkg/secret/secret.go
+++ b/pkg/secret/secret.go
@@ -211,8 +211,8 @@ func (builder *Builder) WithData(data map[string][]byte) *Builder {
 	}
 
 	klog.V(100).Infof(
-		"Defining secret %s in namespace %s with this data: %s",
-		builder.Definition.Name, builder.Definition.Namespace, data)
+		"Defining secret %s in namespace %s with data (redacted)",
+		builder.Definition.Name, builder.Definition.Namespace)
 
 	if len(data) == 0 {
 		klog.V(100).Info("The data of the secret is empty")
@@ -234,8 +234,8 @@ func (builder *Builder) WithStringData(data map[string]string) *Builder {
 	}
 
 	klog.V(100).Infof(
-		"Defining secret %s in namespace %s with this stringData: %s",
-		builder.Definition.Name, builder.Definition.Namespace, data)
+		"Defining secret %s in namespace %s with stringData (redacted)",
+		builder.Definition.Name, builder.Definition.Namespace)
 
 	if len(data) == 0 {
 		klog.V(100).Info("The stringData of the secret is empty")


### PR DESCRIPTION
This commit redacts the secret data from the WithData and WithStringData methods. Though it may be useful to see this data, secret data should be considered sensitive by default and not printed to the console.

Callers may access the data directly if they wish to store it, rather than printing by default.

Assisted-by: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sensitive secret values are now redacted from logs, reducing the risk of accidental data exposure while preserving existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->