### PR TITLE
ocm: migrate placementbinding to common builder

### DIFF
--- a/pkg/ocm/placementbinding.go
+++ b/pkg/ocm/placementbinding.go
@@ -2,7 +2,7 @@ package ocm
 
 import (
 	"context"
-	"fmt"
+	"errors"
 
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common"
@@ -58,13 +58,13 @@ func NewPlacementBindingBuilder(
 	}
 
 	if placementRefErr := validatePlacementRef(placementRef); placementRefErr != "" {
-		builder.SetError(fmt.Errorf("%s", placementRefErr))
+		builder.SetError(errors.New(placementRefErr))
 
 		return builder
 	}
 
 	if subjectErr := validateSubject(subject); subjectErr != "" {
-		builder.SetError(fmt.Errorf("%s", subjectErr))
+		builder.SetError(errors.New(subjectErr))
 
 		return builder
 	}
@@ -90,7 +90,7 @@ func (builder *PlacementBindingBuilder) WithAdditionalSubject(subject policiesv1
 	klog.V(100).Infof("Adding Subject %s to PlacementBinding %s", subject.Name, builder.Definition.Name)
 
 	if err := validateSubject(subject); err != "" {
-		builder.SetError(fmt.Errorf("%s", err))
+		builder.SetError(errors.New(err))
 
 		return builder
 	}
@@ -100,8 +100,8 @@ func (builder *PlacementBindingBuilder) WithAdditionalSubject(subject policiesv1
 	return builder
 }
 
-// validatePlacementRef validates all the fields of the PlacementRef and returns an errorMsg based on the validation.
-// The errorMsg will be empty for valid Subjects.
+// validatePlacementRef validates all the fields of the PlacementRef and returns an error message based on the
+// validation. The message will be empty for valid placement refs.
 func validatePlacementRef(placementRef policiesv1.PlacementSubject) string {
 	apiGroup := placementRef.APIGroup
 	if apiGroup != appsOpenClusterManagementIo && apiGroup != "cluster.open-cluster-management.io" {
@@ -126,8 +126,8 @@ func validatePlacementRef(placementRef policiesv1.PlacementSubject) string {
 	return ""
 }
 
-// validateSubject validates the fields of the Subject and returns an errorMsg based on the validation. The errorMsg
-// will be empty for valid Subjects.
+// validateSubject validates the fields of the Subject and returns an error message based on the validation. The message
+// will be empty for valid subjects.
 func validateSubject(subject policiesv1.Subject) string {
 	if subject.APIGroup != policyOpenClusterManagementIo {
 		klog.V(100).Info("The APIGroup of the PlacementBinding subject is invalid")

--- a/pkg/ocm/placementbinding.go
+++ b/pkg/ocm/placementbinding.go
@@ -1,16 +1,14 @@
 package ocm
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/logging"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/msg"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog/v2"
 	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
-	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -21,16 +19,29 @@ const (
 	errEmptySubjectName           = "placementBinding's 'Subject.Name' cannot be empty"
 )
 
+var placementBindingGVK = policiesv1.GroupVersion.WithKind("PlacementBinding")
+
 // PlacementBindingBuilder type definition.
 type PlacementBindingBuilder struct {
-	// placementBinding Definition, used to create the placementBinding object.
-	Definition *policiesv1.PlacementBinding
-	// created placementBinding object.
-	Object *policiesv1.PlacementBinding
-	// api client to interact with the cluster.
-	apiClient runtimeclient.Client
-	// used to store latest error message upon defining or mutating placementBinding definition.
-	errorMsg string
+	common.EmbeddableBuilder[policiesv1.PlacementBinding, *policiesv1.PlacementBinding]
+	common.EmbeddableCreator[
+		policiesv1.PlacementBinding, PlacementBindingBuilder, *policiesv1.PlacementBinding, *PlacementBindingBuilder]
+	common.EmbeddableDeleteReturner[
+		policiesv1.PlacementBinding, PlacementBindingBuilder, *policiesv1.PlacementBinding, *PlacementBindingBuilder]
+	common.EmbeddableForceUpdater[
+		policiesv1.PlacementBinding, PlacementBindingBuilder, *policiesv1.PlacementBinding, *PlacementBindingBuilder]
+}
+
+// AttachMixins wires the embedded CRUD mixins to this builder instance.
+func (builder *PlacementBindingBuilder) AttachMixins() {
+	builder.EmbeddableCreator.SetBase(builder)
+	builder.EmbeddableDeleteReturner.SetBase(builder)
+	builder.EmbeddableForceUpdater.SetBase(builder)
+}
+
+// GetGVK returns the PlacementBinding GVK for this builder.
+func (builder *PlacementBindingBuilder) GetGVK() schema.GroupVersionKind {
+	return placementBindingGVK
 }
 
 // NewPlacementBindingBuilder creates a new instance of PlacementBindingBuilder.
@@ -40,253 +51,46 @@ func NewPlacementBindingBuilder(
 	nsname string,
 	placementRef policiesv1.PlacementSubject,
 	subject policiesv1.Subject) *PlacementBindingBuilder {
-	klog.V(100).Infof(
-		"Initializing new placement binding structure with the following params: name: %s, nsname: %s",
-		name, nsname)
-
-	if apiClient == nil {
-		klog.V(100).Info("The apiClient of the PlacementBinding is nil")
-
-		return nil
-	}
-
-	err := apiClient.AttachScheme(policiesv1.AddToScheme)
-	if err != nil {
-		klog.V(100).Info("Failed to add PlacementBinding scheme to client schemes")
-
-		return nil
-	}
-
-	builder := &PlacementBindingBuilder{
-		apiClient: apiClient.Client,
-		Definition: &policiesv1.PlacementBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: nsname,
-			},
-			PlacementRef: placementRef,
-			Subjects:     []policiesv1.Subject{subject},
-		},
-	}
-
-	if name == "" {
-		builder.errorMsg = "placementBinding's 'name' cannot be empty"
-
-		return builder
-	}
-
-	if nsname == "" {
-		builder.errorMsg = "placementBinding's 'nsname' cannot be empty"
-
+	builder := common.NewNamespacedBuilder[policiesv1.PlacementBinding, PlacementBindingBuilder](
+		apiClient, policiesv1.AddToScheme, name, nsname)
+	if builder.GetError() != nil {
 		return builder
 	}
 
 	if placementRefErr := validatePlacementRef(placementRef); placementRefErr != "" {
-		builder.errorMsg = placementRefErr
+		builder.SetError(fmt.Errorf("%s", placementRefErr))
 
 		return builder
 	}
 
 	if subjectErr := validateSubject(subject); subjectErr != "" {
-		builder.errorMsg = subjectErr
+		builder.SetError(fmt.Errorf("%s", subjectErr))
 
 		return builder
 	}
+
+	builder.Definition.PlacementRef = placementRef
+	builder.Definition.Subjects = []policiesv1.Subject{subject}
 
 	return builder
 }
 
 // PullPlacementBinding pulls existing placementBinding into Builder struct.
 func PullPlacementBinding(apiClient *clients.Settings, name, nsname string) (*PlacementBindingBuilder, error) {
-	klog.V(100).Infof("Pulling existing placementBinding name %s under namespace %s from cluster", name, nsname)
-
-	if apiClient == nil {
-		klog.V(100).Info("The apiClient is empty")
-
-		return nil, fmt.Errorf("placementBinding's 'apiClient' cannot be empty")
-	}
-
-	err := apiClient.AttachScheme(policiesv1.AddToScheme)
-	if err != nil {
-		klog.V(100).Info("Failed to add PlacementBinding scheme to client schemes")
-
-		return nil, err
-	}
-
-	builder := &PlacementBindingBuilder{
-		apiClient: apiClient.Client,
-		Definition: &policiesv1.PlacementBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: nsname,
-			},
-		},
-	}
-
-	if name == "" {
-		klog.V(100).Info("The name of the placementBinding is empty")
-
-		return nil, fmt.Errorf("placementBinding's 'name' cannot be empty")
-	}
-
-	if nsname == "" {
-		klog.V(100).Info("The namespace of the placementBinding is empty")
-
-		return nil, fmt.Errorf("placementBinding's 'namespace' cannot be empty")
-	}
-
-	if !builder.Exists() {
-		return nil, fmt.Errorf("placementBinding object %s does not exist in namespace %s", name, nsname)
-	}
-
-	builder.Definition = builder.Object
-
-	return builder, nil
-}
-
-// Exists checks whether the given placementBinding exists.
-func (builder *PlacementBindingBuilder) Exists() bool {
-	if valid, _ := builder.validate(); !valid {
-		return false
-	}
-
-	klog.V(100).Infof("Checking if placementBinding %s exists in namespace %s",
-		builder.Definition.Name, builder.Definition.Namespace)
-
-	var err error
-
-	builder.Object, err = builder.Get()
-
-	return err == nil || !k8serrors.IsNotFound(err)
-}
-
-// Get returns a placementBinding object if found.
-func (builder *PlacementBindingBuilder) Get() (*policiesv1.PlacementBinding, error) {
-	if valid, err := builder.validate(); !valid {
-		return nil, err
-	}
-
-	klog.V(100).Infof("Getting placementBinding %s in namespace %s",
-		builder.Definition.Name, builder.Definition.Namespace)
-
-	placementBinding := &policiesv1.PlacementBinding{}
-
-	err := builder.apiClient.Get(logging.DiscardContext(), runtimeclient.ObjectKey{
-		Name:      builder.Definition.Name,
-		Namespace: builder.Definition.Namespace,
-	}, placementBinding)
-	if err != nil {
-		klog.V(100).Infof("Failed to get placementBinding %s in namespace %s: %v",
-			builder.Definition.Name, builder.Definition.Namespace, err)
-
-		return nil, err
-	}
-
-	return placementBinding, err
-}
-
-// Create makes a placementBinding in the cluster and stores the created object in struct.
-func (builder *PlacementBindingBuilder) Create() (*PlacementBindingBuilder, error) {
-	if valid, err := builder.validate(); !valid {
-		return builder, err
-	}
-
-	klog.V(100).Infof("Creating the placementBinding %s in namespace %s",
-		builder.Definition.Name, builder.Definition.Namespace)
-
-	if builder.Exists() {
-		return builder, nil
-	}
-
-	err := builder.apiClient.Create(logging.DiscardContext(), builder.Definition)
-	if err != nil {
-		return builder, err
-	}
-
-	builder.Object = builder.Definition
-
-	return builder, nil
-}
-
-// Delete removes a placementBinding from a cluster.
-func (builder *PlacementBindingBuilder) Delete() (*PlacementBindingBuilder, error) {
-	if valid, err := builder.validate(); !valid {
-		return builder, err
-	}
-
-	klog.V(100).Infof("Deleting the placementBinding %s in namespace %s",
-		builder.Definition.Name, builder.Definition.Namespace)
-
-	if !builder.Exists() {
-		klog.V(100).Infof("placementBinding %s cannot be deleted because it does not exist",
-			builder.Definition.Name)
-
-		builder.Object = nil
-
-		return builder, nil
-	}
-
-	err := builder.apiClient.Delete(logging.DiscardContext(), builder.Definition)
-	if err != nil {
-		return builder, fmt.Errorf("can not delete placementBinding: %w", err)
-	}
-
-	builder.Object = nil
-
-	return builder, nil
-}
-
-// Update renovates the existing placementBinding object with the placementBinding definition in builder.
-func (builder *PlacementBindingBuilder) Update(force bool) (*PlacementBindingBuilder, error) {
-	if valid, err := builder.validate(); !valid {
-		return builder, err
-	}
-
-	if !builder.Exists() {
-		klog.V(100).Infof(
-			"PlacementBinding %s does not exist in namespace %s", builder.Definition.Name, builder.Definition.Namespace)
-
-		return nil, fmt.Errorf("cannot update non-existent placementBinding")
-	}
-
-	klog.V(100).Infof("Updating the placementBinding object: %s in namespace: %s",
-		builder.Definition.Name, builder.Definition.Namespace)
-
-	builder.Definition.ResourceVersion = builder.Object.ResourceVersion
-
-	err := builder.apiClient.Update(logging.DiscardContext(), builder.Definition)
-	if err != nil {
-		if force {
-			klog.V(100).Infof("%v", msg.FailToUpdateNotification("placementBinding", builder.Definition.Name, builder.Definition.Namespace))
-
-			builder, err := builder.Delete()
-			builder.Definition.ResourceVersion = ""
-
-			if err != nil {
-				klog.V(100).Infof("%v", msg.FailToUpdateError("placementBinding", builder.Definition.Name, builder.Definition.Namespace))
-
-				return nil, err
-			}
-
-			return builder.Create()
-		}
-	}
-
-	builder.Object = builder.Definition
-
-	return builder, err
+	return common.PullNamespacedBuilder[policiesv1.PlacementBinding, PlacementBindingBuilder](
+		context.TODO(), apiClient, policiesv1.AddToScheme, name, nsname)
 }
 
 // WithAdditionalSubject appends a subject to the subjects list in the PlacementBinding definition.
 func (builder *PlacementBindingBuilder) WithAdditionalSubject(subject policiesv1.Subject) *PlacementBindingBuilder {
-	if valid, _ := builder.validate(); !valid {
+	if err := common.Validate(builder); err != nil {
 		return builder
 	}
 
 	klog.V(100).Infof("Adding Subject %s to PlacementBinding %s", subject.Name, builder.Definition.Name)
 
 	if err := validateSubject(subject); err != "" {
-		builder.errorMsg = err
+		builder.SetError(fmt.Errorf("%s", err))
 
 		return builder
 	}
@@ -344,36 +148,4 @@ func validateSubject(subject policiesv1.Subject) string {
 	}
 
 	return ""
-}
-
-// validate will check that the builder and builder definition are properly initialized before
-// accessing any member fields.
-func (builder *PlacementBindingBuilder) validate() (bool, error) {
-	resourceCRD := "PlacementBinding"
-
-	if builder == nil {
-		klog.V(100).Infof("The %s builder is uninitialized", resourceCRD)
-
-		return false, fmt.Errorf("error: received nil %s builder", resourceCRD)
-	}
-
-	if builder.Definition == nil {
-		klog.V(100).Infof("The %s is undefined", resourceCRD)
-
-		return false, fmt.Errorf("%s", msg.UndefinedCrdObjectErrString(resourceCRD))
-	}
-
-	if builder.apiClient == nil {
-		klog.V(100).Infof("The %s builder apiclient is nil", resourceCRD)
-
-		return false, fmt.Errorf("%s builder cannot have nil apiClient", resourceCRD)
-	}
-
-	if builder.errorMsg != "" {
-		klog.V(100).Infof("The %s builder has error message: %s", resourceCRD, builder.errorMsg)
-
-		return false, fmt.Errorf("%s", builder.errorMsg)
-	}
-
-	return true, nil
 }

--- a/pkg/ocm/placementbindingList.go
+++ b/pkg/ocm/placementbindingList.go
@@ -1,11 +1,11 @@
 package ocm
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/logging"
-	"k8s.io/klog/v2"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common"
 	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -14,56 +14,10 @@ import (
 func ListPlacementBindingsInAllNamespaces(apiClient *clients.Settings,
 	options ...runtimeclient.ListOptions) (
 	[]*PlacementBindingBuilder, error) {
-	if apiClient == nil {
-		klog.V(100).Info("PlacementBindings 'apiClient' parameter cannot be nil")
-
-		return nil, fmt.Errorf("failed to list placementBindings, 'apiClient' parameter is nil")
-	}
-
-	err := apiClient.AttachScheme(policiesv1.AddToScheme)
-	if err != nil {
-		klog.V(100).Info("Failed to add PlacementBinding scheme to client schemes")
-
-		return nil, err
-	}
-
-	logMessage := string("Listing all placementBindings in all namespaces")
-	passedOptions := runtimeclient.ListOptions{}
-
 	if len(options) > 1 {
-		klog.V(100).Info("'options' parameter must be empty or single-valued")
-
 		return nil, fmt.Errorf("error: more than one ListOptions was passed")
 	}
 
-	if len(options) == 1 {
-		passedOptions = options[0]
-		logMessage += fmt.Sprintf(" with the options %v", passedOptions)
-	}
-
-	klog.V(100).Infof("%v", logMessage)
-
-	placementBindingList := new(policiesv1.PlacementBindingList)
-
-	err = apiClient.List(logging.DiscardContext(), placementBindingList, &passedOptions)
-	if err != nil {
-		klog.V(100).Infof("Failed to list all placementBindings in all namespaces due to %s", err.Error())
-
-		return nil, err
-	}
-
-	var placementBindingObjects []*PlacementBindingBuilder
-
-	for _, placementBinding := range placementBindingList.Items {
-		copiedplacementBinding := placementBinding
-		placementBinding := &PlacementBindingBuilder{
-			apiClient:  apiClient.Client,
-			Object:     &copiedplacementBinding,
-			Definition: &copiedplacementBinding,
-		}
-
-		placementBindingObjects = append(placementBindingObjects, placementBinding)
-	}
-
-	return placementBindingObjects, nil
+	return common.List[policiesv1.PlacementBinding, policiesv1.PlacementBindingList, PlacementBindingBuilder](
+		context.TODO(), apiClient, policiesv1.AddToScheme, common.ConvertListOptionsToOptions(options)...)
 }

--- a/pkg/ocm/placementbindingList.go
+++ b/pkg/ocm/placementbindingList.go
@@ -2,7 +2,6 @@ package ocm
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common"
@@ -14,10 +13,6 @@ import (
 func ListPlacementBindingsInAllNamespaces(apiClient *clients.Settings,
 	options ...runtimeclient.ListOptions) (
 	[]*PlacementBindingBuilder, error) {
-	if len(options) > 1 {
-		return nil, fmt.Errorf("error: more than one ListOptions was passed")
-	}
-
 	return common.List[policiesv1.PlacementBinding, policiesv1.PlacementBindingList, PlacementBindingBuilder](
 		context.TODO(), apiClient, policiesv1.AddToScheme, common.ConvertListOptionsToOptions(options)...)
 }

--- a/pkg/ocm/placementbinding_test.go
+++ b/pkg/ocm/placementbinding_test.go
@@ -9,8 +9,6 @@ import (
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common/testhelper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 )
 
@@ -292,30 +290,6 @@ func TestValidateSubject(t *testing.T) {
 			assert.Equal(t, testCase.expectedErrorText, err)
 		})
 	}
-}
-
-// buildDummyPlacementBinding returns a PlacementBinding with the provided name and namespace.
-func buildDummyPlacementBinding(name, nsname string) *policiesv1.PlacementBinding {
-	return &policiesv1.PlacementBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: nsname,
-		},
-		PlacementRef: defaultPlacementBindingRef,
-		Subjects:     []policiesv1.Subject{defaultPlacementBindingSubject},
-	}
-}
-
-// buildTestClientWithDummyPlacementBinding returns a client with a mock dummy PlacementBinding.
-func buildTestClientWithDummyPlacementBinding() *clients.Settings {
-	return clients.GetTestClients(clients.TestClientParams{
-		K8sMockObjects: []runtime.Object{
-			buildDummyPlacementBinding(defaultPlacementBindingName, defaultPlacementBindingNsName),
-		},
-		SchemeAttachers: []clients.SchemeAttacher{
-			policiesv1.AddToScheme,
-		},
-	})
 }
 
 // buildTestClientWithPlacementBindingScheme returns a client with no objects but the PlacementBinding scheme attached.

--- a/pkg/ocm/placementbinding_test.go
+++ b/pkg/ocm/placementbinding_test.go
@@ -5,8 +5,10 @@ import (
 	"testing"
 
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	commonerrors "github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common/errors"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common/testhelper"
 	"github.com/stretchr/testify/assert"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
@@ -28,355 +30,179 @@ var (
 		APIGroup: policyOpenClusterManagementIo,
 		Kind:     kindPolicySet,
 	}
-	placementBindingTestSchemes = []clients.SchemeAttacher{
-		policiesv1.AddToScheme,
-	}
 )
 
 func TestNewPlacementBindingBuilder(t *testing.T) {
-	// No test cases for invalid refs or subjects, those have their own unit tests.
+	t.Parallel()
+
+	t.Run("common namespaced builder behavior", func(t *testing.T) {
+		t.Parallel()
+
+		testhelper.NewNamespacedBuilderTestConfig(
+			func(apiClient *clients.Settings, name, nsname string) *PlacementBindingBuilder {
+				return NewPlacementBindingBuilder(
+					apiClient, name, nsname, defaultPlacementBindingRef, defaultPlacementBindingSubject)
+			},
+			policiesv1.AddToScheme,
+			placementBindingGVK,
+		).ExecuteTests(t)
+	})
+
 	testCases := []struct {
-		placementBindingName      string
-		placementBindingNamespace string
-		placementBindingRef       policiesv1.PlacementSubject
-		placementBindingSubject   policiesv1.Subject
-		client                    bool
-		expectedErrorText         string
-	}{
-		{
-			placementBindingName:      defaultPlacementBindingName,
-			placementBindingNamespace: defaultPlacementBindingNsName,
-			placementBindingRef:       defaultPlacementBindingRef,
-			placementBindingSubject:   defaultPlacementBindingSubject,
-			client:                    true,
-			expectedErrorText:         "",
-		},
-		{
-			placementBindingName:      "",
-			placementBindingNamespace: defaultPlacementBindingNsName,
-			placementBindingRef:       defaultPlacementBindingRef,
-			placementBindingSubject:   defaultPlacementBindingSubject,
-			client:                    true,
-			expectedErrorText:         "placementBinding's 'name' cannot be empty",
-		},
-		{
-			placementBindingName:      defaultPlacementBindingName,
-			placementBindingNamespace: "",
-			placementBindingRef:       defaultPlacementBindingRef,
-			placementBindingSubject:   defaultPlacementBindingSubject,
-			client:                    true,
-			expectedErrorText:         "placementBinding's 'nsname' cannot be empty",
-		},
-		{
-			placementBindingName:      defaultPlacementBindingName,
-			placementBindingNamespace: defaultPlacementBindingNsName,
-			placementBindingRef:       defaultPlacementBindingRef,
-			placementBindingSubject:   defaultPlacementBindingSubject,
-			client:                    false,
-			expectedErrorText:         "",
-		},
-	}
-
-	for _, testCase := range testCases {
-		var client *clients.Settings
-
-		if testCase.client {
-			client = buildTestClientWithPlacementBindingScheme()
-		}
-
-		placementBindingBuilder := NewPlacementBindingBuilder(
-			client,
-			testCase.placementBindingName,
-			testCase.placementBindingNamespace,
-			testCase.placementBindingRef,
-			testCase.placementBindingSubject)
-
-		if testCase.client {
-			assert.Equal(t, testCase.expectedErrorText, placementBindingBuilder.errorMsg)
-
-			if testCase.expectedErrorText == "" {
-				assert.Equal(t, testCase.expectedErrorText, placementBindingBuilder.errorMsg)
-				assert.Equal(t, testCase.placementBindingRef, placementBindingBuilder.Definition.PlacementRef)
-				assert.Equal(t, []policiesv1.Subject{testCase.placementBindingSubject}, placementBindingBuilder.Definition.Subjects)
-			}
-		} else {
-			assert.Nil(t, placementBindingBuilder)
-		}
-	}
-}
-
-func TestPullPlacementBinding(t *testing.T) {
-	testCases := []struct {
-		placementBindingName      string
-		placementBindingNamespace string
-		addToRuntimeObjects       bool
-		client                    bool
-		expectedError             error
-	}{
-		{
-			placementBindingName:      defaultPlacementBindingName,
-			placementBindingNamespace: defaultPlacementBindingNsName,
-			addToRuntimeObjects:       true,
-			client:                    true,
-			expectedError:             nil,
-		},
-		{
-			placementBindingName:      defaultPlacementBindingName,
-			placementBindingNamespace: defaultPlacementBindingNsName,
-			addToRuntimeObjects:       false,
-			client:                    true,
-			expectedError: fmt.Errorf(
-				"placementBinding object %s does not exist in namespace %s",
-				defaultPlacementBindingName,
-				defaultPlacementBindingNsName),
-		},
-		{
-			placementBindingName:      "",
-			placementBindingNamespace: defaultPlacementBindingNsName,
-			addToRuntimeObjects:       false,
-			client:                    true,
-			expectedError:             fmt.Errorf("placementBinding's 'name' cannot be empty"),
-		},
-		{
-			placementBindingName:      defaultPlacementBindingName,
-			placementBindingNamespace: "",
-			addToRuntimeObjects:       false,
-			client:                    true,
-			expectedError:             fmt.Errorf("placementBinding's 'namespace' cannot be empty"),
-		},
-		{
-			placementBindingName:      defaultPlacementBindingName,
-			placementBindingNamespace: defaultPlacementBindingNsName,
-			addToRuntimeObjects:       false,
-			client:                    false,
-			expectedError:             fmt.Errorf("placementBinding's 'apiClient' cannot be empty"),
-		},
-	}
-
-	for _, testCase := range testCases {
-		var (
-			runtimeObjects []runtime.Object
-			testSettings   *clients.Settings
-		)
-
-		testPlacementBinding := buildDummyPlacementBinding(testCase.placementBindingName, testCase.placementBindingNamespace)
-
-		if testCase.addToRuntimeObjects {
-			runtimeObjects = append(runtimeObjects, testPlacementBinding)
-		}
-
-		if testCase.client {
-			testSettings = clients.GetTestClients(clients.TestClientParams{
-				K8sMockObjects:  runtimeObjects,
-				SchemeAttachers: placementBindingTestSchemes,
-			})
-		}
-
-		placementBindingBuilder, err := PullPlacementBinding(
-			testSettings, testPlacementBinding.Name, testPlacementBinding.Namespace)
-		assert.Equal(t, testCase.expectedError, err)
-
-		if testCase.expectedError == nil {
-			assert.Equal(t, testPlacementBinding.Name, placementBindingBuilder.Object.Name)
-			assert.Equal(t, testPlacementBinding.Namespace, placementBindingBuilder.Object.Namespace)
-		}
-	}
-}
-
-func TestPlacementBindingExists(t *testing.T) {
-	testCases := []struct {
-		testBuilder *PlacementBindingBuilder
-		exists      bool
-	}{
-		{
-			testBuilder: buildValidPlacementBindingTestBuilder(buildTestClientWithDummyPlacementBinding()),
-			exists:      true,
-		},
-		{
-			testBuilder: buildInvalidPlacementBindingTestBuilder(buildTestClientWithDummyPlacementBinding()),
-			exists:      false,
-		},
-		{
-			testBuilder: buildValidPlacementBindingTestBuilder(buildTestClientWithPlacementBindingScheme()),
-			exists:      false,
-		},
-	}
-
-	for _, testCase := range testCases {
-		exists := testCase.testBuilder.Exists()
-		assert.Equal(t, testCase.exists, exists)
-	}
-}
-
-func TestPlacementBindingGet(t *testing.T) {
-	testCases := []struct {
-		testBuilder              *PlacementBindingBuilder
-		expectedPlacementBinding *policiesv1.PlacementBinding
-	}{
-		{
-			testBuilder:              buildValidPlacementBindingTestBuilder(buildTestClientWithDummyPlacementBinding()),
-			expectedPlacementBinding: buildDummyPlacementBinding(defaultPlacementBindingName, defaultPlacementBindingNsName),
-		},
-		{
-			testBuilder:              buildValidPlacementBindingTestBuilder(buildTestClientWithPlacementBindingScheme()),
-			expectedPlacementBinding: nil,
-		},
-	}
-
-	for _, testCase := range testCases {
-		placementBinding, err := testCase.testBuilder.Get()
-
-		if testCase.expectedPlacementBinding == nil {
-			assert.Nil(t, placementBinding)
-			assert.True(t, k8serrors.IsNotFound(err))
-		} else {
-			assert.Nil(t, err)
-			assert.Equal(t, testCase.expectedPlacementBinding.Name, placementBinding.Name)
-			assert.Equal(t, testCase.expectedPlacementBinding.Namespace, placementBinding.Namespace)
-		}
-	}
-}
-
-func TestPlacementBindingCreate(t *testing.T) {
-	testCases := []struct {
-		testBuilder   *PlacementBindingBuilder
+		name          string
+		placementRef  policiesv1.PlacementSubject
+		subject       policiesv1.Subject
 		expectedError error
 	}{
 		{
-			testBuilder:   buildValidPlacementBindingTestBuilder(buildTestClientWithPlacementBindingScheme()),
+			name:          "valid refs",
+			placementRef:  defaultPlacementBindingRef,
+			subject:       defaultPlacementBindingSubject,
 			expectedError: nil,
 		},
 		{
-			testBuilder:   buildInvalidPlacementBindingTestBuilder(buildTestClientWithPlacementBindingScheme()),
-			expectedError: fmt.Errorf("placementBinding's 'nsname' cannot be empty"),
-		},
-	}
-
-	for _, testCase := range testCases {
-		placementBindingBuilder, err := testCase.testBuilder.Create()
-		assert.Equal(t, testCase.expectedError, err)
-
-		if testCase.expectedError == nil {
-			assert.Equal(t, placementBindingBuilder.Definition, placementBindingBuilder.Object)
-		}
-	}
-}
-
-func TestPlacementBindingDelete(t *testing.T) {
-	testCases := []struct {
-		testBuilder   *PlacementBindingBuilder
-		expectedError error
-	}{
-		{
-			testBuilder:   buildValidPlacementBindingTestBuilder(buildTestClientWithDummyPlacementBinding()),
-			expectedError: nil,
+			name: "invalid placement ref",
+			placementRef: policiesv1.PlacementSubject{
+				Name:     defaultPlacementRuleName,
+				APIGroup: "",
+				Kind:     kindPlacementRule,
+			},
+			subject:       defaultPlacementBindingSubject,
+			expectedError: fmt.Errorf("placementBinding's 'PlacementRef.APIGroup' must be a valid option"),
 		},
 		{
-			testBuilder:   buildInvalidPlacementBindingTestBuilder(buildTestClientWithDummyPlacementBinding()),
-			expectedError: fmt.Errorf("placementBinding's 'nsname' cannot be empty"),
-		},
-	}
-
-	for _, testCase := range testCases {
-		_, err := testCase.testBuilder.Delete()
-		assert.Equal(t, testCase.expectedError, err)
-
-		if testCase.expectedError == nil {
-			assert.Nil(t, testCase.testBuilder.Object)
-		}
-	}
-}
-
-func TestPlacementBindingUpdate(t *testing.T) {
-	testCases := []struct {
-		alreadyExists bool
-		force         bool
-	}{
-		{
-			alreadyExists: false,
-			force:         false,
-		},
-		{
-			alreadyExists: true,
-			force:         false,
-		},
-		{
-			alreadyExists: false,
-			force:         true,
-		},
-		{
-			alreadyExists: true,
-			force:         true,
-		},
-	}
-
-	for _, testCase := range testCases {
-		testBuilder := buildValidPlacementBindingTestBuilder(buildTestClientWithPlacementBindingScheme())
-
-		// Create the builder rather than just adding it to the client so that the proper metadata is added and
-		// the update will not fail.
-		if testCase.alreadyExists {
-			var err error
-
-			testBuilder = buildValidPlacementBindingTestBuilder(buildTestClientWithPlacementBindingScheme())
-			testBuilder, err = testBuilder.Create()
-			assert.Nil(t, err)
-		}
-
-		assert.NotNil(t, testBuilder.Definition)
-		assert.Empty(t, testBuilder.Definition.SubFilter)
-
-		testBuilder.Definition.SubFilter = "restricted"
-
-		placementBindingBuilder, err := testBuilder.Update(testCase.force)
-		assert.NotNil(t, testBuilder.Definition)
-
-		if testCase.alreadyExists {
-			assert.Nil(t, err)
-			assert.Equal(t, testBuilder.Definition.Name, placementBindingBuilder.Definition.Name)
-			assert.Equal(t, testBuilder.Definition.SubFilter, placementBindingBuilder.Definition.SubFilter)
-		} else {
-			assert.NotNil(t, err)
-		}
-	}
-}
-
-func TestWithAdditionalSubject(t *testing.T) {
-	testCases := []struct {
-		subject           policiesv1.Subject
-		expectedErrorText string
-	}{
-		{
-			subject:           defaultPlacementBindingSubject,
-			expectedErrorText: "",
-		},
-		{
+			name:         "invalid subject",
+			placementRef: defaultPlacementBindingRef,
 			subject: policiesv1.Subject{
 				Name:     "",
 				APIGroup: policyOpenClusterManagementIo,
 				Kind:     kindPolicySet,
 			},
-			expectedErrorText: errEmptySubjectName,
+			expectedError: fmt.Errorf(errEmptySubjectName),
 		},
 	}
 
 	for _, testCase := range testCases {
-		testSettings := buildTestClientWithPlacementBindingScheme()
-		placementBindingBuilder := buildValidPlacementBindingTestBuilder(testSettings).WithAdditionalSubject(testCase.subject)
-		assert.Equal(t, testCase.expectedErrorText, placementBindingBuilder.errorMsg)
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 
-		if testCase.expectedErrorText == "" {
-			assert.Equal(
-				t,
-				[]policiesv1.Subject{defaultPlacementBindingSubject, testCase.subject},
-				placementBindingBuilder.Definition.Subjects)
-		} else {
-			assert.Equal(t, []policiesv1.Subject{defaultPlacementBindingSubject}, placementBindingBuilder.Definition.Subjects)
-		}
+			testBuilder := NewPlacementBindingBuilder(
+				clients.GetTestClients(clients.TestClientParams{
+					SchemeAttachers: []clients.SchemeAttacher{policiesv1.AddToScheme},
+				}),
+				defaultPlacementBindingName,
+				defaultPlacementBindingNsName,
+				testCase.placementRef,
+				testCase.subject,
+			)
+
+			assert.Equal(t, testCase.expectedError, testBuilder.GetError())
+
+			if testCase.expectedError == nil {
+				assert.Equal(t, testCase.placementRef, testBuilder.Definition.PlacementRef)
+				assert.Equal(t, []policiesv1.Subject{testCase.subject}, testBuilder.Definition.Subjects)
+			}
+		})
+	}
+}
+
+func TestPullPlacementBinding(t *testing.T) {
+	t.Parallel()
+
+	testhelper.NewNamespacedPullTestConfig(
+		PullPlacementBinding, policiesv1.AddToScheme, placementBindingGVK).ExecuteTests(t)
+}
+
+func TestPlacementBindingBuilderMethods(t *testing.T) {
+	t.Parallel()
+
+	commonTestConfig := testhelper.NewCommonTestConfig[policiesv1.PlacementBinding, PlacementBindingBuilder](
+		policiesv1.AddToScheme,
+		placementBindingGVK,
+		testhelper.ResourceScopeNamespaced,
+	)
+
+	testhelper.NewTestSuite().
+		With(testhelper.NewGetTestConfig(commonTestConfig)).
+		With(testhelper.NewExistsTestConfig(commonTestConfig)).
+		With(testhelper.NewCreateTestConfig(commonTestConfig)).
+		With(testhelper.NewDeleteReturnerTestConfig(commonTestConfig)).
+		With(testhelper.NewForceUpdateTestConfig(commonTestConfig)).
+		Run(t)
+}
+
+func TestPlacementBindingWithAdditionalSubject(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name          string
+		subject       policiesv1.Subject
+		valid         bool
+		expectedError error
+	}{
+		{
+			name:    "valid subject",
+			subject: defaultPlacementBindingSubject,
+			valid:   true,
+		},
+		{
+			name: "empty subject name",
+			subject: policiesv1.Subject{
+				Name:     "",
+				APIGroup: policyOpenClusterManagementIo,
+				Kind:     kindPolicySet,
+			},
+			valid:         true,
+			expectedError: fmt.Errorf(errEmptySubjectName),
+		},
+		{
+			name:    "invalid builder",
+			subject: defaultPlacementBindingSubject,
+			valid:   false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			var placementBindingBuilder *PlacementBindingBuilder
+			if testCase.valid {
+				placementBindingBuilder = buildValidPlacementBindingTestBuilder(buildTestClientWithPlacementBindingScheme())
+			} else {
+				placementBindingBuilder = buildInvalidPlacementBindingTestBuilder(buildTestClientWithPlacementBindingScheme())
+			}
+
+			placementBindingBuilder = placementBindingBuilder.WithAdditionalSubject(testCase.subject)
+
+			switch testCase.name {
+			case "invalid builder":
+				require.Error(t, placementBindingBuilder.GetError())
+				assert.True(t, commonerrors.IsBuilderNamespaceEmpty(placementBindingBuilder.GetError()))
+			default:
+				assert.Equal(t, testCase.expectedError, placementBindingBuilder.GetError())
+
+				if testCase.expectedError == nil {
+					assert.Equal(
+						t,
+						[]policiesv1.Subject{defaultPlacementBindingSubject, testCase.subject},
+						placementBindingBuilder.Definition.Subjects,
+					)
+				} else {
+					assert.Equal(
+						t,
+						[]policiesv1.Subject{defaultPlacementBindingSubject},
+						placementBindingBuilder.Definition.Subjects,
+					)
+				}
+			}
+		})
 	}
 }
 
 func TestValidatePlacementRef(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		ref               policiesv1.PlacementSubject
 		expectedErrorText string
@@ -412,12 +238,18 @@ func TestValidatePlacementRef(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		err := validatePlacementRef(testCase.ref)
-		assert.Equal(t, testCase.expectedErrorText, err)
+		t.Run(testCase.expectedErrorText, func(t *testing.T) {
+			t.Parallel()
+
+			err := validatePlacementRef(testCase.ref)
+			assert.Equal(t, testCase.expectedErrorText, err)
+		})
 	}
 }
 
 func TestValidateSubject(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		subject           policiesv1.Subject
 		expectedErrorText string
@@ -453,84 +285,12 @@ func TestValidateSubject(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		err := validateSubject(testCase.subject)
-		assert.Equal(t, testCase.expectedErrorText, err)
-	}
-}
+		t.Run(testCase.expectedErrorText, func(t *testing.T) {
+			t.Parallel()
 
-func TestPlacementBindingValidate(t *testing.T) {
-	testCases := []struct {
-		builderNil      bool
-		definitionNil   bool
-		apiClientNil    bool
-		builderErrorMsg string
-		expectedError   error
-	}{
-		{
-			builderNil:      false,
-			definitionNil:   false,
-			apiClientNil:    false,
-			builderErrorMsg: "",
-			expectedError:   nil,
-		},
-		{
-			builderNil:      true,
-			definitionNil:   false,
-			apiClientNil:    false,
-			builderErrorMsg: "",
-			expectedError:   fmt.Errorf("error: received nil PlacementBinding builder"),
-		},
-		{
-			builderNil:      false,
-			definitionNil:   true,
-			apiClientNil:    false,
-			builderErrorMsg: "",
-			expectedError:   fmt.Errorf("can not redefine the undefined PlacementBinding"),
-		},
-		{
-			builderNil:      false,
-			definitionNil:   false,
-			apiClientNil:    true,
-			builderErrorMsg: "",
-			expectedError:   fmt.Errorf("PlacementBinding builder cannot have nil apiClient"),
-		},
-		{
-			builderNil:      false,
-			definitionNil:   false,
-			apiClientNil:    false,
-			builderErrorMsg: "test error",
-			expectedError:   fmt.Errorf("test error"),
-		},
-	}
-
-	for _, testCase := range testCases {
-		placementBindingBuilder := buildValidPlacementBindingTestBuilder(buildTestClientWithPlacementBindingScheme())
-
-		if testCase.builderNil {
-			placementBindingBuilder = nil
-		}
-
-		if testCase.definitionNil {
-			placementBindingBuilder.Definition = nil
-		}
-
-		if testCase.apiClientNil {
-			placementBindingBuilder.apiClient = nil
-		}
-
-		if testCase.builderErrorMsg != "" {
-			placementBindingBuilder.errorMsg = testCase.builderErrorMsg
-		}
-
-		valid, err := placementBindingBuilder.validate()
-
-		if testCase.expectedError != nil {
-			assert.False(t, valid)
-			assert.Equal(t, testCase.expectedError, err)
-		} else {
-			assert.True(t, valid)
-			assert.Nil(t, err)
-		}
+			err := validateSubject(testCase.subject)
+			assert.Equal(t, testCase.expectedErrorText, err)
+		})
 	}
 }
 
