### PR TITLE
ocm: migrate klusterlet to common builder

### DIFF
--- a/pkg/ocm/klusterlet.go
+++ b/pkg/ocm/klusterlet.go
@@ -1,255 +1,47 @@
 package ocm
 
 import (
-	"fmt"
+	"context"
 
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/logging"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/msg"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog/v2"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	operatorv1 "open-cluster-management.io/api/operator/v1"
-	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const (
-	errEmptyKlusterletName = "klusterlet 'name' cannot be empty"
-)
+var klusterletGVK = schema.GroupVersion{Group: operatorv1.GroupName, Version: "v1"}.WithKind("Klusterlet")
 
 // KlusterletName is the name of the klusterlet created by importing a ManagedCluster.
 const KlusterletName = "klusterlet"
 
 // KlusterletBuilder provides a struct to interface with Klusterlet resources on a specific cluster.
 type KlusterletBuilder struct {
-	// Definition of the Klusterlet used to create the resource.
-	Definition *operatorv1.Klusterlet
-	// Object of the Klusterlet as it is on the cluster.
-	Object *operatorv1.Klusterlet
-	// apiClient used to interact with the cluster.
-	apiClient runtimeclient.Client
-	// errorMsg is used to store the error message from functions that do not return an error.
-	errorMsg string
+	common.EmbeddableBuilder[operatorv1.Klusterlet, *operatorv1.Klusterlet]
+	common.EmbeddableCreator[operatorv1.Klusterlet, KlusterletBuilder, *operatorv1.Klusterlet, *KlusterletBuilder]
+	common.EmbeddableDeleter[operatorv1.Klusterlet, *operatorv1.Klusterlet]
+	common.EmbeddableUpdater[operatorv1.Klusterlet, KlusterletBuilder, *operatorv1.Klusterlet, *KlusterletBuilder]
+}
+
+// AttachMixins wires the embedded CRUD mixins to this builder instance.
+func (builder *KlusterletBuilder) AttachMixins() {
+	builder.EmbeddableCreator.SetBase(builder)
+	builder.EmbeddableDeleter.SetBase(builder)
+	builder.EmbeddableUpdater.SetBase(builder)
+}
+
+// GetGVK returns the Klusterlet GVK for this builder.
+func (builder *KlusterletBuilder) GetGVK() schema.GroupVersionKind {
+	return klusterletGVK
 }
 
 // NewKlusterletBuilder creates a new instance of a Klusterlet builder.
 func NewKlusterletBuilder(apiClient *clients.Settings, name string) *KlusterletBuilder {
-	klog.V(100).Infof("Initializing new Klusterlet structure with the following params: name: %s", name)
-
-	if apiClient == nil {
-		klog.V(100).Info("The apiClient of the Klusterlet is nil")
-
-		return nil
-	}
-
-	err := apiClient.AttachScheme(operatorv1.Install)
-	if err != nil {
-		klog.V(100).Infof("Failed to add ocm operator v1 scheme to client schemes: %v", err)
-
-		return nil
-	}
-
-	builder := &KlusterletBuilder{
-		apiClient: apiClient.Client,
-		Definition: &operatorv1.Klusterlet{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: name,
-			},
-		},
-	}
-
-	if name == "" {
-		klog.V(100).Info("The name of the Klusterlet is empty")
-
-		builder.errorMsg = errEmptyKlusterletName
-
-		return builder
-	}
-
-	return builder
+	return common.NewClusterScopedBuilder[operatorv1.Klusterlet, KlusterletBuilder](
+		apiClient, operatorv1.Install, name)
 }
 
 // PullKlusterlet pulls an existing Klusterlet into a Builder struct.
 func PullKlusterlet(apiClient *clients.Settings, name string) (*KlusterletBuilder, error) {
-	klog.V(100).Infof("Pulling existing Klusterlet %s from cluster", name)
-
-	if apiClient == nil {
-		klog.V(100).Info("The apiClient of the Klusterlet is nil")
-
-		return nil, fmt.Errorf("klusterlet 'apiClient' cannot be nil")
-	}
-
-	err := apiClient.AttachScheme(operatorv1.Install)
-	if err != nil {
-		klog.V(100).Infof("Failed to add ocm operator v1 scheme to client schemes: %v", err)
-
-		return nil, err
-	}
-
-	builder := &KlusterletBuilder{
-		apiClient: apiClient.Client,
-		Definition: &operatorv1.Klusterlet{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: name,
-			},
-		},
-	}
-
-	if name == "" {
-		klog.V(100).Info("The name of the Klusterlet is empty")
-
-		return nil, fmt.Errorf(errEmptyKlusterletName)
-	}
-
-	if !builder.Exists() {
-		klog.V(100).Infof("The Klusterlet %s does not exist", name)
-
-		return nil, fmt.Errorf("klusterlet object %s does not exist", name)
-	}
-
-	builder.Definition = builder.Object
-
-	return builder, nil
-}
-
-// Get returns the Klusterlet object if found.
-func (builder *KlusterletBuilder) Get() (*operatorv1.Klusterlet, error) {
-	if valid, err := builder.validate(); !valid {
-		return nil, err
-	}
-
-	klog.V(100).Infof("Getting Klusterlet object %s", builder.Definition.Name)
-
-	klusterlet := &operatorv1.Klusterlet{}
-
-	err := builder.apiClient.Get(logging.DiscardContext(), runtimeclient.ObjectKey{Name: builder.Definition.Name}, klusterlet)
-	if err != nil {
-		klog.V(100).Infof("Failed to get Klusterlet object %s: %v", builder.Definition.Name, err)
-
-		return nil, err
-	}
-
-	return klusterlet, nil
-}
-
-// Exists checks whether this Klusterlet exists on the cluster.
-func (builder *KlusterletBuilder) Exists() bool {
-	if valid, _ := builder.validate(); !valid {
-		return false
-	}
-
-	klog.V(100).Infof("Checking if Klusterlet %s", builder.Definition.Name)
-
-	var err error
-
-	builder.Object, err = builder.Get()
-
-	return err == nil || !k8serrors.IsNotFound(err)
-}
-
-// Create makes a Klusterlet on the cluster if it does not already exist.
-func (builder *KlusterletBuilder) Create() (*KlusterletBuilder, error) {
-	if valid, err := builder.validate(); !valid {
-		return nil, err
-	}
-
-	klog.V(100).Infof("Creating Klusterlet %s", builder.Definition.Name)
-
-	if builder.Exists() {
-		return builder, nil
-	}
-
-	err := builder.apiClient.Create(logging.DiscardContext(), builder.Definition)
-	if err != nil {
-		return nil, err
-	}
-
-	builder.Object = builder.Definition
-
-	return builder, nil
-}
-
-// Update changes the existing Klusterlet resource on the cluster to match the builder Definition. Deleting a Klusterlet
-// is nontrivial and affects the connection to the hub cluster, so there is no force option to allow deleting and
-// recreating the Klusterlet if the update fails.
-func (builder *KlusterletBuilder) Update() (*KlusterletBuilder, error) {
-	if valid, err := builder.validate(); !valid {
-		return nil, err
-	}
-
-	klog.V(100).Infof("Updating Klusterlet %s", builder.Definition.Name)
-
-	if !builder.Exists() {
-		klog.V(100).Infof("Klusterlet %s does not exist", builder.Definition.Name)
-
-		return nil, fmt.Errorf("cannot update non-existent klusterlet")
-	}
-
-	builder.Definition.ResourceVersion = builder.Object.ResourceVersion
-
-	err := builder.apiClient.Update(logging.DiscardContext(), builder.Definition)
-	if err != nil {
-		return nil, err
-	}
-
-	builder.Object = builder.Definition
-
-	return builder, nil
-}
-
-// Delete removes a Klusterlet from the cluster if it exists.
-func (builder *KlusterletBuilder) Delete() error {
-	if valid, err := builder.validate(); !valid {
-		return err
-	}
-
-	klog.V(100).Infof("Deleting Klusterlet %s", builder.Definition.Name)
-
-	if !builder.Exists() {
-		klog.V(100).Infof("Klusterlet %s does not exist", builder.Definition.Name)
-
-		builder.Object = nil
-
-		return nil
-	}
-
-	err := builder.apiClient.Delete(logging.DiscardContext(), builder.Object)
-	if err != nil {
-		return err
-	}
-
-	builder.Object = nil
-
-	return nil
-}
-
-// validate checks that the builder, definition, and apiClient are properly initialized and there is no errorMsg.
-func (builder *KlusterletBuilder) validate() (bool, error) {
-	resourceCRD := "klusterlet"
-
-	if builder == nil {
-		klog.V(100).Infof("The %s builder is uninitialized", resourceCRD)
-
-		return false, fmt.Errorf("error: received nil %s builder", resourceCRD)
-	}
-
-	if builder.Definition == nil {
-		klog.V(100).Infof("The %s is uninitialized", resourceCRD)
-
-		return false, fmt.Errorf("%s", msg.UndefinedCrdObjectErrString(resourceCRD))
-	}
-
-	if builder.apiClient == nil {
-		klog.V(100).Infof("The %s builder apiClient is nil", resourceCRD)
-
-		return false, fmt.Errorf("%s builder cannot have nil apiClient", resourceCRD)
-	}
-
-	if builder.errorMsg != "" {
-		klog.V(100).Infof("The %s builder has error message %s", resourceCRD, builder.errorMsg)
-
-		return false, fmt.Errorf("%s", builder.errorMsg)
-	}
-
-	return true, nil
+	return common.PullClusterScopedBuilder[operatorv1.Klusterlet, KlusterletBuilder](
+		context.TODO(), apiClient, operatorv1.Install, name)
 }

