### PR TITLE
apiservers: convert to the common builder

### DIFF
--- a/pkg/apiservers/apiserver.go
+++ b/pkg/apiservers/apiserver.go
@@ -1,137 +1,44 @@
 package apiservers
 
 import (
+	"context"
 	"fmt"
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/logging"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/msg"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog/v2"
-	goclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const apiServerName = "cluster"
 
 // APIServerBuilder provides a struct for the config.openshift.io/v1 APIServer object.
 type APIServerBuilder struct {
-	// APIServer definition. Used to define the APIServer object.
-	Definition *configv1.APIServer
-	// Created APIServer object.
-	Object *configv1.APIServer
-	// apiClient opens api connection to the cluster.
-	apiClient goclient.Client
-	// Used in functions that define or mutate APIServer definition. errorMsg is processed before the
-	// APIServer object is created.
-	errorMsg string
+	common.EmbeddableBuilder[configv1.APIServer, *configv1.APIServer]
+	common.EmbeddableUpdater[configv1.APIServer, APIServerBuilder, *configv1.APIServer, *APIServerBuilder]
+}
+
+// AttachMixins wires the embedded mixins to this builder instance.
+func (builder *APIServerBuilder) AttachMixins() {
+	builder.SetBase(builder)
+}
+
+// GetGVK returns the APIServer GVK for this builder.
+func (builder *APIServerBuilder) GetGVK() schema.GroupVersionKind {
+	return configv1.GroupVersion.WithKind("APIServer")
 }
 
 // PullAPIServer pulls the existing config.openshift.io/v1 APIServer singleton from the cluster.
 func PullAPIServer(apiClient *clients.Settings) (*APIServerBuilder, error) {
-	klog.V(100).Infof("Pulling existing APIServer name: %s", apiServerName)
-
-	if apiClient == nil {
-		klog.V(100).Info("The apiClient of the APIServer is nil")
-
-		return nil, fmt.Errorf("apiserver 'apiClient' cannot be nil")
-	}
-
-	err := apiClient.AttachScheme(configv1.Install)
-	if err != nil {
-		klog.V(100).Info("Failed to add config v1 scheme to client schemes")
-
-		return nil, err
-	}
-
-	builder := APIServerBuilder{
-		apiClient: apiClient.Client,
-		Definition: &configv1.APIServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: apiServerName,
-			},
-		},
-	}
-
-	if !builder.Exists() {
-		return nil, fmt.Errorf("apiserver object %s does not exist", apiServerName)
-	}
-
-	builder.Definition = builder.Object
-
-	return &builder, nil
-}
-
-// Get returns the APIServer object from the cluster if it exists.
-func (builder *APIServerBuilder) Get() (*configv1.APIServer, error) {
-	if valid, err := builder.validate(); !valid {
-		return nil, err
-	}
-
-	klog.V(100).Infof("Getting APIServer object %s", builder.Definition.Name)
-
-	apiServerObject := &configv1.APIServer{}
-
-	err := builder.apiClient.Get(logging.DiscardContext(),
-		goclient.ObjectKey{Name: builder.Definition.Name}, apiServerObject)
-	if err != nil {
-		klog.V(100).Infof("Failed to get APIServer %s: %s", builder.Definition.Name, err)
-
-		return nil, err
-	}
-
-	return apiServerObject, nil
-}
-
-// Exists checks whether the given APIServer exists.
-func (builder *APIServerBuilder) Exists() bool {
-	if valid, _ := builder.validate(); !valid {
-		return false
-	}
-
-	klog.V(100).Infof("Checking if APIServer %s exists", builder.Definition.Name)
-
-	var err error
-
-	builder.Object, err = builder.Get()
-	if err != nil {
-		klog.V(100).Infof("Failed to collect APIServer object due to %s", err.Error())
-	}
-
-	return err == nil
-}
-
-// Update renovates the existing APIServer object with the APIServer definition in builder.
-func (builder *APIServerBuilder) Update() (*APIServerBuilder, error) {
-	if valid, err := builder.validate(); !valid {
-		return builder, err
-	}
-
-	klog.V(100).Infof("Updating APIServer %s", builder.Definition.Name)
-
-	if !builder.Exists() {
-		return nil, fmt.Errorf("apiserver object %s does not exist", builder.Definition.Name)
-	}
-
-	builder.Definition.ResourceVersion = builder.Object.ResourceVersion
-	builder.Definition.CreationTimestamp = metav1.Time{}
-
-	err := builder.apiClient.Update(logging.DiscardContext(), builder.Definition)
-	if err != nil {
-		klog.V(100).Infof("Failed to update APIServer %s: %s", builder.Definition.Name, err)
-
-		return nil, err
-	}
-
-	builder.Object = builder.Definition
-
-	return builder, nil
+	return common.PullClusterScopedBuilder[configv1.APIServer, APIServerBuilder](
+		context.TODO(), apiClient, configv1.Install, apiServerName)
 }
 
 // WithTLSAdherence sets the TLS adherence policy on the APIServer definition.
 func (builder *APIServerBuilder) WithTLSAdherence(
 	policy configv1.TLSAdherencePolicy) *APIServerBuilder {
-	if valid, _ := builder.validate(); !valid {
+	if err := common.Validate(builder); err != nil {
 		return builder
 	}
 
@@ -145,14 +52,14 @@ func (builder *APIServerBuilder) WithTLSAdherence(
 // WithTLSSecurityProfile sets the TLS security profile on the APIServer definition.
 func (builder *APIServerBuilder) WithTLSSecurityProfile(
 	profile *configv1.TLSSecurityProfile) *APIServerBuilder {
-	if valid, _ := builder.validate(); !valid {
+	if err := common.Validate(builder); err != nil {
 		return builder
 	}
 
 	klog.V(100).Infof("Setting TLS security profile on APIServer %s", builder.Definition.Name)
 
 	if profile == nil {
-		builder.errorMsg = "apiserver TLS security profile cannot be nil"
+		builder.SetError(fmt.Errorf("apiserver TLS security profile cannot be nil"))
 
 		return builder
 	}
@@ -160,36 +67,4 @@ func (builder *APIServerBuilder) WithTLSSecurityProfile(
 	builder.Definition.Spec.TLSSecurityProfile = profile
 
 	return builder
-}
-
-// validate will check that the builder and builder definition are properly initialized before
-// accessing any member fields.
-func (builder *APIServerBuilder) validate() (bool, error) {
-	resourceCRD := "apiservers.config.openshift.io"
-
-	if builder == nil {
-		klog.V(100).Infof("The %s builder is uninitialized", resourceCRD)
-
-		return false, fmt.Errorf("error: received nil %s builder", resourceCRD)
-	}
-
-	if builder.Definition == nil {
-		klog.V(100).Infof("The %s is undefined", resourceCRD)
-
-		return false, fmt.Errorf("%s", msg.UndefinedCrdObjectErrString(resourceCRD))
-	}
-
-	if builder.apiClient == nil {
-		klog.V(100).Infof("The %s builder apiclient is nil", resourceCRD)
-
-		return false, fmt.Errorf("%s builder cannot have nil apiClient", resourceCRD)
-	}
-
-	if builder.errorMsg != "" {
-		klog.V(100).Infof("The %s builder has error message: %s", resourceCRD, builder.errorMsg)
-
-		return false, fmt.Errorf("%s", builder.errorMsg)
-	}
-
-	return true, nil
 }

--- a/pkg/apiservers/apiserver_test.go
+++ b/pkg/apiservers/apiserver_test.go
@@ -1,291 +1,192 @@
 package apiservers
 
 import (
-	"fmt"
 	"testing"
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common"
+	commonerrors "github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common/errors"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common/testhelper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-var apiServerTestSchemes = []clients.SchemeAttacher{
-	configv1.Install,
-}
+var apiServerGVK = configv1.GroupVersion.WithKind("APIServer")
 
 func TestPullAPIServer(t *testing.T) {
-	testCases := []struct {
-		addToRuntimeObjects bool
-		client              bool
-		expectedError       error
-	}{
-		{
-			addToRuntimeObjects: true,
-			client:              true,
-			expectedError:       nil,
-		},
-		{
-			addToRuntimeObjects: false,
-			client:              true,
-			expectedError:       fmt.Errorf("apiserver object %s does not exist", apiServerName),
-		},
-		{
-			addToRuntimeObjects: true,
-			client:              false,
-			expectedError:       fmt.Errorf("apiserver 'apiClient' cannot be nil"),
-		},
-	}
+	t.Parallel()
 
-	for _, testCase := range testCases {
-		var (
-			runtimeObjects []runtime.Object
-			testSettings   *clients.Settings
-		)
-
-		testAPIServer := buildDummyAPIServer()
-
-		if testCase.addToRuntimeObjects {
-			runtimeObjects = append(runtimeObjects, testAPIServer)
-		}
-
-		if testCase.client {
-			testSettings = clients.GetTestClients(clients.TestClientParams{
-				K8sMockObjects:  runtimeObjects,
-				SchemeAttachers: apiServerTestSchemes,
-			})
-		}
-
-		testBuilder, err := PullAPIServer(testSettings)
-		assert.Equal(t, testCase.expectedError, err)
-
-		if testCase.expectedError == nil {
-			assert.Equal(t, apiServerName, testBuilder.Definition.Name)
-		}
-	}
+	testhelper.NewSingletonClusterScopedPullTestConfig(
+		PullAPIServer,
+		configv1.Install,
+		apiServerGVK,
+		apiServerName,
+	).ExecuteTests(t)
 }
 
-func TestAPIServerGet(t *testing.T) {
-	testCases := []struct {
-		testBuilder   *APIServerBuilder
-		expectedError string
-	}{
-		{
-			testBuilder:   newAPIServerBuilder(buildTestClientWithDummyAPIServer()),
-			expectedError: "",
-		},
-		{
-			testBuilder: newAPIServerBuilder(clients.GetTestClients(clients.TestClientParams{
-				SchemeAttachers: apiServerTestSchemes,
-			})),
-			expectedError: "apiservers.config.openshift.io \"cluster\" not found",
-		},
-	}
+func TestAPIServerBuilderMethods(t *testing.T) {
+	t.Parallel()
 
-	for _, testCase := range testCases {
-		apiServerObject, err := testCase.testBuilder.Get()
+	commonConfig := testhelper.NewCommonTestConfig[configv1.APIServer, APIServerBuilder](
+		configv1.Install, apiServerGVK, testhelper.ResourceScopeClusterScoped)
 
-		if testCase.expectedError == "" {
-			assert.Nil(t, err)
-			assert.Equal(t, testCase.testBuilder.Definition.Name, apiServerObject.Name)
-		} else {
-			assert.EqualError(t, err, testCase.expectedError)
-		}
-	}
-}
-
-func TestAPIServerExists(t *testing.T) {
-	testCases := []struct {
-		testBuilder *APIServerBuilder
-		exists      bool
-	}{
-		{
-			testBuilder: newAPIServerBuilder(buildTestClientWithDummyAPIServer()),
-			exists:      true,
-		},
-		{
-			testBuilder: newAPIServerBuilder(clients.GetTestClients(clients.TestClientParams{
-				SchemeAttachers: apiServerTestSchemes,
-			})),
-			exists: false,
-		},
-	}
-
-	for _, testCase := range testCases {
-		exists := testCase.testBuilder.Exists()
-		assert.Equal(t, testCase.exists, exists)
-	}
-}
-
-func TestAPIServerUpdate(t *testing.T) {
-	testCases := []struct {
-		testBuilder   *APIServerBuilder
-		expectedError error
-	}{
-		{
-			testBuilder:   newAPIServerBuilder(buildTestClientWithDummyAPIServer()),
-			expectedError: nil,
-		},
-		{
-			testBuilder: newAPIServerBuilder(clients.GetTestClients(clients.TestClientParams{
-				SchemeAttachers: apiServerTestSchemes,
-			})),
-			expectedError: fmt.Errorf("apiserver object %s does not exist", apiServerName),
-		},
-	}
-
-	for _, testCase := range testCases {
-		assert.Nil(t, testCase.testBuilder.Definition.Spec.TLSSecurityProfile)
-
-		testCase.testBuilder.Definition.Spec.TLSSecurityProfile = &configv1.TLSSecurityProfile{
-			Type: configv1.TLSProfileOldType,
-		}
-
-		testBuilder, err := testCase.testBuilder.Update()
-		assert.Equal(t, testCase.expectedError, err)
-
-		if testCase.expectedError == nil {
-			assert.Equal(t, configv1.TLSProfileOldType, testBuilder.Object.Spec.TLSSecurityProfile.Type)
-		}
-	}
+	testhelper.NewTestSuite().
+		With(testhelper.NewGetTestConfig(commonConfig)).
+		With(testhelper.NewExistsTestConfig(commonConfig)).
+		With(testhelper.NewUpdateTestConfig(commonConfig)).
+		Run(t)
 }
 
 func TestAPIServerWithTLSAdherence(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
+		name     string
 		policy   configv1.TLSAdherencePolicy
 		expected configv1.TLSAdherencePolicy
+		builder  func() *APIServerBuilder
 	}{
 		{
+			name:     "sets strict policy on valid builder",
 			policy:   configv1.TLSAdherencePolicyStrictAllComponents,
 			expected: configv1.TLSAdherencePolicyStrictAllComponents,
+			builder: func() *APIServerBuilder {
+				return buildValidAPIServerBuilder(buildTestClientWithDummyAPIServer())
+			},
 		},
 		{
+			name:     "sets legacy policy on valid builder",
 			policy:   configv1.TLSAdherencePolicyLegacyAdheringComponentsOnly,
 			expected: configv1.TLSAdherencePolicyLegacyAdheringComponentsOnly,
+			builder: func() *APIServerBuilder {
+				return buildValidAPIServerBuilder(buildTestClientWithDummyAPIServer())
+			},
+		},
+		{
+			name:   "invalid builder short circuits",
+			policy: configv1.TLSAdherencePolicyStrictAllComponents,
+			builder: func() *APIServerBuilder {
+				return buildInvalidAPIServerBuilder(newAPIServerTestClient())
+			},
 		},
 	}
 
 	for _, testCase := range testCases {
-		testBuilder := newAPIServerBuilder(buildTestClientWithDummyAPIServer())
-		result := testBuilder.WithTLSAdherence(testCase.policy)
+		testCase := testCase
 
-		assert.Equal(t, testBuilder, result)
-		assert.Equal(t, testCase.expected, result.Definition.Spec.TLSAdherence)
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			testBuilder := testCase.builder()
+			require.NotNil(t, testBuilder)
+
+			result := testBuilder.WithTLSAdherence(testCase.policy)
+			require.Same(t, testBuilder, result)
+
+			if testCase.expected != "" {
+				require.Nil(t, result.GetError())
+				assert.Equal(t, testCase.expected, result.Definition.Spec.TLSAdherence)
+			} else {
+				require.True(t, commonerrors.IsBuilderNameEmpty(result.GetError()))
+			}
+		})
 	}
 }
 
 func TestAPIServerWithTLSSecurityProfile(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
-		profile       *configv1.TLSSecurityProfile
-		expectedError string
+		name        string
+		profile     *configv1.TLSSecurityProfile
+		assertError func(error) bool
+		expectNil   bool
+		builder     func() *APIServerBuilder
 	}{
 		{
+			name: "sets profile on valid builder",
 			profile: &configv1.TLSSecurityProfile{
 				Type: configv1.TLSProfileIntermediateType,
 			},
-			expectedError: "",
+			assertError: func(err error) bool { return err == nil },
+			builder: func() *APIServerBuilder {
+				return buildValidAPIServerBuilder(buildTestClientWithDummyAPIServer())
+			},
 		},
 		{
-			profile:       nil,
-			expectedError: "apiserver TLS security profile cannot be nil",
+			name:    "nil profile sets builder error",
+			profile: nil,
+			assertError: func(err error) bool {
+				return err != nil && err.Error() == "apiserver TLS security profile cannot be nil"
+			},
+			expectNil: true,
+			builder: func() *APIServerBuilder {
+				return buildValidAPIServerBuilder(buildTestClientWithDummyAPIServer())
+			},
+		},
+		{
+			name: "invalid builder short circuits",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileIntermediateType,
+			},
+			assertError: commonerrors.IsBuilderNameEmpty,
+			expectNil:   true,
+			builder: func() *APIServerBuilder {
+				return buildInvalidAPIServerBuilder(newAPIServerTestClient())
+			},
 		},
 	}
 
 	for _, testCase := range testCases {
-		testBuilder := newAPIServerBuilder(buildTestClientWithDummyAPIServer())
-		result := testBuilder.WithTLSSecurityProfile(testCase.profile)
+		testCase := testCase
 
-		assert.Equal(t, testBuilder, result)
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 
-		if testCase.expectedError == "" {
-			assert.Equal(t, testCase.profile, result.Definition.Spec.TLSSecurityProfile)
-		} else {
-			assert.Equal(t, testCase.expectedError, result.errorMsg)
-		}
+			testBuilder := testCase.builder()
+			require.NotNil(t, testBuilder)
+
+			result := testBuilder.WithTLSSecurityProfile(testCase.profile)
+			require.Same(t, testBuilder, result)
+			require.Truef(t, testCase.assertError(result.GetError()), "unexpected error: %v", result.GetError())
+
+			if testCase.expectNil {
+				assert.Nil(t, result.Definition.Spec.TLSSecurityProfile)
+			} else {
+				assert.Equal(t, testCase.profile, result.Definition.Spec.TLSSecurityProfile)
+			}
+		})
 	}
 }
 
