### PR TITLE
Add Update() and WithSettings() methods to HFSBuilder

### DIFF
--- a/pkg/bmh/hfs.go
+++ b/pkg/bmh/hfs.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/msg"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/klog/v2"
 	goclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -134,6 +135,54 @@ func (builder *HFSBuilder) Create() (*HFSBuilder, error) {
 	builder.Object = builder.Definition
 
 	return builder, nil
+}
+
+// Update modifies the HostFirmwareSettings on the cluster with the Definition values.
+func (builder *HFSBuilder) Update() (*HFSBuilder, error) {
+	if valid, err := builder.validate(); !valid {
+		return nil, err
+	}
+
+	klog.V(100).Infof(
+		"Updating HostFirmwareSettings %s in namespace %s", builder.Definition.Name, builder.Definition.Namespace)
+
+	if !builder.Exists() {
+		return nil, fmt.Errorf("hostFirmwareSettings object %s does not exist in namespace %s",
+			builder.Definition.Name, builder.Definition.Namespace)
+	}
+
+	builder.Definition.ResourceVersion = builder.Object.ResourceVersion
+	builder.Definition.CreationTimestamp = metav1.Time{}
+
+	err := builder.apiClient.Update(logging.DiscardContext(), builder.Definition)
+	if err != nil {
+		return nil, err
+	}
+
+	builder.Object = builder.Definition
+
+	return builder, nil
+}
+
+// WithSettings sets the desired firmware settings on the HostFirmwareSettings definition.
+func (builder *HFSBuilder) WithSettings(settings map[string]string) *HFSBuilder {
+	if valid, _ := builder.validate(); !valid {
+		return builder
+	}
+
+	klog.V(100).Infof(
+		"Setting firmware settings on HostFirmwareSettings %s in namespace %s",
+		builder.Definition.Name, builder.Definition.Namespace)
+
+	if builder.Definition.Spec.Settings == nil {
+		builder.Definition.Spec.Settings = make(bmhv1alpha1.DesiredSettingsMap)
+	}
+
+	for key, value := range settings {
+		builder.Definition.Spec.Settings[key] = intstr.FromString(value)
+	}
+
+	return builder
 }
 
 // Delete removes a HostFirmwareSettings from the cluster if it exists.

--- a/pkg/bmh/hfs_test.go
+++ b/pkg/bmh/hfs_test.go
@@ -195,6 +195,67 @@ func TestHFSDelete(t *testing.T) {
 	}
 }
 
+func TestHFSUpdate(t *testing.T) {
+	testCases := []struct {
+		testBuilder   *HFSBuilder
+		expectedError string
+	}{
+		{
+			testBuilder:   buildValidHFSBuilder(buildTestClientWithDummyHFS()),
+			expectedError: "",
+		},
+		{
+			testBuilder:   buildValidHFSBuilder(buildTestClientWithHFSScheme()),
+			expectedError: fmt.Sprintf("hostFirmwareSettings object %s does not exist in namespace %s", defaultHFSName, defaultHFSNamespace),
+		},
+		{
+			testBuilder: &HFSBuilder{
+				Definition: buildDummyHFS(defaultHFSName, defaultHFSNamespace),
+				apiClient:  buildTestClientWithDummyHFS().Client,
+				errorMsg:   "test error",
+			},
+			expectedError: "test error",
+		},
+	}
+
+	for _, testCase := range testCases {
+		hfsBuilder, err := testCase.testBuilder.Update()
+
+		if testCase.expectedError == "" {
+			assert.Nil(t, err)
+			assert.Equal(t, hfsBuilder.Definition.Name, hfsBuilder.Object.Name)
+			assert.Equal(t, hfsBuilder.Definition.Namespace, hfsBuilder.Object.Namespace)
+		} else {
+			assert.Nil(t, hfsBuilder)
+			assert.EqualError(t, err, testCase.expectedError)
+		}
+	}
+}
+
+func TestHFSWithSettings(t *testing.T) {
+	testBuilder := buildValidHFSBuilder(buildTestClientWithDummyHFS())
+
+	testBuilder.WithSettings(map[string]string{
+		"SecureBoot":        "Enabled",
+		"SriovGlobalEnable": "Enabled",
+	})
+
+	secureBoot := testBuilder.Definition.Spec.Settings["SecureBoot"]
+	assert.Equal(t, "Enabled", secureBoot.String())
+
+	sriovGlobal := testBuilder.Definition.Spec.Settings["SriovGlobalEnable"]
+	assert.Equal(t, "Enabled", sriovGlobal.String())
+
+	invalidBuilder := &HFSBuilder{
+		Definition: buildDummyHFS(defaultHFSName, defaultHFSNamespace),
+		errorMsg:   "test error",
+	}
+
+	result := invalidBuilder.WithSettings(map[string]string{"SecureBoot": "Enabled"})
+	assert.Equal(t, invalidBuilder, result)
+	assert.Nil(t, result.Definition.Spec.Settings)
+}
+
 // buildDummyHFS returns a HostFirmwareSettings with the provided name and namespace.
 func buildDummyHFS(name, namespace string) *bmhv1alpha1.HostFirmwareSettings {
 	return &bmhv1alpha1.HostFirmwareSettings{


### PR DESCRIPTION
Enable modifying HostFirmwareSettings resources on the cluster, needed for day-2 BIOS configuration after IBI cluster deployment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for updating existing host firmware settings.
  * Introduced a fluent API to set firmware settings (including Secure Boot and SR-IOV options) via key/value pairs.

* **Bug Fixes**
  * Improved update behavior for existing firmware settings by preserving the live resource version and ensuring settings are properly populated before applying changes.

* **Tests**
  * Expanded test coverage for successful updates, handling when the target resource is missing, and correct firmware settings configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->