--- a/pkg/ocm/klusterlet_test.go
+++ b/pkg/ocm/klusterlet_test.go
@@ -1,366 +1,40 @@
 package ocm
 
 import (
-	"fmt"
 	"testing"
 
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
-	"github.com/stretchr/testify/assert"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common/testhelper"
 	operatorv1 "open-cluster-management.io/api/operator/v1"
 )
 
-var operatorTestSchemes = []clients.SchemeAttacher{
-	operatorv1.Install,
-}
-
 func TestNewKlusterletBuilder(t *testing.T) {
-	testCases := []struct {
-		name          string
-		client        bool
-		expectedError string
-	}{
-		{
-			name:          KlusterletName,
-			client:        true,
-			expectedError: "",
-		},
-		{
-			name:          "",
-			client:        true,
-			expectedError: errEmptyKlusterletName,
-		},
-		{
-			name:          KlusterletName,
-			client:        false,
-			expectedError: "",
-		},
-	}
+	t.Parallel()
 
-	for _, testCase := range testCases {
-		var testSettings *clients.Settings
-
-		if testCase.client {
-			testSettings = clients.GetTestClients(clients.TestClientParams{})
-		}
-
-		testBuilder := NewKlusterletBuilder(testSettings, testCase.name)
-
-		if testCase.client {
-			assert.Equal(t, testCase.expectedError, testBuilder.errorMsg)
-
-			if testCase.expectedError == "" {
-				assert.Equal(t, testCase.name, testBuilder.Definition.Name)
-			}
-		} else {
-			assert.Nil(t, testBuilder)
-		}
-	}
+	testhelper.NewClusterScopedBuilderTestConfig(
+		NewKlusterletBuilder, operatorv1.Install, klusterletGVK).ExecuteTests(t)
 }
 
 func TestPullKlusterlet(t *testing.T) {
-	testCases := []struct {
-		name                string
-		addToRuntimeObjects bool
-		client              bool
-		expectedError       error
-	}{
-		{
-			name:                KlusterletName,
-			addToRuntimeObjects: true,
-			client:              true,
-			expectedError:       nil,
-		},
-		{
-			name:                "",
-			addToRuntimeObjects: true,
-			client:              true,
-			expectedError:       fmt.Errorf(errEmptyKlusterletName),
-		},
-		{
-			name:                KlusterletName,
-			addToRuntimeObjects: false,
-			client:              true,
-			expectedError:       fmt.Errorf("klusterlet object %s does not exist", KlusterletName),
-		},
-		{
-			name:                KlusterletName,
-			addToRuntimeObjects: true,
-			client:              false,
-			expectedError:       fmt.Errorf("klusterlet 'apiClient' cannot be nil"),
-		},
-	}
+	t.Parallel()
 
-	for _, testCase := range testCases {
-		var (
-			runtimeObjects []runtime.Object
-			testSettings   *clients.Settings
-		)
-
-		if testCase.addToRuntimeObjects {
-			runtimeObjects = append(runtimeObjects, buildDummyKlusterlet(KlusterletName))
-		}
-
-		if testCase.client {
-			testSettings = clients.GetTestClients(clients.TestClientParams{
-				K8sMockObjects:  runtimeObjects,
-				SchemeAttachers: operatorTestSchemes,
-			})
-		}
-
-		testBuilder, err := PullKlusterlet(testSettings, testCase.name)
-		assert.Equal(t, testCase.expectedError, err)
-
-		if testCase.expectedError == nil {
-			assert.Equal(t, testCase.name, testBuilder.Definition.Name)
-		}
-	}
+	testhelper.NewClusterScopedPullTestConfig(
+		PullKlusterlet, operatorv1.Install, klusterletGVK).ExecuteTests(t)
 }
 