-func TestAPIServerBuilderValidate(t *testing.T) {
-	testCases := []struct {
-		builderNil    bool
-		definitionNil bool
-		apiClientNil  bool
-		builderErrMsg string
-		expectedError string
-	}{
-		{
-			builderNil:    true,
-			expectedError: "error: received nil apiservers.config.openshift.io builder",
-		},
-		{
-			definitionNil: true,
-			expectedError: "can not redefine the undefined apiservers.config.openshift.io",
-		},
-		{
-			apiClientNil:  true,
-			expectedError: "apiservers.config.openshift.io builder cannot have nil apiClient",
-		},
-		{
-			expectedError: "",
-		},
-		{
-			builderErrMsg: "test error",
-			expectedError: "test error",
-		},
-	}
-
-	for _, testCase := range testCases {
-		testBuilder := newAPIServerBuilder(clients.GetTestClients(clients.TestClientParams{
-			SchemeAttachers: apiServerTestSchemes,
-		}))
-
-		if testCase.builderNil {
-			testBuilder = nil
-		}
-
-		if testCase.definitionNil {
-			testBuilder.Definition = nil
-		}
-
-		if testCase.apiClientNil {
-			testBuilder.apiClient = nil
-		}
-
-		if testCase.builderErrMsg != "" {
-			testBuilder.errorMsg = testCase.builderErrMsg
-		}
-
-		valid, err := testBuilder.validate()
-
-		if testCase.expectedError != "" {
-			assert.False(t, valid)
-			assert.Equal(t, testCase.expectedError, err.Error())
-		} else {
-			assert.True(t, valid)
-			assert.Nil(t, err)
-		}
-	}
+func newAPIServerTestClient() *clients.Settings {
+	return clients.GetTestClients(clients.TestClientParams{
+		SchemeAttachers: []clients.SchemeAttacher{configv1.Install},
+	})
 }
 
-func buildDummyAPIServer() *configv1.APIServer {
-	return &configv1.APIServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: apiServerName,
-		},
-	}
+func buildValidAPIServerBuilder(apiClient *clients.Settings) *APIServerBuilder {
+	return common.NewClusterScopedBuilder[configv1.APIServer, APIServerBuilder](
+		apiClient, configv1.Install, apiServerName)
+}
+
+func buildInvalidAPIServerBuilder(apiClient *clients.Settings) *APIServerBuilder {
+	return common.NewClusterScopedBuilder[configv1.APIServer, APIServerBuilder](
+		apiClient, configv1.Install, "")
 }
 
 func buildTestClientWithDummyAPIServer() *clients.Settings {
 	return clients.GetTestClients(clients.TestClientParams{
-		K8sMockObjects:  []runtime.Object{buildDummyAPIServer()},
-		SchemeAttachers: apiServerTestSchemes,
+		K8sMockObjects: []runtime.Object{
+			&configv1.APIServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: apiServerName,
+				},
+			},
+		},
+		SchemeAttachers: []clients.SchemeAttacher{configv1.Install},
 	})