@@ -552,14 +312,18 @@ func buildTestClientWithDummyPlacementBinding() *clients.Settings {
 		K8sMockObjects: []runtime.Object{
 			buildDummyPlacementBinding(defaultPlacementBindingName, defaultPlacementBindingNsName),
 		},
-		SchemeAttachers: placementBindingTestSchemes,
+		SchemeAttachers: []clients.SchemeAttacher{
+			policiesv1.AddToScheme,
+		},
 	})
 }
 
 // buildTestClientWithPlacementBindingScheme returns a client with no objects but the PlacementBinding scheme attached.
 func buildTestClientWithPlacementBindingScheme() *clients.Settings {
 	return clients.GetTestClients(clients.TestClientParams{
-		SchemeAttachers: placementBindingTestSchemes,
+		SchemeAttachers: []clients.SchemeAttacher{
+			policiesv1.AddToScheme,
+		},
 	})
 }
 

--- a/pkg/ocm/placementbindinglist_test.go
+++ b/pkg/ocm/placementbindinglist_test.go
@@ -1,81 +1,18 @@
 package ocm
 
 import (
-	"fmt"
 	"testing"
 
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
-	commonerrors "github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common/errors"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"k8s.io/apimachinery/pkg/labels"
-	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common/testhelper"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 )
 
 func TestListPlacementBindingsInAllNamespaces(t *testing.T) {
 	t.Parallel()
 
-	testCases := []struct {
-		name          string
-		listOptions   []runtimeclient.ListOptions
-		expectedError error
-		client        bool
-	}{
-		{
-			name:          "list all",
-			listOptions:   nil,
-			expectedError: nil,
-			client:        true,
-		},
-		{
-			name:          "list with options",
-			listOptions:   []runtimeclient.ListOptions{{LabelSelector: labels.NewSelector()}},
-			expectedError: nil,
-			client:        true,
-		},
-		{
-			name: "too many list options",
-			listOptions: []runtimeclient.ListOptions{
-				{LabelSelector: labels.NewSelector()},
-				{LabelSelector: labels.NewSelector()},
-			},
-			expectedError: fmt.Errorf("error: more than one ListOptions was passed"),
-			client:        true,
-		},
-		{
-			name:          "nil client",
-			listOptions:   []runtimeclient.ListOptions{{LabelSelector: labels.NewSelector()}},
-			expectedError: fmt.Errorf("apiClient for PlacementBinding is nil"),
-			client:        false,
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			t.Parallel()
-
-			var testSettings *clients.Settings
-
-			if testCase.client {
-				testSettings = buildTestClientWithDummyPlacementBinding()
-			}
-
-			builders, err := ListPlacementBindingsInAllNamespaces(testSettings, testCase.listOptions...)
-
-			switch testCase.name {
-			case "nil client":
-				require.Error(t, err)
-				assert.True(t, commonerrors.IsAPIClientNil(err))
-				assert.Nil(t, builders)
-			case "too many list options":
-				assert.Equal(t, testCase.expectedError, err)
-			default:
-				assert.NoError(t, err)
-
-				if len(testCase.listOptions) == 0 {
-					assert.Len(t, builders, 1)
-				}
-			}
-		})
-	}
+	testhelper.NewListTestConfig(
+		ListPlacementBindingsInAllNamespaces,
+		policiesv1.AddToScheme,
+		placementBindingGVK,
+	).ExecuteTests(t)
 }