-func TestKlusterletGet(t *testing.T) {
-	testCases := []struct {
-		testBuilder   *KlusterletBuilder
-		expectedError string
-	}{
-		{
-			testBuilder:   buildValidKlusterletTestBuilder(buildTestClientWithDummyKlusterlet()),
-			expectedError: "",
-		},
-		{
-			testBuilder:   buildInvalidKlusterlettestbuilder(buildTestClientWithDummyKlusterlet()),
-			expectedError: errEmptyKlusterletName,
-		},
-		{
-			testBuilder:   buildValidKlusterletTestBuilder(clients.GetTestClients(clients.TestClientParams{})),
-			expectedError: fmt.Sprintf("klusterlets.operator.open-cluster-management.io \"%s\" not found", KlusterletName),
-		},
-	}
+func TestKlusterletBuilderMethods(t *testing.T) {
+	t.Parallel()
 
-	for _, testCase := range testCases {
-		klusterlet, err := testCase.testBuilder.Get()
+	commonTestConfig := testhelper.NewCommonTestConfig[operatorv1.Klusterlet, KlusterletBuilder](
+		operatorv1.Install,
+		klusterletGVK,
+		testhelper.ResourceScopeClusterScoped,
+	)
 
-		if testCase.expectedError == "" {
-			assert.Nil(t, err)
-			assert.Equal(t, testCase.testBuilder.Definition.Name, klusterlet.Name)
-		} else {
-			assert.EqualError(t, err, testCase.expectedError)
-		}
-	}
-}
-
-func TestKlusterletExists(t *testing.T) {
-	testCases := []struct {
-		testBuilder *KlusterletBuilder
-		exists      bool
-	}{
-		{
-			testBuilder: buildValidKlusterletTestBuilder(buildTestClientWithDummyKlusterlet()),
-			exists:      true,
-		},
-		{
-			testBuilder: buildInvalidKlusterlettestbuilder(buildTestClientWithDummyKlusterlet()),
-			exists:      false,
-		},
-		{
-			testBuilder: buildValidKlusterletTestBuilder(clients.GetTestClients(clients.TestClientParams{})),
-			exists:      false,
-		},
-	}
-
-	for _, testCase := range testCases {
-		exists := testCase.testBuilder.Exists()
-		assert.Equal(t, testCase.exists, exists)
-	}
-}
-
-func TestKlusterletCreate(t *testing.T) {
-	testCases := []struct {
-		testBuilder   *KlusterletBuilder
-		expectedError error
-	}{
-		{
-			testBuilder:   buildValidKlusterletTestBuilder(buildTestClientWithDummyKlusterlet()),
-			expectedError: nil,
-		},
-		{
-			testBuilder:   buildValidKlusterletTestBuilder(clients.GetTestClients(clients.TestClientParams{})),
-			expectedError: nil,
-		},
-		{
-			testBuilder:   buildInvalidKlusterlettestbuilder(buildTestClientWithDummyKlusterlet()),
-			expectedError: fmt.Errorf(errEmptyKlusterletName),
-		},
-	}
-
-	for _, testCase := range testCases {
-		testBuilder, err := testCase.testBuilder.Create()
-		assert.Equal(t, testCase.expectedError, err)
-
-		if testCase.expectedError == nil {
-			assert.Equal(t, testBuilder.Definition.Name, testBuilder.Object.Name)
-		}
-	}
-}
-
-func TestKlusterletUpdate(t *testing.T) {
-	testCases := []struct {
-		testBuilder   *KlusterletBuilder
-		expectedError error
-	}{
-		{
-			testBuilder:   buildValidKlusterletTestBuilder(buildTestClientWithDummyKlusterlet()),
-			expectedError: nil,
-		},
-		{
-			testBuilder:   buildValidKlusterletTestBuilder(clients.GetTestClients(clients.TestClientParams{})),
-			expectedError: fmt.Errorf("cannot update non-existent klusterlet"),
-		},
-		{
-			testBuilder:   buildInvalidKlusterlettestbuilder(buildTestClientWithDummyKlusterlet()),
-			expectedError: fmt.Errorf(errEmptyKlusterletName),
-		},
-	}
-
-	for _, testCase := range testCases {
-		assert.Empty(t, testCase.testBuilder.Definition.Spec.ClusterName)
-
-		testCase.testBuilder.Definition.Spec.ClusterName = "test"
-		testCase.testBuilder.Definition.ResourceVersion = "999"
-
-		testBuilder, err := testCase.testBuilder.Update()
-		assert.Equal(t, testCase.expectedError, err)
-
-		if testCase.expectedError == nil {
-			assert.Equal(t, "test", testBuilder.Object.Spec.ClusterName)
-		}
-	}
-}
-
-func TestKlusterletDelete(t *testing.T) {
-	testCases := []struct {
-		testBuilder   *KlusterletBuilder
-		expectedError error
-	}{
-		{
-			testBuilder:   buildValidKlusterletTestBuilder(buildTestClientWithDummyKlusterlet()),
-			expectedError: nil,
-		},
-		{
-			testBuilder:   buildValidKlusterletTestBuilder(clients.GetTestClients(clients.TestClientParams{})),
-			expectedError: nil,
-		},
-		{
-			testBuilder:   buildInvalidKlusterlettestbuilder(buildTestClientWithDummyKlusterlet()),
-			expectedError: fmt.Errorf(errEmptyKlusterletName),
-		},
-	}
-
-	for _, testCase := range testCases {
-		err := testCase.testBuilder.Delete()
-		assert.Equal(t, testCase.expectedError, err)
-
-		if testCase.expectedError == nil {
-			assert.Nil(t, testCase.testBuilder.Object)
-		}
-	}
-}
-
-func TestKlusterletValidate(t *testing.T) {
-	testCases := []struct {
-		builderNil      bool
-		definitionNil   bool
-		apiClientNil    bool
-		builderErrorMsg string
-		expectedError   error
-	}{
-		{
-			builderNil:      false,
-			definitionNil:   false,
-			apiClientNil:    false,
-			builderErrorMsg: "",
-			expectedError:   nil,
-		},
-		{
-			builderNil:      true,
-			definitionNil:   false,
-			apiClientNil:    false,
-			builderErrorMsg: "",
-			expectedError:   fmt.Errorf("error: received nil klusterlet builder"),
-		},
-		{
-			builderNil:      false,
-			definitionNil:   true,
-			apiClientNil:    false,
-			builderErrorMsg: "",
-			expectedError:   fmt.Errorf("can not redefine the undefined klusterlet"),
-		},
-		{
-			builderNil:      false,
-			definitionNil:   false,
-			apiClientNil:    true,
-			builderErrorMsg: "",
-			expectedError:   fmt.Errorf("klusterlet builder cannot have nil apiClient"),
-		},
-		{
-			builderNil:      false,
-			definitionNil:   false,
-			apiClientNil:    false,
-			builderErrorMsg: "test error",
-			expectedError:   fmt.Errorf("test error"),
-		},
-	}
-
-	for _, testCase := range testCases {
-		testBuilder := buildValidKlusterletTestBuilder(clients.GetTestClients(clients.TestClientParams{}))
-
-		if testCase.builderNil {
-			testBuilder = nil
-		}
-
-		if testCase.definitionNil {
-			testBuilder.Definition = nil
-		}
-
-		if testCase.apiClientNil {
-			testBuilder.apiClient = nil
-		}
-
-		if testCase.builderErrorMsg != "" {
-			testBuilder.errorMsg = testCase.builderErrorMsg
-		}
-
-		valid, err := testBuilder.validate()
-		assert.Equal(t, testCase.expectedError, err)
-		assert.Equal(t, testCase.expectedError == nil, valid)
-	}
-}
-
-// buildDummyKlusterlet returns a Klusterlet with the provided name.
-func buildDummyKlusterlet(name string) *operatorv1.Klusterlet {
-	return &operatorv1.Klusterlet{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-		},
-	}
-}
-
-// buildTestClientWithDummyKlusterlet returns a test client with a Klusterlet using KlusterletName.
-func buildTestClientWithDummyKlusterlet() *clients.Settings {
-	return clients.GetTestClients(clients.TestClientParams{
-		K8sMockObjects: []runtime.Object{
-			buildDummyKlusterlet(KlusterletName),
-		},
-		SchemeAttachers: operatorTestSchemes,
-	})
-}
-
-// buildValidKlusterletTestBuilder returns a valid KlusterletBuilder using KlusterletName.
-func buildValidKlusterletTestBuilder(apiClient *clients.Settings) *KlusterletBuilder {
-	return NewKlusterletBuilder(apiClient, KlusterletName)
-}
-
-// buildInvalidKlusterlettestbuilder returns an invalid KlusterletBuilder with an empty name.
-func buildInvalidKlusterlettestbuilder(apiClient *clients.Settings) *KlusterletBuilder {
-	return NewKlusterletBuilder(apiClient, "")
+	testhelper.NewTestSuite().
+		With(testhelper.NewGetTestConfig(commonTestConfig)).
+		With(testhelper.NewExistsTestConfig(commonTestConfig)).
+		With(testhelper.NewCreateTestConfig(commonTestConfig)).
+		With(testhelper.NewDeleterTestConfig(commonTestConfig)).
+		With(testhelper.NewUpdateTestConfig(commonTestConfig)).
+		Run(t)
 }


### PR DESCRIPTION
## Summary
Migrate klusterlet builder in pkg/ocm to the common builder framework.

Closes #1452

Made with [Cursor](https://cursor.com)