-}
-
-func newAPIServerBuilder(apiClient *clients.Settings) *APIServerBuilder {
-	return &APIServerBuilder{
-		apiClient:  apiClient.Client,
-		Definition: buildDummyAPIServer(),
-	}
 }

--- a/pkg/apiservers/kubeapiserver.go
+++ b/pkg/apiservers/kubeapiserver.go
@@ -6,15 +6,12 @@ import (
 	"time"
 
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/logging"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/msg"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 
 	operatorV1 "github.com/openshift/api/operator/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	goclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -24,86 +21,28 @@ const (
 
 // KubeAPIServerBuilder provides struct for kubeAPIServer object.
 type KubeAPIServerBuilder struct {
-	// KubeApiServer definition. Used to create an kubeAPIServer object.
-	Definition *operatorV1.KubeAPIServer
-	// Created kubeAPIServer object.
-	Object *operatorV1.KubeAPIServer
-	// apiClient opens api connection to the cluster.
-	apiClient goclient.Client
-	// Used in functions that define or mutate kubeAPIServer definition. errorMsg is processed before the
-	// kubeAPIServer object is created.
-	errorMsg string
+	common.EmbeddableBuilder[operatorV1.KubeAPIServer, *operatorV1.KubeAPIServer]
 }
 
 var kubeAPIServerObjName = "cluster"
 
+// AttachMixins wires the embedded mixins to this builder instance.
+func (builder *KubeAPIServerBuilder) AttachMixins() {}
+
+// GetGVK returns the KubeAPIServer GVK for this builder.
+func (builder *KubeAPIServerBuilder) GetGVK() schema.GroupVersionKind {
+	return operatorV1.GroupVersion.WithKind("KubeAPIServer")
+}
+
 // PullKubeAPIServer pulls existing kubeApiServer from the cluster.
 func PullKubeAPIServer(apiClient *clients.Settings) (*KubeAPIServerBuilder, error) {
-	klog.V(100).Info("Pulling existing kubeApiServer from cluster")
-
-	if apiClient == nil {
-		klog.V(100).Info("The apiClient is empty")
-
-		return nil, fmt.Errorf("kubeApiServer 'apiClient' cannot be empty")
-	}
-
-	builder := KubeAPIServerBuilder{
-		apiClient: apiClient.Client,
-		Definition: &operatorV1.KubeAPIServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: kubeAPIServerObjName,
-			},
-		},
-	}
-
-	if !builder.Exists() {
-		return nil, fmt.Errorf("kubeAPIServer object %s does not exist", kubeAPIServerObjName)
-	}
-
-	builder.Definition = builder.Object
-
-	return &builder, nil
-}
-
-// Exists checks whether the given kubeAPIServer exists.
-func (builder *KubeAPIServerBuilder) Exists() bool {
-	if valid, _ := builder.validate(); !valid {
-		return false
-	}
-
-	var err error
-
-	builder.Object, err = builder.Get()
-	if err != nil {
-		klog.V(100).Infof("Failed to collect kubeAPIServer object due to %s", err.Error())
-	}
-
-	return err == nil || !k8serrors.IsNotFound(err)
-}
-
-// Get returns KubeAPIServer object if found.
-func (builder *KubeAPIServerBuilder) Get() (*operatorV1.KubeAPIServer, error) {
-	if valid, err := builder.validate(); !valid {
-		return nil, err
-	}
-
-	kubeAPIServer := &operatorV1.KubeAPIServer{}
-
-	err := builder.apiClient.Get(logging.DiscardContext(), goclient.ObjectKey{
-		Name: builder.Definition.Name,
-	}, kubeAPIServer)
-	if err != nil {
-		klog.V(100).Info("kubeAPIServer object does not exist")
-
-		return nil, err
-	}
-
-	return kubeAPIServer, err
+	return common.PullClusterScopedBuilder[operatorV1.KubeAPIServer, KubeAPIServerBuilder](
+		context.TODO(), apiClient, operatorV1.Install, kubeAPIServerObjName)
 }
 
 // GetCondition get specific kubeAPIServer condition and message if presented.
 func (builder *KubeAPIServerBuilder) GetCondition(conditionType string) (*operatorV1.ConditionStatus, string, error) {
-	if valid, err := builder.validate(); !valid {
+	if err := common.Validate(builder); err != nil {
 		return nil, "", err
 	}
 
@@ -135,7 +74,7 @@ func (builder *KubeAPIServerBuilder) GetCondition(conditionType string) (*operat
 // WaitUntilConditionTrue waits for timeout duration or until kubeAPIServer gets to a specific status.
 func (builder *KubeAPIServerBuilder) WaitUntilConditionTrue(
 	conditionType string, timeout time.Duration) error {
-	if valid, err := builder.validate(); !valid {
+	if err := common.Validate(builder); err != nil {
 		return err
 	}
 
@@ -192,8 +131,6 @@ func (builder *KubeAPIServerBuilder) WaitAllNodesAtTheLatestRevision(timeout tim
 
 	err = wait.PollUntilContextTimeout(
 		context.TODO(), time.Second, timeout, true, func(ctx context.Context) (bool, error) {
-			var err error
-
 			_, reasonMsg, err := builder.GetCondition(conditionType)
 			if err != nil {
 				return false, nil
@@ -212,36 +149,4 @@ func (builder *KubeAPIServerBuilder) WaitAllNodesAtTheLatestRevision(timeout tim
 	}
 
 	return nil
-}
-
-// validate will check that the builder and builder definition are properly initialized before
-// accessing any member fields.
-func (builder *KubeAPIServerBuilder) validate() (bool, error) {
-	resourceCRD := "KubeAPIServer"
-
-	if builder == nil {
-		klog.V(100).Infof("The %s builder is uninitialized", resourceCRD)
-
-		return false, fmt.Errorf("error: received nil %s builder", resourceCRD)
-	}
-
-	if builder.Definition == nil {
-		klog.V(100).Infof("The %s is undefined", resourceCRD)
-
-		return false, fmt.Errorf("%s", msg.UndefinedCrdObjectErrString(resourceCRD))
-	}
-
-	if builder.apiClient == nil {
-		klog.V(100).Infof("The %s builder apiclient is nil", resourceCRD)
-
-		return false, fmt.Errorf("%s builder cannot have nil apiClient", resourceCRD)
-	}
-
-	if builder.errorMsg != "" {
-		klog.V(100).Infof("The %s builder has error message: %s", resourceCRD, builder.errorMsg)
-
-		return false, fmt.Errorf("%s", builder.errorMsg)
-	}
-
-	return true, nil
 }

--- a/pkg/apiservers/kubeapiserver_test.go
+++ b/pkg/apiservers/kubeapiserver_test.go
@@ -7,117 +7,42 @@ import (
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common/testhelper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+var kubeAPIServerGVK = operatorv1.GroupVersion.WithKind("KubeAPIServer")
+
 func TestPullKubeAPIServer(t *testing.T) {
-	generateKubeAPIServer := func() *operatorv1.KubeAPIServer {
-		return &operatorv1.KubeAPIServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: kubeAPIServerObjName,
-			},
-			Spec: operatorv1.KubeAPIServerSpec{},
-		}
-	}
+	t.Parallel()
 
-	testCases := []struct {
-		addToRuntimeObjects bool
-		expectedError       error
-		client              bool
-	}{
-		{
-			addToRuntimeObjects: true,
-			expectedError:       nil,
-			client:              true,
-		},
-		{
-			addToRuntimeObjects: true,
-			expectedError:       fmt.Errorf("kubeApiServer 'apiClient' cannot be empty"),
-			client:              false,
-		},
-		{
-			addToRuntimeObjects: false,
-			expectedError:       fmt.Errorf("kubeAPIServer object cluster does not exist"),
-			client:              true,
-		},
-	}
-
-	for _, testCase := range testCases {
-		// Pre-populate the runtime objects
-		var runtimeObjects []runtime.Object
-
-		var testSettings *clients.Settings
-
-		kubeAPIServer := generateKubeAPIServer()
-
-		if testCase.addToRuntimeObjects {
-			runtimeObjects = append(runtimeObjects, kubeAPIServer)
-		}
-
-		if testCase.client {
-			testSettings = clients.GetTestClients(clients.TestClientParams{K8sMockObjects: runtimeObjects})
-		}
-
-		builderResult, err := PullKubeAPIServer(testSettings)
-
-		assert.Equal(t, testCase.expectedError, err)
-
-		if testCase.expectedError == nil {
-			assert.Equal(t, "cluster", builderResult.Object.Name)
-		}
-	}
+	testhelper.NewSingletonClusterScopedPullTestConfig(
+		PullKubeAPIServer,
+		operatorv1.Install,
+		kubeAPIServerGVK,
+		kubeAPIServerObjName,
+	).ExecuteTests(t)
 }
 
-func TestKubeAPIServerGet(t *testing.T) {
-	testCases := []struct {
-		testKubeAPIServerBuilder *KubeAPIServerBuilder
-		expectedError            error
-	}{
-		{
-			testKubeAPIServerBuilder: buildValidKubeAPIServerBuilder(buildKubeAPIServerWithDummyObject()),
-			expectedError:            nil,
-		},
-		{
-			testKubeAPIServerBuilder: buildValidKubeAPIServerBuilder(clients.GetTestClients(clients.TestClientParams{})),
-			expectedError:            fmt.Errorf("kubeapiservers.operator.openshift.io \"cluster\" not found"),
-		},
-	}
+func TestKubeAPIServerBuilderMethods(t *testing.T) {
+	t.Parallel()
 
-	for _, testCase := range testCases {
-		testKubeAPIServer, err := testCase.testKubeAPIServerBuilder.Get()
+	commonConfig := testhelper.NewCommonTestConfig[operatorv1.KubeAPIServer, KubeAPIServerBuilder](
+		operatorv1.Install, kubeAPIServerGVK, testhelper.ResourceScopeClusterScoped)
 
-		if testCase.expectedError == nil {
-			assert.Equal(t, testKubeAPIServer.Name, testCase.testKubeAPIServerBuilder.Definition.Name)
-		} else {
-			assert.Equal(t, testCase.expectedError.Error(), err.Error())
-		}
-	}
-}
-
-func TestKubeAPIServerExist(t *testing.T) {
-	testCases := []struct {
-		testKubeAPIServerBuilder *KubeAPIServerBuilder
-		expectedStatus           bool
-	}{
-		{
-			testKubeAPIServerBuilder: buildValidKubeAPIServerBuilder(buildKubeAPIServerWithDummyObject()),
-			expectedStatus:           true,
-		},
-		{
-			testKubeAPIServerBuilder: buildValidKubeAPIServerBuilder(clients.GetTestClients(clients.TestClientParams{})),
-			expectedStatus:           false,
-		},
-	}
-
-	for _, testCase := range testCases {
-		status := testCase.testKubeAPIServerBuilder.Exists()
-		assert.Equal(t, testCase.expectedStatus, status)
-	}
+	testhelper.NewTestSuite().
+		With(testhelper.NewGetTestConfig(commonConfig)).
+		With(testhelper.NewExistsTestConfig(commonConfig)).
+		Run(t)
 }
 
 func TestKubeAPIServerGetCondition(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		testKubeAPIServerBuilder *KubeAPIServerBuilder
 		condition                string
@@ -145,170 +70,125 @@ func TestKubeAPIServerGetCondition(t *testing.T) {
 		{
 			condition:                conditionTypeNodeInstallerProgressing,
 			conditionStatus:          operatorv1.ConditionTrue,
-			testKubeAPIServerBuilder: buildValidKubeAPIServerBuilder(clients.GetTestClients(clients.TestClientParams{})),
+			testKubeAPIServerBuilder: buildValidKubeAPIServerBuilder(newKubeAPIServerTestClient()),
 			expectedError:            fmt.Errorf("cluster kubeAPIServer not found"),
 		},
 	}
 
 	for _, testCase := range testCases {
-		status, msg, err := testCase.testKubeAPIServerBuilder.GetCondition(testCase.condition)
-		assert.Equal(t, testCase.expectedError, err)
+		t.Run(testCase.condition, func(t *testing.T) {
+			t.Parallel()
 
-		if err == nil {
-			assert.Equal(t, *status, testCase.conditionStatus)
-		} else {
-			assert.Nil(t, status)
-			assert.Equal(t, "", msg)
-		}
+			status, msg, err := testCase.testKubeAPIServerBuilder.GetCondition(testCase.condition)
+			assert.Equal(t, testCase.expectedError, err)
+
+			if err == nil {
+				assert.Equal(t, *status, testCase.conditionStatus)
+			} else {
+				assert.Nil(t, status)
+				assert.Equal(t, "", msg)
+			}
+		})
 	}
 }
 
 func TestKubeAPIServerWaitUntilConditionTrue(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
+		name                     string
 		testKubeAPIServerBuilder *KubeAPIServerBuilder
 		condition                string
 		expectedError            error
 	}{
 		{
+			name:                     "condition becomes true",
 			condition:                conditionTypeNodeInstallerProgressing,
 			testKubeAPIServerBuilder: buildValidKubeAPIServerBuilder(buildKubeAPIServerWithDummyObject()),
 			expectedError:            nil,
 		},
 		{
+			name:                     "unknown condition times out",
 			condition:                "unavailable",
 			testKubeAPIServerBuilder: buildValidKubeAPIServerBuilder(buildKubeAPIServerWithDummyObject()),
 			expectedError:            fmt.Errorf("the unavailable condition not found exists: context deadline exceeded"),
 		},
 		{
+			name:                     "empty condition type",
 			condition:                "",
 			testKubeAPIServerBuilder: buildValidKubeAPIServerBuilder(buildKubeAPIServerWithDummyObject()),
 			expectedError:            fmt.Errorf("kubeAPIServer 'conditionType' cannot be empty"),
 		},
 		{
+			name:                     "resource not found",
 			condition:                conditionTypeNodeInstallerProgressing,
-			testKubeAPIServerBuilder: buildValidKubeAPIServerBuilder(clients.GetTestClients(clients.TestClientParams{})),
+			testKubeAPIServerBuilder: buildValidKubeAPIServerBuilder(newKubeAPIServerTestClient()),
 			expectedError:            fmt.Errorf("cluster kubeAPIServer not found"),
 		},
 	}
 
 	for _, testCase := range testCases {
-		err := testCase.testKubeAPIServerBuilder.WaitUntilConditionTrue(testCase.condition, 1*time.Second)
-		if err != nil {
-			assert.Equal(t, testCase.expectedError.Error(), err.Error())
-		}
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := testCase.testKubeAPIServerBuilder.WaitUntilConditionTrue(testCase.condition, 1*time.Second)
+			if testCase.expectedError != nil {
+				require.EqualError(t, err, testCase.expectedError.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
 	}
 }
 
 func TestKubeAPIServerWaitAllNodesAtTheLatestRevision(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
+		name                     string
 		testKubeAPIServerBuilder *KubeAPIServerBuilder
 		expectedError            error
 	}{
 		{
+			name:                     "all nodes at latest revision",
 			testKubeAPIServerBuilder: buildValidKubeAPIServerBuilder(buildKubeAPIServerWithDummyObject()),
 			expectedError:            nil,
 		},
 		{
-			testKubeAPIServerBuilder: buildValidKubeAPIServerBuilder(buildKubeAPIServerWithDummyObject()),
-			expectedError:            fmt.Errorf("the unavailable condition not found exists: context deadline exceeded"),
-		},
-		{
-			testKubeAPIServerBuilder: buildValidKubeAPIServerBuilder(buildKubeAPIServerWithDummyObject()),
-			expectedError:            fmt.Errorf("kubeAPIServer 'conditionType' cannot be empty"),
-		},
-		{
-			testKubeAPIServerBuilder: buildValidKubeAPIServerBuilder(clients.GetTestClients(clients.TestClientParams{})),
+			name:                     "resource not found",
+			testKubeAPIServerBuilder: buildValidKubeAPIServerBuilder(newKubeAPIServerTestClient()),
 			expectedError:            fmt.Errorf("cluster kubeAPIServer not found"),
 		},
 	}
 
 	for _, testCase := range testCases {
-		err := testCase.testKubeAPIServerBuilder.WaitAllNodesAtTheLatestRevision(1 * time.Second)
-		if err != nil {
-			assert.Equal(t, testCase.expectedError.Error(), err.Error())
-		}
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := testCase.testKubeAPIServerBuilder.WaitAllNodesAtTheLatestRevision(1 * time.Second)
+			if testCase.expectedError != nil {
+				require.EqualError(t, err, testCase.expectedError.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
 	}
 }
 
-func TestKubeAPIServerBuilderValidate(t *testing.T) {
-	testCases := []struct {
-		builderNil    bool
-		definitionNil bool
-		apiClientNil  bool
-		expectedError string
-		builderErrMsg string
-	}{
-		{
-			builderNil:    true,
-			definitionNil: false,
-			apiClientNil:  false,
-			expectedError: "error: received nil KubeAPIServer builder",
-			builderErrMsg: "",
-		},
-		{
-			builderNil:    false,
-			definitionNil: true,
-			apiClientNil:  false,
-			expectedError: "can not redefine the undefined KubeAPIServer",
-			builderErrMsg: "",
-		},
-		{
-			builderNil:    false,
-			definitionNil: false,
-			apiClientNil:  true,
-			expectedError: "KubeAPIServer builder cannot have nil apiClient",
-			builderErrMsg: "",
-		},
-		{
-			builderNil:    false,
-			definitionNil: false,
-			apiClientNil:  false,
-			expectedError: "",
-			builderErrMsg: "",
-		},
-		{
-			builderNil:    false,
-			definitionNil: false,
-			apiClientNil:  false,
-			expectedError: "test error",
-			builderErrMsg: "test error",
-		},
-	}
-
-	for _, testCase := range testCases {
-		testBuilder := buildValidKubeAPIServerBuilder(clients.GetTestClients(clients.TestClientParams{}))
-
-		if testCase.builderNil {
-			testBuilder = nil
-		}
-
-		if testCase.definitionNil {
-			testBuilder.Definition = nil
-		}
-
-		if testCase.apiClientNil {
-			testBuilder.apiClient = nil
-		}
-
-		if testCase.builderErrMsg != "" {
-			testBuilder.errorMsg = testCase.builderErrMsg
-		}
-
-		valid, err := testBuilder.validate()
-		if testCase.expectedError != "" {
-			assert.False(t, valid)
-			assert.Equal(t, testCase.expectedError, err.Error())
-		} else {
-			assert.True(t, valid)
-			assert.Nil(t, err)
-		}
-	}
+func newKubeAPIServerTestClient() *clients.Settings {
+	return clients.GetTestClients(clients.TestClientParams{
+		SchemeAttachers: []clients.SchemeAttacher{operatorv1.Install},
+	})
 }
 
 func buildValidKubeAPIServerBuilder(apiClient *clients.Settings) *KubeAPIServerBuilder {
-	return &KubeAPIServerBuilder{
-		apiClient: apiClient.Client,
-		Definition: &operatorv1.KubeAPIServer{
+	return common.NewClusterScopedBuilder[operatorv1.KubeAPIServer, KubeAPIServerBuilder](
+		apiClient, operatorv1.Install, kubeAPIServerObjName)
+}
+
+func buildKubeAPIServerWithDummyObject() *clients.Settings {
+	return clients.GetTestClients(clients.TestClientParams{
+		K8sMockObjects: append([]runtime.Object{}, &operatorv1.KubeAPIServer{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            kubeAPIServerObjName,
 				ResourceVersion: "999",
@@ -322,29 +202,7 @@ func buildValidKubeAPIServerBuilder(apiClient *clients.Settings) *KubeAPIServerB
 					},
 				},
 			},
-		},
-	}
-}
-
-func buildKubeAPIServerWithDummyObject() *clients.Settings {
-	return clients.GetTestClients(clients.TestClientParams{
-		K8sMockObjects: buildDummyKubeAPIServerObject()})
-}
-
-func buildDummyKubeAPIServerObject() []runtime.Object {
-	return append([]runtime.Object{}, &operatorv1.KubeAPIServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:            kubeAPIServerObjName,
-			ResourceVersion: "999",
-		},
-		Spec: operatorv1.KubeAPIServerSpec{},
-		Status: operatorv1.KubeAPIServerStatus{
-			StaticPodOperatorStatus: operatorv1.StaticPodOperatorStatus{
-				OperatorStatus: operatorv1.OperatorStatus{
-					Conditions: []operatorv1.OperatorCondition{
-						{Type: conditionTypeNodeInstallerProgressing, Status: operatorv1.ConditionTrue, Reason: conditionReasonAllNodesAtLatestRevision}},
-				},
-			},
-		},
+		}),
+		SchemeAttachers: []clients.SchemeAttacher{operatorv1.Install},
 	})
 }

--- a/pkg/apiservers/openshiftapiserver.go
+++ b/pkg/apiservers/openshiftapiserver.go
@@ -6,15 +6,12 @@ import (
 	"time"
 
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/logging"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/msg"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 
 	operatorV1 "github.com/openshift/api/operator/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	goclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -26,85 +23,27 @@ var openshiftAPIServerObjName = "cluster"
 
 // OpenshiftAPIServerBuilder provides struct for openshiftAPIServer object.
 type OpenshiftAPIServerBuilder struct {
-	// OpenshiftAPIServer definition. Used to create an openshiftAPIServer object.
-	Definition *operatorV1.OpenShiftAPIServer
-	// Created openshiftAPIServer object.
-	Object *operatorV1.OpenShiftAPIServer
-	// apiClient opens api connection to the cluster.
-	apiClient goclient.Client
-	// Used in functions that define or mutate openshiftAPIServer definition. errorMsg is processed before the
-	// OpenshiftApiServer object is created.
-	errorMsg string
+	common.EmbeddableBuilder[operatorV1.OpenShiftAPIServer, *operatorV1.OpenShiftAPIServer]
+}
+
+// AttachMixins wires the embedded mixins to this builder instance.
+func (builder *OpenshiftAPIServerBuilder) AttachMixins() {}
+
+// GetGVK returns the OpenShiftAPIServer GVK for this builder.
+func (builder *OpenshiftAPIServerBuilder) GetGVK() schema.GroupVersionKind {
+	return operatorV1.GroupVersion.WithKind("OpenShiftAPIServer")
 }
 
 // PullOpenshiftAPIServer pulls existing openshiftApiServer from the cluster.
 func PullOpenshiftAPIServer(apiClient *clients.Settings) (*OpenshiftAPIServerBuilder, error) {
-	klog.V(100).Info("Pulling existing openshiftApiServer from cluster")
-
-	if apiClient == nil {
-		klog.V(100).Info("The apiClient is empty")
-
-		return nil, fmt.Errorf("openshiftApiServer 'apiClient' cannot be empty")
-	}
-
-	builder := OpenshiftAPIServerBuilder{
-		apiClient: apiClient.Client,
-		Definition: &operatorV1.OpenShiftAPIServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: openshiftAPIServerObjName,
-			},
-		},
-	}
-
-	if !builder.Exists() {
-		return nil, fmt.Errorf("openshiftAPIServer object %s does not exist", openshiftAPIServerObjName)
-	}
-
-	builder.Definition = builder.Object
-
-	return &builder, nil
-}
-
-// Exists checks whether the given openshiftAPIServer exists.
-func (builder *OpenshiftAPIServerBuilder) Exists() bool {
-	if valid, _ := builder.validate(); !valid {
-		return false
-	}
-
-	var err error
-
-	builder.Object, err = builder.Get()
-	if err != nil {
-		klog.V(100).Infof("Failed to collect openshiftAPIServer object due to %s", err.Error())
-	}
-
-	return err == nil || !k8serrors.IsNotFound(err)
-}
-
-// Get returns openshiftAPIServer object if found.
-func (builder *OpenshiftAPIServerBuilder) Get() (*operatorV1.OpenShiftAPIServer, error) {
-	if valid, err := builder.validate(); !valid {
-		return nil, err
-	}
-
-	openshiftAPIServer := &operatorV1.OpenShiftAPIServer{}
-
-	err := builder.apiClient.Get(logging.DiscardContext(), goclient.ObjectKey{
-		Name: builder.Definition.Name,
-	}, openshiftAPIServer)
-	if err != nil {
-		klog.V(100).Info("openshiftAPIServer object does not exist")
-
-		return nil, err
-	}
-
-	return openshiftAPIServer, err
+	return common.PullClusterScopedBuilder[operatorV1.OpenShiftAPIServer, OpenshiftAPIServerBuilder](
+		context.TODO(), apiClient, operatorV1.Install, openshiftAPIServerObjName)
 }
 
 // GetCondition get specific openshiftAPIServer condition and message if presented.
 func (builder *OpenshiftAPIServerBuilder) GetCondition(conditionType string) (
 	*operatorV1.ConditionStatus, string, error) {
-	if valid, err := builder.validate(); !valid {
+	if err := common.Validate(builder); err != nil {
 		return nil, "", err
 	}
 
@@ -136,7 +75,7 @@ func (builder *OpenshiftAPIServerBuilder) GetCondition(conditionType string) (
 // WaitUntilConditionTrue waits for timeout duration or until openshiftAPIServer gets to a specific status.
 func (builder *OpenshiftAPIServerBuilder) WaitUntilConditionTrue(
 	conditionType string, timeout time.Duration) error {
-	if valid, err := builder.validate(); !valid {
+	if err := common.Validate(builder); err != nil {
 		return err
 	}
 
@@ -197,8 +136,6 @@ func (builder *OpenshiftAPIServerBuilder) WaitAllPodsAtTheLatestGeneration(timeo
 		timeout,
 		true,
 		func(ctx context.Context) (bool, error) {
-			var err error
-
 			_, reasonMsg, err := builder.GetCondition(conditionType)
 			if err != nil {
 				return false, nil
@@ -217,36 +154,4 @@ func (builder *OpenshiftAPIServerBuilder) WaitAllPodsAtTheLatestGeneration(timeo
 	}
 
 	return nil
-}
-
-// validate will check that the builder and builder definition are properly initialized before
-// accessing any member fields.
-func (builder *OpenshiftAPIServerBuilder) validate() (bool, error) {
-	resourceCRD := "OpenshiftAPIServer"
-
-	if builder == nil {
-		klog.V(100).Infof("The %s builder is uninitialized", resourceCRD)
-
-		return false, fmt.Errorf("error: received nil %s builder", resourceCRD)
-	}
-
-	if builder.Definition == nil {
-		klog.V(100).Infof("The %s is undefined", resourceCRD)
-
-		return false, fmt.Errorf("%s", msg.UndefinedCrdObjectErrString(resourceCRD))
-	}
-
-	if builder.apiClient == nil {
-		klog.V(100).Infof("The %s builder apiclient is nil", resourceCRD)
-
-		return false, fmt.Errorf("%s builder cannot have nil apiClient", resourceCRD)
-	}
-
-	if builder.errorMsg != "" {
-		klog.V(100).Infof("The %s builder has error message: %s", resourceCRD, builder.errorMsg)
-
-		return false, fmt.Errorf("%s", builder.errorMsg)
-	}
-
-	return true, nil
 }

--- a/pkg/apiservers/openshiftapiserver_test.go
+++ b/pkg/apiservers/openshiftapiserver_test.go
@@ -7,120 +7,42 @@ import (
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common/testhelper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+var openshiftAPIServerGVK = operatorv1.GroupVersion.WithKind("OpenShiftAPIServer")
+
 func TestPullOpenshiftAPIServer(t *testing.T) {
-	generateOpenShiftAPIServer := func() *operatorv1.OpenShiftAPIServer {
-		return &operatorv1.OpenShiftAPIServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: openshiftAPIServerObjName,
-			},
-			Spec: operatorv1.OpenShiftAPIServerSpec{},
-		}
-	}
+	t.Parallel()
 
-	testCases := []struct {
-		addToRuntimeObjects bool
-		expectedError       error
-		client              bool
-	}{
-		{
-			addToRuntimeObjects: true,
-			expectedError:       nil,
-			client:              true,
-		},
-		{
-			addToRuntimeObjects: true,
-			expectedError:       fmt.Errorf("openshiftApiServer 'apiClient' cannot be empty"),
-			client:              false,
-		},
-		{
-			addToRuntimeObjects: false,
-			expectedError:       fmt.Errorf("openshiftAPIServer object cluster does not exist"),
-			client:              true,
-		},
-	}
-
-	for _, testCase := range testCases {
-		// Pre-populate the runtime objects
-		var runtimeObjects []runtime.Object
-
-		var testSettings *clients.Settings
-
-		openShiftAPIServer := generateOpenShiftAPIServer()
-
-		if testCase.addToRuntimeObjects {
-			runtimeObjects = append(runtimeObjects, openShiftAPIServer)
-		}
-
-		if testCase.client {
-			testSettings = clients.GetTestClients(clients.TestClientParams{K8sMockObjects: runtimeObjects})
-		}
-
-		builderResult, err := PullOpenshiftAPIServer(testSettings)
-
-		assert.Equal(t, testCase.expectedError, err)
-
-		if testCase.expectedError == nil {
-			assert.Equal(t, "cluster", builderResult.Object.Name)
-		}
-	}
+	testhelper.NewSingletonClusterScopedPullTestConfig(
+		PullOpenshiftAPIServer,
+		operatorv1.Install,
+		openshiftAPIServerGVK,
+		openshiftAPIServerObjName,
+	).ExecuteTests(t)
 }
 
-func TestOpenshiftAPIServerGet(t *testing.T) {
-	testCases := []struct {
-		testOpenshiftAPIServerBuilder *OpenshiftAPIServerBuilder
-		expectedError                 error
-	}{
-		{
-			testOpenshiftAPIServerBuilder: buildValidOpenshiftAPIServerBuilder(buildOpenshiftAPIServerBuilderWithDummyObject()),
-			expectedError:                 nil,
-		},
-		{
-			testOpenshiftAPIServerBuilder: buildValidOpenshiftAPIServerBuilder(
-				clients.GetTestClients(clients.TestClientParams{})),
-			expectedError: fmt.Errorf("openshiftapiservers.operator.openshift.io \"cluster\" not found"),
-		},
-	}
+func TestOpenshiftAPIServerBuilderMethods(t *testing.T) {
+	t.Parallel()
 
-	for _, testCase := range testCases {
-		testOpenshiftAPIServer, err := testCase.testOpenshiftAPIServerBuilder.Get()
+	commonConfig := testhelper.NewCommonTestConfig[operatorv1.OpenShiftAPIServer, OpenshiftAPIServerBuilder](
+		operatorv1.Install, openshiftAPIServerGVK, testhelper.ResourceScopeClusterScoped)
 
-		if testCase.expectedError == nil {
-			assert.Equal(t, testOpenshiftAPIServer.Name, testCase.testOpenshiftAPIServerBuilder.Definition.Name)
-		} else {
-			assert.Equal(t, testCase.expectedError.Error(), err.Error())
-		}
-	}
-}
-
-func TestOpenshiftAPIServerExists(t *testing.T) {
-	testCases := []struct {
-		testOpenshiftAPIServerBuilder *OpenshiftAPIServerBuilder
-		expectedStatus                bool
-	}{
-		{
-			testOpenshiftAPIServerBuilder: buildValidOpenshiftAPIServerBuilder(
-				buildOpenshiftAPIServerBuilderWithDummyObject()),
-			expectedStatus: true,
-		},
-		{
-			testOpenshiftAPIServerBuilder: buildValidOpenshiftAPIServerBuilder(
-				clients.GetTestClients(clients.TestClientParams{})),
-			expectedStatus: false,
-		},
-	}
-
-	for _, testCase := range testCases {
-		status := testCase.testOpenshiftAPIServerBuilder.Exists()
-		assert.Equal(t, testCase.expectedStatus, status)
-	}
+	testhelper.NewTestSuite().
+		With(testhelper.NewGetTestConfig(commonConfig)).
+		With(testhelper.NewExistsTestConfig(commonConfig)).
+		Run(t)
 }
 
 func TestOpenshiftAPIServerGetCondition(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		testOpenshiftAPIServerBuilder *OpenshiftAPIServerBuilder
 		condition                     string
@@ -149,111 +71,132 @@ func TestOpenshiftAPIServerGetCondition(t *testing.T) {
 			condition:       conditionTypeAPIServerDeploymentProgressing,
 			conditionStatus: operatorv1.ConditionTrue,
 			testOpenshiftAPIServerBuilder: buildValidOpenshiftAPIServerBuilder(
-				clients.GetTestClients(clients.TestClientParams{})),
+				newOpenshiftAPIServerTestClient()),
 			expectedError: fmt.Errorf("cluster openshiftAPIServer not found"),
 		},
 	}
 
 	for _, testCase := range testCases {
-		status, msg, err := testCase.testOpenshiftAPIServerBuilder.GetCondition(testCase.condition)
-		assert.Equal(t, testCase.expectedError, err)
+		t.Run(testCase.condition, func(t *testing.T) {
+			t.Parallel()
 
-		if err == nil {
-			assert.Equal(t, *status, testCase.conditionStatus)
-		} else {
-			assert.Nil(t, status)
-			assert.Equal(t, "", msg)
-		}
+			status, msg, err := testCase.testOpenshiftAPIServerBuilder.GetCondition(testCase.condition)
+			assert.Equal(t, testCase.expectedError, err)
+
+			if err == nil {
+				assert.Equal(t, *status, testCase.conditionStatus)
+			} else {
+				assert.Nil(t, status)
+				assert.Equal(t, "", msg)
+			}
+		})
 	}
 }
 
 func TestOpenshiftAPIServerWaitUntilConditionTrue(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
+		name                          string
 		testOpenshiftAPIServerBuilder *OpenshiftAPIServerBuilder
 		condition                     string
 		expectedError                 error
 	}{
 		{
+			name:      "condition becomes true",
 			condition: conditionTypeAPIServerDeploymentProgressing,
 			testOpenshiftAPIServerBuilder: buildValidOpenshiftAPIServerBuilder(
 				buildOpenshiftAPIServerBuilderWithDummyObject()),
 			expectedError: nil,
 		},
 		{
+			name:      "unknown condition times out",
 			condition: "Unavailable",
 			testOpenshiftAPIServerBuilder: buildValidOpenshiftAPIServerBuilder(
 				buildOpenshiftAPIServerBuilderWithDummyObject()),
 			expectedError: fmt.Errorf("the Unavailable condition not found exists: context deadline exceeded"),
 		},
 		{
+			name:      "empty condition type",
 			condition: "",
 			testOpenshiftAPIServerBuilder: buildValidOpenshiftAPIServerBuilder(
 				buildOpenshiftAPIServerBuilderWithDummyObject()),
 			expectedError: fmt.Errorf("openshiftAPIServer 'conditionType' cannot be empty"),
 		},
 		{
+			name:      "resource not found",
 			condition: conditionTypeAPIServerDeploymentProgressing,
 			testOpenshiftAPIServerBuilder: buildValidOpenshiftAPIServerBuilder(
-				clients.GetTestClients(clients.TestClientParams{})),
+				newOpenshiftAPIServerTestClient()),
 			expectedError: fmt.Errorf("cluster openshiftAPIServer not found"),
 		},
 	}
 
 	for _, testCase := range testCases {
-		err := testCase.testOpenshiftAPIServerBuilder.WaitUntilConditionTrue(testCase.condition, 1*time.Second)
-		if err != nil {
-			assert.Equal(t, testCase.expectedError.Error(), err.Error())
-		}
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := testCase.testOpenshiftAPIServerBuilder.WaitUntilConditionTrue(testCase.condition, 1*time.Second)
+			if testCase.expectedError != nil {
+				require.Error(t, err)
+				assert.Equal(t, testCase.expectedError.Error(), err.Error())
+			} else {
+				require.NoError(t, err)
+			}
+		})
 	}
 }
 
 func TestOpenshiftAPIServerWaitAllPodsAtTheLatestGeneration(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
+		name                          string
 		testOpenshiftAPIServerBuilder *OpenshiftAPIServerBuilder
-		condition                     string
-		conditionStatus               operatorv1.ConditionStatus
 		expectedError                 error
 	}{
 		{
-			condition:                     conditionTypeAPIServerDeploymentProgressing,
-			conditionStatus:               operatorv1.ConditionTrue,
+			name:                          "all pods at latest generation",
 			testOpenshiftAPIServerBuilder: buildValidOpenshiftAPIServerBuilder(buildOpenshiftAPIServerBuilderWithDummyObject()),
 			expectedError:                 nil,
 		},
 		{
-			condition:                     "Unavailable",
-			conditionStatus:               "",
-			testOpenshiftAPIServerBuilder: buildValidOpenshiftAPIServerBuilder(buildOpenshiftAPIServerBuilderWithDummyObject()),
-			expectedError:                 fmt.Errorf("the Unavailable condition not found exists: context deadline exceeded"),
-		},
-		{
-			condition:       "",
-			conditionStatus: "",
+			name: "openshift apiserver not found",
 			testOpenshiftAPIServerBuilder: buildValidOpenshiftAPIServerBuilder(
-				buildOpenshiftAPIServerBuilderWithDummyObject()),
-			expectedError: fmt.Errorf("openshiftAPIServer 'conditionType' cannot be empty"),
-		},
-		{
-			condition:       conditionTypeNodeInstallerProgressing,
-			conditionStatus: operatorv1.ConditionTrue,
-			testOpenshiftAPIServerBuilder: buildValidOpenshiftAPIServerBuilder(
-				clients.GetTestClients(clients.TestClientParams{})),
+				newOpenshiftAPIServerTestClient()),
 			expectedError: fmt.Errorf("cluster openshiftAPIServer not found"),
 		},
 	}
 
 	for _, testCase := range testCases {
-		err := testCase.testOpenshiftAPIServerBuilder.WaitAllPodsAtTheLatestGeneration(1 * time.Second)
-		if err != nil {
-			assert.Equal(t, testCase.expectedError.Error(), err.Error())
-		}
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := testCase.testOpenshiftAPIServerBuilder.WaitAllPodsAtTheLatestGeneration(1 * time.Second)
+			if testCase.expectedError != nil {
+				require.Error(t, err)
+				assert.Equal(t, testCase.expectedError.Error(), err.Error())
+			} else {
+				require.NoError(t, err)
+			}
+		})
 	}
 }
 
+func newOpenshiftAPIServerTestClient() *clients.Settings {
+	return clients.GetTestClients(clients.TestClientParams{
+		SchemeAttachers: []clients.SchemeAttacher{operatorv1.Install},
+	})
+}
+
 func buildValidOpenshiftAPIServerBuilder(apiClient *clients.Settings) *OpenshiftAPIServerBuilder {
-	return &OpenshiftAPIServerBuilder{
-		apiClient: apiClient.Client,
-		Definition: &operatorv1.OpenShiftAPIServer{
+	return common.NewClusterScopedBuilder[operatorv1.OpenShiftAPIServer, OpenshiftAPIServerBuilder](
+		apiClient, operatorv1.Install, openshiftAPIServerObjName)
+}
+
+func buildOpenshiftAPIServerBuilderWithDummyObject() *clients.Settings {
+	return clients.GetTestClients(clients.TestClientParams{
+		K8sMockObjects: append([]runtime.Object{}, &operatorv1.OpenShiftAPIServer{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: openshiftAPIServerObjName,
 			},
@@ -264,26 +207,7 @@ func buildValidOpenshiftAPIServerBuilder(apiClient *clients.Settings) *Openshift
 						{Type: conditionTypeAPIServerDeploymentProgressing, Status: operatorv1.ConditionTrue, Reason: conditionReasonAsExpected}},
 				},
 			},
-		},
-	}
-}
-
-func buildOpenshiftAPIServerBuilderWithDummyObject() *clients.Settings {
-	return clients.GetTestClients(clients.TestClientParams{
-		K8sMockObjects: buildDummyOpenshiftAPIServerBuilderObject()})
-}
-
-func buildDummyOpenshiftAPIServerBuilderObject() []runtime.Object {
-	return append([]runtime.Object{}, &operatorv1.OpenShiftAPIServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: openshiftAPIServerObjName,
-		},
-		Spec: operatorv1.OpenShiftAPIServerSpec{},
-		Status: operatorv1.OpenShiftAPIServerStatus{
-			OperatorStatus: operatorv1.OperatorStatus{
-				Conditions: []operatorv1.OperatorCondition{
-					{Type: conditionTypeAPIServerDeploymentProgressing, Status: operatorv1.ConditionTrue, Reason: conditionReasonAsExpected}},
-			},
-		},
+		}),
+		SchemeAttachers: []clients.SchemeAttacher{operatorv1.Install},
 	})
 }

