### PR TITLE
ocm: migrate kac to common builder

### DIFF
--- a/pkg/ocm/kac.go
+++ b/pkg/ocm/kac.go
@@ -6,272 +6,49 @@ import (
 	"time"
 
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/logging"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/msg"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/ocm/kacv1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
-	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
-)
-
-const (
-	errEmptyAddonConfigName = "klusterletAddonConfig 'name' cannot be empty"
-	errEmptyNsname          = "klusterletAddonConfig 'nsname' cannot be empty"
 )
 
 // KACBuilder provides a struct for the KlusterletAddonConfig resource containing a connection to the cluster and the
 // KlusterletAddonConfig definition.
 type KACBuilder struct {
-	// Definition of the KlusterletAddonConfig used to create the object.
-	Definition *kacv1.KlusterletAddonConfig
-	// Object of the KlusterletAddonConfig as it is on the cluster.
-	Object *kacv1.KlusterletAddonConfig
-	// apiClient used to interact with the cluster.
-	apiClient runtimeclient.Client
-	// errorMsg used to store latest error message from functions that do not return errors.
-	errorMsg string
+	common.EmbeddableBuilder[kacv1.KlusterletAddonConfig, *kacv1.KlusterletAddonConfig]
+	common.EmbeddableCreator[kacv1.KlusterletAddonConfig, KACBuilder, *kacv1.KlusterletAddonConfig, *KACBuilder]
+	common.EmbeddableDeleter[kacv1.KlusterletAddonConfig, *kacv1.KlusterletAddonConfig]
+	common.EmbeddableForceUpdater[kacv1.KlusterletAddonConfig, KACBuilder, *kacv1.KlusterletAddonConfig, *KACBuilder]
+}
+
+// AttachMixins wires the embedded CRUD mixins to this builder instance.
+func (builder *KACBuilder) AttachMixins() {
+	builder.EmbeddableCreator.SetBase(builder)
+	builder.EmbeddableDeleter.SetBase(builder)
+	builder.EmbeddableForceUpdater.SetBase(builder)
+}
+
+// GetGVK returns the KlusterletAddonConfig GVK for this builder.
+func (builder *KACBuilder) GetGVK() schema.GroupVersionKind {
+	return kacv1.SchemeGroupVersion.WithKind("KlusterletAddonConfig")
 }
 
 // NewKACBuilder creates a new instance of a KlusterletAddonConfig builder.
 func NewKACBuilder(apiClient *clients.Settings, name, nsname string) *KACBuilder {
-	klog.V(100).Infof(
-		"Initializing new KlusterletAddonConfig structure with the following params: name: %s, nsname: %s", name, nsname)
-
-	if apiClient == nil {
-		klog.V(100).Info("The apiClient of the KlusterletAddonConfig is nil")
-
-		return nil
-	}
-
-	err := apiClient.AttachScheme(kacv1.SchemeBuilder.AddToScheme)
-	if err != nil {
-		klog.V(100).Info("Failed to add KlusterletAddonConfig scheme to client schemes")
-
-		return nil
-	}
-
-	builder := &KACBuilder{
-		apiClient: apiClient.Client,
-		Definition: &kacv1.KlusterletAddonConfig{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: nsname,
-			},
-		},
-	}
-
-	if name == "" {
-		klog.V(100).Info("The name of the KlusterletAddonConfig is empty")
-
-		builder.errorMsg = errEmptyAddonConfigName
-
-		return builder
-	}
-
-	if nsname == "" {
-		klog.V(100).Info("The namespace of the KlusterletAddonConfig is empty")
-
-		builder.errorMsg = errEmptyNsname
-
-		return builder
-	}
-
-	return builder
+	return common.NewNamespacedBuilder[kacv1.KlusterletAddonConfig, KACBuilder](
+		apiClient, kacv1.SchemeBuilder.AddToScheme, name, nsname)
 }
 
 // PullKAC pulls an existing KlusterletAddonConfig into a Builder struct.
 func PullKAC(apiClient *clients.Settings, name, nsname string) (*KACBuilder, error) {
-	klog.V(100).Infof("Pulling existing KlusterletAddonConfig %s under namespace %s from cluster", name, nsname)
-
-	if apiClient == nil {
-		klog.V(100).Info("The apiClient is empty")
-
-		return nil, fmt.Errorf("klusterletAddonConfig 'apiClient' cannot be nil")
-	}
-
-	err := apiClient.AttachScheme(kacv1.SchemeBuilder.AddToScheme)
-	if err != nil {
-		klog.V(100).Info("Failed to add KlusterletAddonConfig scheme to client schemes")
-
-		return nil, err
-	}
-
-	builder := &KACBuilder{
-		apiClient: apiClient.Client,
-		Definition: &kacv1.KlusterletAddonConfig{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: nsname,
-			},
-		},
-	}
-
-	if name == "" {
-		klog.V(100).Info("The name of the KlusterletAddonConfig is empty")
-
-		return nil, fmt.Errorf(errEmptyAddonConfigName)
-	}
-
-	if nsname == "" {
-		klog.V(100).Info("The namespace of the KlusterletAddonConfig is empty")
-
-		return nil, fmt.Errorf(errEmptyNsname)
-	}
-
-	if !builder.Exists() {
-		klog.V(100).Infof("The KlusterletAddonConfig %s does not exist in namespace %s", name, nsname)
-
-		return nil, fmt.Errorf("klusterletAddonConfig object %s does not exist in namespace %s", name, nsname)
-	}
-
-	builder.Definition = builder.Object
-
-	return builder, nil
-}
-
-// Get returns the KlusterletAddonConfig object if found.
-func (builder *KACBuilder) Get() (*kacv1.KlusterletAddonConfig, error) {
-	if valid, err := builder.validate(); !valid {
-		return nil, err
-	}
-
-	klog.V(100).Infof(
-		"Getting KlusterletAddonConfig object %s in namespace %s", builder.Definition.Name, builder.Definition.Namespace)
-
-	klusterletAddonConfig := &kacv1.KlusterletAddonConfig{}
-
-	err := builder.apiClient.Get(logging.DiscardContext(), runtimeclient.ObjectKey{
-		Name:      builder.Definition.Name,
-		Namespace: builder.Definition.Namespace,
-	}, klusterletAddonConfig)
-	if err != nil {
-		klog.V(100).Infof(
-			"KlusterletAddonConfig object %s does not exist in namespace %s",
-			builder.Definition.Name, builder.Definition.Namespace)
-
-		return nil, err
-	}
-
-	return klusterletAddonConfig, nil
-}
-
-// Exists checks whether the given KlusterletAddonConfig exists on the cluster.
-func (builder *KACBuilder) Exists() bool {
-	if valid, _ := builder.validate(); !valid {
-		return false
-	}
-
-	klog.V(100).Infof(
-		"Checking if KlusterletAddonConfig %s exists in namespace %s", builder.Definition.Name, builder.Definition.Namespace)
-
-	var err error
-
-	builder.Object, err = builder.Get()
-
-	return err == nil || !k8serrors.IsNotFound(err)
-}
-
-// Create makes a KlusterletAddonConfig on the cluster if it does not already exist.
-func (builder *KACBuilder) Create() (*KACBuilder, error) {
-	if valid, err := builder.validate(); !valid {
-		return nil, err
-	}
-
-	klog.V(100).Infof(
-		"Creating KlusterletAddonConfig %s in namespace %s", builder.Definition.Name, builder.Definition.Namespace)
-
-	if builder.Exists() {
-		return builder, nil
-	}
-
-	err := builder.apiClient.Create(logging.DiscardContext(), builder.Definition)
-	if err != nil {
-		return nil, err
-	}
-
-	builder.Object = builder.Definition
-
-	return builder, nil
-}
-
-// Update changes the existing KlusterletAddonConfig resource on the cluster, falling back to deleting and recreating if
-// the update fails when force is set.
-func (builder *KACBuilder) Update(force bool) (*KACBuilder, error) {
-	if valid, err := builder.validate(); !valid {
-		return nil, err
-	}
-
-	klog.V(100).Infof(
-		"Updating KlusterletAddonConfig %s in namespace %s", builder.Definition.Name, builder.Definition.Namespace)
-
-	if !builder.Exists() {
-		klog.V(100).Infof(
-			"KlusterletAddonConfig %s does not exist in namespace %s", builder.Definition.Name, builder.Definition.Namespace)
-
-		return nil, fmt.Errorf("cannot update non-existent klusterletAddonConfig")
-	}
-
-	builder.Definition.ResourceVersion = builder.Object.ResourceVersion
-
-	err := builder.apiClient.Update(logging.DiscardContext(), builder.Definition)
-	if err != nil {
-		if force {
-			klog.V(100).Infof("%v", msg.FailToUpdateNotification("klusterletAddonConfig", builder.Definition.Name))
-
-			err := builder.Delete()
-			builder.Definition.ResourceVersion = ""
-
-			if err != nil {
-				klog.V(100).Infof("%v", msg.FailToUpdateError("klusterletAddonConfig", builder.Definition.Name))
-
-				return nil, err
-			}
-
-			return builder.Create()
-		}
-
-		return nil, err
-	}
-
-	builder.Object = builder.Definition
-
-	return builder, nil
-}
-
-// Delete removes a KlusterletAddonConfig from the cluster if it exists.
-func (builder *KACBuilder) Delete() error {
-	if valid, err := builder.validate(); !valid {
-		return err
-	}
-
-	klog.V(100).Infof(
-		"Deleting KlusterletAddonConfig %s in namespace %s", builder.Definition.Name, builder.Definition.Namespace)
-
-	if !builder.Exists() {
-		klog.V(100).Infof(
-			"KlusterletAddonConfig %s in namespace %s does not exist",
-			builder.Definition.Name, builder.Definition.Namespace)
-
-		builder.Object = nil
-
-		return nil
-	}
-
-	err := builder.apiClient.Delete(logging.DiscardContext(), builder.Object)
-	if err != nil {
-		return err
-	}
-
-	builder.Object = nil
-
-	return nil
+	return common.PullNamespacedBuilder[kacv1.KlusterletAddonConfig, KACBuilder](
+		context.TODO(), apiClient, kacv1.SchemeBuilder.AddToScheme, name, nsname)
 }
 
 // WaitUntilSearchCollectorEnabled waits up to the specified timeout until the search collector config has been enabled.
 func (builder *KACBuilder) WaitUntilSearchCollectorEnabled(timeout time.Duration) (*KACBuilder, error) {
-	if valid, err := builder.validate(); !valid {
+	if err := common.Validate(builder); err != nil {
 		return nil, err
 	}
 
@@ -301,35 +78,4 @@ func (builder *KACBuilder) WaitUntilSearchCollectorEnabled(timeout time.Duration
 	}
 
 	return builder, nil
-}
-
-// validate checks that the builder, definition, and apiClient are properly initialized and there is no errorMsg.
-func (builder *KACBuilder) validate() (bool, error) {
-	resourceCRD := "klusterletAddonConfig"
-
-	if builder == nil {
-		klog.V(100).Infof("The %s builder is uninitialized", resourceCRD)
-
-		return false, fmt.Errorf("error: received nil %s builder", resourceCRD)
-	}
-
-	if builder.Definition == nil {
-		klog.V(100).Infof("The %s is uninitialized", resourceCRD)
-
-		return false, fmt.Errorf("%s", msg.UndefinedCrdObjectErrString(resourceCRD))
-	}
-
-	if builder.apiClient == nil {
-		klog.V(100).Infof("The %s builder apiClient is nil", resourceCRD)
-
-		return false, fmt.Errorf("%s builder cannot have nil apiClient", resourceCRD)
-	}
-
-	if builder.errorMsg != "" {
-		klog.V(100).Infof("The %s builder has error message %s", resourceCRD, builder.errorMsg)
-
-		return false, fmt.Errorf("%s", builder.errorMsg)
-	}
-
-	return true, nil
 }

--- a/pkg/ocm/kac_test.go
+++ b/pkg/ocm/kac_test.go
@@ -7,8 +7,11 @@ import (
 	"time"
 
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	commonerrors "github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common/errors"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common/testhelper"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/ocm/kacv1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -18,350 +21,71 @@ const (
 	defaultKACNamespace = "test-ns"
 )
 
-var kacTestSchemes = []clients.SchemeAttacher{
-	kacv1.SchemeBuilder.AddToScheme,
-}
+var kacGVK = kacv1.SchemeGroupVersion.WithKind("KlusterletAddonConfig")
 
 func TestNewKACBuilder(t *testing.T) {
-	testCases := []struct {
-		kacName           string
-		kacNamespace      string
-		client            bool
-		expectedErrorText string
-	}{
-		{
-			kacName:           defaultKACName,
-			kacNamespace:      defaultKACNamespace,
-			client:            true,
-			expectedErrorText: "",
-		},
-		{
-			kacName:           "",
-			kacNamespace:      defaultKACNamespace,
-			client:            true,
-			expectedErrorText: errEmptyAddonConfigName,
-		},
-		{
-			kacName:           defaultKACName,
-			kacNamespace:      "",
-			client:            true,
-			expectedErrorText: errEmptyNsname,
-		},
-		{
-			kacName:           defaultKACName,
-			kacNamespace:      defaultKACNamespace,
-			client:            false,
-			expectedErrorText: "",
-		},
-	}
+	t.Parallel()
 
-	for _, testCase := range testCases {
-		var testSettings *clients.Settings
-
-		if testCase.client {
-			testSettings = buildTestClientWithKACScheme()
-		}
-
-		kacBuilder := NewKACBuilder(testSettings, testCase.kacName, testCase.kacNamespace)
-
-		if testCase.client {
-			assert.Equal(t, testCase.expectedErrorText, kacBuilder.errorMsg)
-
-			if testCase.expectedErrorText == "" {
-				assert.Equal(t, testCase.kacName, kacBuilder.Definition.Name)
-				assert.Equal(t, testCase.kacNamespace, kacBuilder.Definition.Namespace)
-			}
-		} else {
-			assert.Nil(t, kacBuilder)
-		}
-	}
+	testhelper.NewNamespacedBuilderTestConfig(NewKACBuilder, kacv1.SchemeBuilder.AddToScheme, kacGVK).ExecuteTests(t)
 }
 
 func TestPullKAC(t *testing.T) {
-	testCases := []struct {
-		kacName             string
-		kacNamespace        string
-		addToRuntimeObjects bool
-		client              bool
-		expectedErrorText   string
-	}{
-		{
-			kacName:             defaultKACName,
-			kacNamespace:        defaultKACNamespace,
-			addToRuntimeObjects: true,
-			client:              true,
-			expectedErrorText:   "",
-		},
-		{
-			kacName:             "",
-			kacNamespace:        defaultKACNamespace,
-			addToRuntimeObjects: true,
-			client:              true,
-			expectedErrorText:   errEmptyAddonConfigName,
-		},
-		{
-			kacName:             defaultKACName,
-			kacNamespace:        "",
-			addToRuntimeObjects: true,
-			client:              true,
-			expectedErrorText:   errEmptyNsname,
-		},
-		{
-			kacName:             defaultKACName,
-			kacNamespace:        defaultKACNamespace,
-			addToRuntimeObjects: false,
-			client:              true,
-			expectedErrorText: fmt.Sprintf(
-				"klusterletAddonConfig object %s does not exist in namespace %s", defaultKACName, defaultKACNamespace),
-		},
-		{
-			kacName:             defaultKACName,
-			kacNamespace:        defaultKACNamespace,
-			addToRuntimeObjects: true,
-			client:              false,
-			expectedErrorText:   "klusterletAddonConfig 'apiClient' cannot be nil",
-		},
-	}
+	t.Parallel()
 
-	for _, testCase := range testCases {
-		var (
-			runtimeObjects []runtime.Object
-			testSettings   *clients.Settings
-		)
-
-		testKAC := buildDummyKAC(testCase.kacName, testCase.kacNamespace)
-
-		if testCase.addToRuntimeObjects {
-			runtimeObjects = append(runtimeObjects, testKAC)
-		}
-
-		if testCase.client {
-			testSettings = clients.GetTestClients(clients.TestClientParams{
-				K8sMockObjects:  runtimeObjects,
-				SchemeAttachers: kacTestSchemes,
-			})
-		}
-
-		kacBuilder, err := PullKAC(testSettings, testCase.kacName, testCase.kacNamespace)
-
-		if testCase.expectedErrorText == "" {
-			assert.Nil(t, err)
-			assert.Equal(t, testKAC.Name, kacBuilder.Definition.Name)
-			assert.Equal(t, testKAC.Namespace, kacBuilder.Definition.Namespace)
-		} else {
-			assert.EqualError(t, err, testCase.expectedErrorText)
-		}
-	}
+	testhelper.NewNamespacedPullTestConfig(PullKAC, kacv1.SchemeBuilder.AddToScheme, kacGVK).ExecuteTests(t)
 }
 
-func TestKACGet(t *testing.T) {
-	testCases := []struct {
-		testBuilder   *KACBuilder
-		expectedError string
-	}{
-		{
-			testBuilder:   buildValidKACTestBuilder(buildTestClientWithDummyKAC()),
-			expectedError: "",
-		},
-		{
-			testBuilder:   buildInvalidKACTestBuilder(buildTestClientWithDummyKAC()),
-			expectedError: errEmptyNsname,
-		},
-		{
-			testBuilder:   buildValidKACTestBuilder(buildTestClientWithKACScheme()),
-			expectedError: "klusterletaddonconfigs.agent.open-cluster-management.io \"klusterletaddonconfig-test\" not found",
-		},
-	}
+func TestKACBuilderMethods(t *testing.T) {
+	t.Parallel()
 
-	for _, testCase := range testCases {
-		kac, err := testCase.testBuilder.Get()
+	commonTestConfig := testhelper.NewCommonTestConfig[kacv1.KlusterletAddonConfig, KACBuilder](
+		kacv1.SchemeBuilder.AddToScheme,
+		kacGVK,
+		testhelper.ResourceScopeNamespaced,
+	)
 
-		if testCase.expectedError == "" {
-			assert.Nil(t, err)
-			assert.Equal(t, testCase.testBuilder.Definition.Name, kac.Name)
-			assert.Equal(t, testCase.testBuilder.Definition.Namespace, kac.Namespace)
-		} else {
-			assert.EqualError(t, err, testCase.expectedError)
-		}
-	}
-}
-
-func TestKACExists(t *testing.T) {
-	testCases := []struct {
-		testBuilder *KACBuilder
-		exists      bool
-	}{
-		{
-			testBuilder: buildValidKACTestBuilder(buildTestClientWithDummyKAC()),
-			exists:      true,
-		},
-		{
-			testBuilder: buildInvalidKACTestBuilder(buildTestClientWithDummyKAC()),
-			exists:      false,
-		},
-		{
-			testBuilder: buildValidKACTestBuilder(buildTestClientWithKACScheme()),
-			exists:      false,
-		},
-	}
-
-	for _, testCase := range testCases {
-		exists := testCase.testBuilder.Exists()
-		assert.Equal(t, testCase.exists, exists)
-	}
-}
-
-func TestKACCreate(t *testing.T) {
-	testCases := []struct {
-		testBuilder   *KACBuilder
-		expectedError error
-	}{
-		{
-			testBuilder:   buildValidKACTestBuilder(buildTestClientWithKACScheme()),
-			expectedError: nil,
-		},
-		{
-			testBuilder:   buildValidKACTestBuilder(buildTestClientWithDummyKAC()),
-			expectedError: nil,
-		},
-		{
-			testBuilder:   buildInvalidKACTestBuilder(buildTestClientWithKACScheme()),
-			expectedError: fmt.Errorf(errEmptyNsname),
-		},
-	}
-
-	for _, testCase := range testCases {
-		kacBuilder, err := testCase.testBuilder.Create()
-		assert.Equal(t, testCase.expectedError, err)
-
-		if testCase.expectedError == nil {
-			assert.Equal(t, kacBuilder.Definition.Name, kacBuilder.Object.Name)
-			assert.Equal(t, kacBuilder.Definition.Namespace, kacBuilder.Object.Namespace)
-		}
-	}
-}
-
-func TestKACUpdate(t *testing.T) {
-	testCases := []struct {
-		alreadyExists     bool
-		force             bool
-		expectedErrorText string
-	}{
-		{
-			alreadyExists:     false,
-			force:             false,
-			expectedErrorText: "cannot update non-existent klusterletAddonConfig",
-		},
-		{
-			alreadyExists:     true,
-			force:             false,
-			expectedErrorText: "",
-		},
-		{
-			alreadyExists:     false,
-			force:             true,
-			expectedErrorText: "cannot update non-existent klusterletAddonConfig",
-		},
-		{
-			alreadyExists:     true,
-			force:             true,
-			expectedErrorText: "",
-		},
-	}
-
-	for _, testCase := range testCases {
-		kacBuilder := buildValidKACTestBuilder(buildTestClientWithKACScheme())
-
-		// Create the builder rather than just adding it to the client so that the proper metadata is added and
-		// the update will not fail.
-		if testCase.alreadyExists {
-			var err error
-
-			kacBuilder, err = kacBuilder.Create()
-
-			assert.Nil(t, err)
-			assert.True(t, kacBuilder.Exists())
-		}
-
-		// This causes an error while updating and allows us to test the code path for force updates.
-		if testCase.force {
-			kacBuilder.Definition.ResourceVersion = kacBuilder.Definition.Name
-		}
-
-		assert.NotNil(t, kacBuilder.Definition)
-		assert.False(t, kacBuilder.Definition.Spec.SearchCollectorConfig.Enabled)
-
-		kacBuilder.Definition.Spec.SearchCollectorConfig.Enabled = true
-
-		kacBuilder, err := kacBuilder.Update(testCase.force)
-
-		if testCase.expectedErrorText == "" {
-			assert.Nil(t, err)
-			assert.True(t, kacBuilder.Object.Spec.SearchCollectorConfig.Enabled)
-		} else {
-			assert.EqualError(t, err, testCase.expectedErrorText)
-		}
-	}
-}
-
-func TestKACDelete(t *testing.T) {
-	testCases := []struct {
-		testBuilder       *KACBuilder
-		expectedErrorText string
-	}{
-		{
-			testBuilder:       buildValidKACTestBuilder(buildTestClientWithDummyKAC()),
-			expectedErrorText: "",
-		},
-		{
-			testBuilder:       buildValidKACTestBuilder(buildTestClientWithKACScheme()),
-			expectedErrorText: "",
-		},
-		{
-			testBuilder:       buildInvalidKACTestBuilder(buildTestClientWithKACScheme()),
-			expectedErrorText: errEmptyNsname,
-		},
-	}
-
-	for _, testCase := range testCases {
-		err := testCase.testBuilder.Delete()
-
-		if testCase.expectedErrorText == "" {
-			assert.Nil(t, err)
-			assert.Nil(t, testCase.testBuilder.Object)
-		} else {
-			assert.EqualError(t, err, testCase.expectedErrorText)
-		}
-	}
+	testhelper.NewTestSuite().
+		With(testhelper.NewGetTestConfig(commonTestConfig)).
+		With(testhelper.NewExistsTestConfig(commonTestConfig)).
+		With(testhelper.NewCreateTestConfig(commonTestConfig)).
+		With(testhelper.NewDeleterTestConfig(commonTestConfig)).
+		With(testhelper.NewForceUpdateTestConfig(commonTestConfig)).
+		Run(t)
 }
 
 func TestKACWaitUntilSearchCollectorEnabled(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
+		name          string
 		exists        bool
 		valid         bool
 		enabled       bool
 		expectedError error
 	}{
 		{
-			exists:        true,
-			valid:         true,
-			enabled:       true,
-			expectedError: nil,
+			name:    "enabled collector",
+			exists:  true,
+			valid:   true,
+			enabled: true,
 		},
 		{
+			name:    "not exists",
 			exists:  false,
 			valid:   true,
 			enabled: true,
 			expectedError: fmt.Errorf(
-				"klusterletAddonConfig object %s does not exist in namespace %s", defaultKACName, defaultKACNamespace),
+				"klusterletAddonConfig object %s does not exist in namespace %s",
+				defaultKACName, defaultKACNamespace),
 		},
 		{
-			exists:        true,
-			valid:         false,
-			enabled:       true,
-			expectedError: fmt.Errorf(errEmptyNsname),
+			name:    "invalid builder",
+			exists:  true,
+			valid:   false,
+			enabled: true,
 		},
 		{
+			name:          "timeout waiting for enabled",
 			exists:        true,
 			valid:         true,
 			enabled:       false,
@@ -370,110 +94,47 @@ func TestKACWaitUntilSearchCollectorEnabled(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		var (
-			runtimeObjects []runtime.Object
-			kacBuilder     *KACBuilder
-		)
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 
-		if testCase.exists {
-			kac := buildDummyKAC(defaultKACName, defaultKACNamespace)
+			var runtimeObjects []runtime.Object
 
-			if testCase.enabled {
-				kac.Spec.SearchCollectorConfig.Enabled = true
+			if testCase.exists {
+				kac := buildDummyKAC(defaultKACName, defaultKACNamespace)
+
+				if testCase.enabled {
+					kac.Spec.SearchCollectorConfig.Enabled = true
+				}
+
+				runtimeObjects = append(runtimeObjects, kac)
 			}
 
-			runtimeObjects = append(runtimeObjects, kac)
-		}
+			testSettings := clients.GetTestClients(clients.TestClientParams{
+				K8sMockObjects: runtimeObjects,
+				SchemeAttachers: []clients.SchemeAttacher{
+					kacv1.SchemeBuilder.AddToScheme,
+				},
+			})
 
-		testSettings := clients.GetTestClients(clients.TestClientParams{
-			K8sMockObjects:  runtimeObjects,
-			SchemeAttachers: kacTestSchemes,
+			var kacBuilder *KACBuilder
+			if testCase.valid {
+				kacBuilder = buildValidKACTestBuilder(testSettings)
+			} else {
+				kacBuilder = buildInvalidKACTestBuilder(testSettings)
+			}
+
+			_, err := kacBuilder.WaitUntilSearchCollectorEnabled(time.Second)
+
+			switch {
+			case testCase.name == "invalid builder":
+				require.Error(t, err)
+				assert.True(t, commonerrors.IsBuilderNamespaceEmpty(err))
+			case testCase.expectedError != nil:
+				assert.Equal(t, testCase.expectedError, err)
+			default:
+				assert.NoError(t, err)
+			}
 		})
-
-		if testCase.valid {
-			kacBuilder = buildValidKACTestBuilder(testSettings)
-		} else {
-			kacBuilder = buildInvalidKACTestBuilder(testSettings)
-		}
-
-		_, err := kacBuilder.WaitUntilSearchCollectorEnabled(time.Second)
-		assert.Equal(t, testCase.expectedError, err)
-	}
-}
-
-func TestKACValidate(t *testing.T) {
-	testCases := []struct {
-		builderNil      bool
-		definitionNil   bool
-		apiClientNil    bool
-		builderErrorMsg string
-		expectedError   error
-	}{
-		{
-			builderNil:      false,
-			definitionNil:   false,
-			apiClientNil:    false,
-			builderErrorMsg: "",
-			expectedError:   nil,
-		},
-		{
-			builderNil:      true,
-			definitionNil:   false,
-			apiClientNil:    false,
-			builderErrorMsg: "",
-			expectedError:   fmt.Errorf("error: received nil klusterletAddonConfig builder"),
-		},
-		{
-			builderNil:      false,
-			definitionNil:   true,
-			apiClientNil:    false,
-			builderErrorMsg: "",
-			expectedError:   fmt.Errorf("can not redefine the undefined klusterletAddonConfig"),
-		},
-		{
-			builderNil:      false,
-			definitionNil:   false,
-			apiClientNil:    true,
-			builderErrorMsg: "",
-			expectedError:   fmt.Errorf("klusterletAddonConfig builder cannot have nil apiClient"),
-		},
-		{
-			builderNil:      false,
-			definitionNil:   false,
-			apiClientNil:    false,
-			builderErrorMsg: "test error",
-			expectedError:   fmt.Errorf("test error"),
-		},
-	}
-
-	for _, testCase := range testCases {
-		kacBuilder := buildValidKACTestBuilder(buildTestClientWithKACScheme())
-
-		if testCase.builderNil {
-			kacBuilder = nil
-		}
-
-		if testCase.definitionNil {
-			kacBuilder.Definition = nil
-		}
-
-		if testCase.apiClientNil {
-			kacBuilder.apiClient = nil
-		}
-
-		if testCase.builderErrorMsg != "" {
-			kacBuilder.errorMsg = testCase.builderErrorMsg
-		}
-
-		valid, err := kacBuilder.validate()
-
-		if testCase.expectedError != nil {
-			assert.False(t, valid)
-			assert.Equal(t, testCase.expectedError, err)
-		} else {
-			assert.True(t, valid)
-			assert.Nil(t, err)
-		}
 	}
 }
 
@@ -485,23 +146,6 @@ func buildDummyKAC(name, namespace string) *kacv1.KlusterletAddonConfig {
 			Namespace: namespace,
 		},
 	}
-}
-
-// buildTestClientWithDummyKAC returns a client with a mock KlusterletAddonConfig.
-func buildTestClientWithDummyKAC() *clients.Settings {
-	return clients.GetTestClients(clients.TestClientParams{
-		K8sMockObjects: []runtime.Object{
-			buildDummyKAC(defaultKACName, defaultKACNamespace),
-		},
-		SchemeAttachers: kacTestSchemes,
-	})
-}
-
-// buildTestClientWithKACScheme returns a client with no objects but the KlusterletAddonConfig scheme attached.
-func buildTestClientWithKACScheme() *clients.Settings {
-	return clients.GetTestClients(clients.TestClientParams{
-		SchemeAttachers: kacTestSchemes,
-	})
 }
 
 // buildValidKACTestBuilder returns a valid Builder for testing.


### PR DESCRIPTION
## Summary
Migrate kac builder in pkg/ocm to the common builder framework.

Closes #1451

Made with [Cursor](https://cursor.com)