--- a/pkg/ocm/placementbindinglist_test.go
+++ b/pkg/ocm/placementbindinglist_test.go
@@ -5,38 +5,36 @@ import (
 	"testing"
 
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	commonerrors "github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/labels"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestListPlacementBindingsInAllNamespaces(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
-		placementBindings []*PlacementBindingBuilder
-		listOptions       []runtimeclient.ListOptions
-		expectedError     error
-		client            bool
+		name          string
+		listOptions   []runtimeclient.ListOptions
+		expectedError error
+		client        bool
 	}{
 		{
-			placementBindings: []*PlacementBindingBuilder{
-				buildValidPlacementBindingTestBuilder(buildTestClientWithDummyPlacementBinding()),
-			},
+			name:          "list all",
 			listOptions:   nil,
 			expectedError: nil,
 			client:        true,
 		},
 		{
-			placementBindings: []*PlacementBindingBuilder{
-				buildValidPlacementBindingTestBuilder(buildTestClientWithDummyPlacementBinding()),
-			},
+			name:          "list with options",
 			listOptions:   []runtimeclient.ListOptions{{LabelSelector: labels.NewSelector()}},
 			expectedError: nil,
 			client:        true,
 		},
 		{
-			placementBindings: []*PlacementBindingBuilder{
-				buildValidPlacementBindingTestBuilder(buildTestClientWithDummyPlacementBinding()),
-			},
+			name: "too many list options",
 			listOptions: []runtimeclient.ListOptions{
 				{LabelSelector: labels.NewSelector()},
 				{LabelSelector: labels.NewSelector()},
@@ -45,27 +43,39 @@ func TestListPlacementBindingsInAllNamespaces(t *testing.T) {
 			client:        true,
 		},
 		{
-			placementBindings: []*PlacementBindingBuilder{
-				buildValidPlacementBindingTestBuilder(buildTestClientWithDummyPlacementBinding()),
-			},
+			name:          "nil client",
 			listOptions:   []runtimeclient.ListOptions{{LabelSelector: labels.NewSelector()}},
-			expectedError: fmt.Errorf("failed to list placementBindings, 'apiClient' parameter is nil"),
+			expectedError: fmt.Errorf("apiClient for PlacementBinding is nil"),
 			client:        false,
 		},
 	}
 
 	for _, testCase := range testCases {
-		var testSettings *clients.Settings
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 
-		if testCase.client {
-			testSettings = buildTestClientWithDummyPlacementBinding()
-		}
+			var testSettings *clients.Settings
 
-		builders, err := ListPlacementBindingsInAllNamespaces(testSettings, testCase.listOptions...)
-		assert.Equal(t, testCase.expectedError, err)
+			if testCase.client {
+				testSettings = buildTestClientWithDummyPlacementBinding()
+			}
 
-		if testCase.expectedError == nil && len(testCase.listOptions) == 0 {
-			assert.Equal(t, len(testCase.placementBindings), len(builders))
-		}
+			builders, err := ListPlacementBindingsInAllNamespaces(testSettings, testCase.listOptions...)
+
+			switch testCase.name {
+			case "nil client":
+				require.Error(t, err)
+				assert.True(t, commonerrors.IsAPIClientNil(err))
+				assert.Nil(t, builders)
+			case "too many list options":
+				assert.Equal(t, testCase.expectedError, err)
+			default:
+				assert.NoError(t, err)
+
+				if len(testCase.listOptions) == 0 {
+					assert.Len(t, builders, 1)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
Migrate placementbinding builder in pkg/ocm to the common builder framework.

Closes #1454

Made with [Cursor](https://cursor.com)