--- a/pkg/clients/clients.go
+++ b/pkg/clients/clients.go
@@ -276,10 +276,6 @@ func GetModifiableTestClients(tcp TestClientParams) (*Settings, *fakeRuntimeClie
 		case *appsv1.DaemonSet:
 			k8sClientObjects = append(k8sClientObjects, v)
 		// Generic Client Objects
-		case *operatorv1.KubeAPIServer:
-			genericClientObjects = append(genericClientObjects, v)
-		case *operatorv1.OpenShiftAPIServer:
-			genericClientObjects = append(genericClientObjects, v)
 		case *configV1.Node:
 			genericClientObjects = append(genericClientObjects, v)
 		case *operatorv1.IngressController:

--- a/pkg/internal/common/testhelper/pullhelper.go
+++ b/pkg/internal/common/testhelper/pullhelper.go
@@ -21,6 +21,10 @@ type NamespacedPullFunc[SB any] func(apiClient *clients.Settings, name, nsname s
 // ClusterScopedPullFunc is a cluster-scoped Pull function signature.
 type ClusterScopedPullFunc[SB any] func(apiClient *clients.Settings, name string) (SB, error)
 
+// ClusterScopedSingletonPullFunc is a cluster-scoped Pull function signature for singleton resources whose name is
+// fixed (e.g., PullKubeAPIServer).
+type ClusterScopedSingletonPullFunc[SB any] func(apiClient *clients.Settings) (SB, error)
+
 // GenericClusterScopedPullFunc is the signature for the common.PullClusterScopedBuilder function.
 type GenericClusterScopedPullFunc[O, B any, SO common.ObjectPointer[O], SB common.BuilderPointer[B, O, SO]] func(
 	ctx context.Context,
@@ -62,6 +66,13 @@ type PullTestConfig[
 
 	// testSchemeAttacher indicates whether scheme attacher failures should be tested.
 	testSchemeAttacher bool
+
+	// testEmptyName indicates whether empty name validation should be tested. This is false for singleton pull
+	// functions that ignore the name parameter.
+	testEmptyName bool
+
+	// fixedResourceName is the object name used for mock setup and assertions when testing singleton pull functions.
+	fixedResourceName string
 }
 
 // NewNamespacedPullTestConfig creates a new PullTestConfig for namespaced resources.
@@ -84,6 +95,7 @@ func NewNamespacedPullTestConfig[
 			return pullFunc(apiClient, name, nsname)
 		},
 		testSchemeAttacher: false,
+		testEmptyName:      true,
 	}
 }
 
@@ -108,6 +120,34 @@ func NewClusterScopedPullTestConfig[
 			return pullFunc(apiClient, name)
 		},
 		testSchemeAttacher: false,
+		testEmptyName:      true,
+	}
+}
+
+// NewSingletonClusterScopedPullTestConfig creates a new PullTestConfig for cluster-scoped singleton resources whose
+// Pull function ignores the name parameter and always pulls a resource with a fixed name.
+func NewSingletonClusterScopedPullTestConfig[
+	O, B any,
+	SO common.ObjectPointer[O],
+	SB common.BuilderPointer[B, O, SO],
+](
+	pullFunc ClusterScopedSingletonPullFunc[SB],
+	schemeAttacher clients.SchemeAttacher,
+	expectedGVK schema.GroupVersionKind,
+	resourceName string,
+) PullTestConfig[O, B, SO, SB] {
+	return PullTestConfig[O, B, SO, SB]{
+		CommonTestConfig: CommonTestConfig[O, B, SO, SB]{
+			SchemeAttacher: schemeAttacher,
+			ExpectedGVK:    expectedGVK,
+			ResourceScope:  ResourceScopeClusterScoped,
+		},
+		pullFunc: func(_ context.Context, apiClient *clients.Settings, _ clients.SchemeAttacher, _, _ string) (SB, error) {
+			return pullFunc(apiClient)
+		},
+		testSchemeAttacher: false,
+		testEmptyName:      false,
+		fixedResourceName:  resourceName,
 	}
 }
 
@@ -123,6 +163,7 @@ func NewGenericClusterScopedPullTestConfig[O, B any, SO common.ObjectPointer[O],
 			return pullFunc(ctx, apiClient, schemeAttacher, name)
 		},
 		testSchemeAttacher: true,
+		testEmptyName:      true,
 	}
 }
 
@@ -138,6 +179,7 @@ func NewGenericNamespacedPullTestConfig[O, B any, SO common.ObjectPointer[O], SB
 			return pullFunc(ctx, apiClient, schemeAttacher, name, nsname)
 		},
 		testSchemeAttacher: true,
+		testEmptyName:      true,
 	}
 }
 
@@ -164,6 +206,14 @@ func (config PullTestConfig[O, B, SO, SB]) ExecuteTests(t *testing.T) {
 		assertError    func(error) bool
 	}
 
+	pullResourceName := func(name string) string {
+		if config.fixedResourceName != "" {
+			return config.fixedResourceName
+		}
+
+		return name
+	}
+
 	testCases := []testCase{
 		{
 			name:           "valid pull existing resource",
@@ -184,15 +234,6 @@ func (config PullTestConfig[O, B, SO, SB]) ExecuteTests(t *testing.T) {
 			assertError:    commonerrors.IsAPIClientNil,
 		},
 		{
-			name:           "empty name returns error",
-			clientNil:      false,
-			builderName:    "",
-			builderNsName:  testResourceNamespace,
-			schemeAttacher: config.SchemeAttacher,
-			objectExists:   false,
-			assertError:    commonerrors.IsBuilderNameEmpty,
-		},
-		{
 			name:           "non-existent resource returns not found",
 			clientNil:      false,
 			builderName:    "non-existent-resource",
@@ -201,6 +242,18 @@ func (config PullTestConfig[O, B, SO, SB]) ExecuteTests(t *testing.T) {
 			objectExists:   false,
 			assertError:    k8serrors.IsNotFound,
 		},
+	}
+
+	if config.testEmptyName {
+		testCases = append(testCases, testCase{
+			name:           "empty name returns error",
+			clientNil:      false,
+			builderName:    "",
+			builderNsName:  testResourceNamespace,
+			schemeAttacher: config.SchemeAttacher,
+			objectExists:   false,
+			assertError:    commonerrors.IsBuilderNameEmpty,
+		})
 	}
 
 	if config.ResourceScope.IsNamespaced() {
@@ -243,7 +296,7 @@ func (config PullTestConfig[O, B, SO, SB]) ExecuteTests(t *testing.T) {
 						namespace = testCase.builderNsName
 					}
 
-					objects = append(objects, buildDummyObject[O, SO](testCase.builderName, namespace))
+					objects = append(objects, buildDummyObject[O, SO](pullResourceName(testCase.builderName), namespace))
 				}
 
 				client = clients.GetTestClients(clients.TestClientParams{
@@ -257,17 +310,19 @@ func (config PullTestConfig[O, B, SO, SB]) ExecuteTests(t *testing.T) {
 			require.Truef(t, testCase.assertError(err), "unexpected error, got: %v", err)
 
 			if err == nil {
+				expectedName := pullResourceName(testCase.builderName)
+
 				require.NotNil(t, builder)
 				require.NotNil(t, builder.GetDefinition())
 
-				assert.Equal(t, testCase.builderName, builder.GetDefinition().GetName())
+				assert.Equal(t, expectedName, builder.GetDefinition().GetName())
 
 				if config.ResourceScope.IsNamespaced() {
 					assert.Equal(t, testCase.builderNsName, builder.GetDefinition().GetNamespace())
 				}
 
 				require.NotNil(t, builder.GetObject())
-				assert.Equal(t, testCase.builderName, builder.GetObject().GetName())
+				assert.Equal(t, expectedName, builder.GetObject().GetName())
 
 				if config.ResourceScope.IsNamespaced() {
 					assert.Equal(t, testCase.builderNsName, builder.GetObject().GetNamespace())


### PR DESCRIPTION
This commit converts the 3 builders in the apiservers package to use the common builder. Additionally, a new constructor is added for the testhelper for Pull functions which do not accept a name parameter.

Closes #1354 

Assisted-by: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized API server resource handling across Kubernetes and OpenShift integrations, including retrieval, existence checks, updates, and condition/polling flows.
  * Unified builder behavior and type/GVK exposure to keep the integrations consistent.
* **Bug Fixes**
  * Improved validation and error handling for TLS adherence and TLS security profile settings, especially in invalid configurations.
* **Tests**
  * Expanded and reorganized test suites, adding support for fixed-name, cluster-scoped singleton pull scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->