### PR TITLE
ocm: migrate placementrule to common builder

### DIFF
--- a/pkg/ocm/placementrule.go
+++ b/pkg/ocm/placementrule.go
@@ -1,288 +1,45 @@
 package ocm
 
 import (
-	"fmt"
+	"context"
 
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/logging"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/msg"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog/v2"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	placementrulev1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/placementrule/v1"
-	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+var placementRuleGVK = placementrulev1.SchemeGroupVersion.WithKind("PlacementRule")
 
 // PlacementRuleBuilder provides struct for the PlacementRule object containing connection to
 // the cluster and the PlacementRule definitions.
 type PlacementRuleBuilder struct {
-	// PlacementRule Definition, used to create the PlacementRule object.
-	Definition *placementrulev1.PlacementRule
-	// created PlacementRule object.
-	Object *placementrulev1.PlacementRule
-	// api client to interact with the cluster.
-	apiClient runtimeclient.Client
-	// used to store latest error message upon defining or mutating PlacementRule definition.
-	errorMsg string
+	common.EmbeddableBuilder[placementrulev1.PlacementRule, *placementrulev1.PlacementRule]
+	common.EmbeddableCreator[placementrulev1.PlacementRule, PlacementRuleBuilder, *placementrulev1.PlacementRule, *PlacementRuleBuilder]
+	common.EmbeddableDeleteReturner[placementrulev1.PlacementRule, PlacementRuleBuilder, *placementrulev1.PlacementRule, *PlacementRuleBuilder]
+	common.EmbeddableForceUpdater[placementrulev1.PlacementRule, PlacementRuleBuilder, *placementrulev1.PlacementRule, *PlacementRuleBuilder]
+}
+
+// AttachMixins wires the embedded CRUD mixins to this builder instance.
+func (builder *PlacementRuleBuilder) AttachMixins() {
+	builder.EmbeddableCreator.SetBase(builder)
+	builder.EmbeddableDeleteReturner.SetBase(builder)
+	builder.EmbeddableForceUpdater.SetBase(builder)
+}
+
+// GetGVK returns the PlacementRule GVK for this builder.
+func (builder *PlacementRuleBuilder) GetGVK() schema.GroupVersionKind {
+	return placementRuleGVK
 }
 
 // NewPlacementRuleBuilder creates a new instance of PlacementRuleBuilder.
 func NewPlacementRuleBuilder(apiClient *clients.Settings, name, nsname string) *PlacementRuleBuilder {
-	klog.V(100).Infof(
-		"Initializing new placement rule structure with the following params: name: %s, nsname: %s",
-		name, nsname)
-
-	if apiClient == nil {
-		klog.V(100).Info("The apiClient of the PlacementRule is nil")
-
-		return nil
-	}
-
-	err := apiClient.AttachScheme(placementrulev1.AddToScheme)
-	if err != nil {
-		klog.V(100).Info("Failed to add PlacementRule scheme to client schemes")
-
-		return nil
-	}
-
-	builder := &PlacementRuleBuilder{
-		apiClient: apiClient.Client,
-		Definition: &placementrulev1.PlacementRule{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: nsname,
-			},
-		},
-	}
-
-	if name == "" {
-		klog.V(100).Info("The name of the PlacementRule is empty")
-
-		builder.errorMsg = "placementrule's 'name' cannot be empty"
-
-		return builder
-	}
-
-	if nsname == "" {
-		klog.V(100).Info("The namespace of the PlacementRule is empty")
-
-		builder.errorMsg = "placementrule's 'nsname' cannot be empty"
-
-		return builder
-	}
-
-	return builder
+	return common.NewNamespacedBuilder[placementrulev1.PlacementRule, PlacementRuleBuilder](
+		apiClient, placementrulev1.AddToScheme, name, nsname)
 }
 
 // PullPlacementRule pulls existing placementrule into Builder struct.
 func PullPlacementRule(apiClient *clients.Settings, name, nsname string) (*PlacementRuleBuilder, error) {
-	klog.V(100).Infof("Pulling existing placementrule name %s under namespace %s from cluster", name, nsname)
-
-	if apiClient == nil {
-		klog.V(100).Info("The apiClient is empty")
-
-		return nil, fmt.Errorf("placementrule's 'apiClient' cannot be empty")
-	}
-
-	err := apiClient.AttachScheme(placementrulev1.AddToScheme)
-	if err != nil {
-		klog.V(100).Info("Failed to add PlacementRule scheme to client schemes")
-
-		return nil, err
-	}
-
-	builder := PlacementRuleBuilder{
-		apiClient: apiClient.Client,
-		Definition: &placementrulev1.PlacementRule{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: nsname,
-			},
-		},
-	}
-
-	if name == "" {
-		klog.V(100).Info("The name of the placementrule is empty")
-
-		return nil, fmt.Errorf("placementrule's 'name' cannot be empty")
-	}
-
-	if nsname == "" {
-		klog.V(100).Info("The namespace of the placementrule is empty")
-
-		return nil, fmt.Errorf("placementrule's 'namespace' cannot be empty")
-	}
-
-	if !builder.Exists() {
-		return nil, fmt.Errorf("placementrule object %s does not exist in namespace %s", name, nsname)
-	}
-
-	builder.Definition = builder.Object
-
-	return &builder, nil
-}
-
-// Exists checks whether the given placementrule exists.
-func (builder *PlacementRuleBuilder) Exists() bool {
-	if valid, _ := builder.validate(); !valid {
-		return false
-	}
-
-	klog.V(100).Infof("Checking if placementrule %s exists in namespace %s",
-		builder.Definition.Name, builder.Definition.Namespace)
-
-	var err error
-
-	builder.Object, err = builder.Get()
-
-	return err == nil || !k8serrors.IsNotFound(err)
-}
-
-// Get returns a placementrule object if found.
-func (builder *PlacementRuleBuilder) Get() (*placementrulev1.PlacementRule, error) {
-	if valid, err := builder.validate(); !valid {
-		return nil, err
-	}
-
-	klog.V(100).Infof("Getting placementrule %s in namespace %s",
-		builder.Definition.Name, builder.Definition.Namespace)
-
-	placementRule := &placementrulev1.PlacementRule{}
-
-	err := builder.apiClient.Get(logging.DiscardContext(), runtimeclient.ObjectKey{
-		Name:      builder.Definition.Name,
-		Namespace: builder.Definition.Namespace,
-	}, placementRule)
-	if err != nil {
-		klog.V(100).Infof("Failed to get placementrule %s in namespace %s: %v",
-			builder.Definition.Name, builder.Definition.Namespace, err)
-
-		return nil, err
-	}
-
-	return placementRule, nil
-}
-
-// Create makes a placementrule in the cluster and stores the created object in struct.
-func (builder *PlacementRuleBuilder) Create() (*PlacementRuleBuilder, error) {
-	if valid, err := builder.validate(); !valid {
-		return builder, err
-	}
-
-	klog.V(100).Infof("Creating the placementrule %s in namespace %s",
-		builder.Definition.Name, builder.Definition.Namespace)
-
-	if builder.Exists() {
-		return builder, nil
-	}
-
-	err := builder.apiClient.Create(logging.DiscardContext(), builder.Definition)
-	if err != nil {
-		return builder, err
-	}
-
-	builder.Object = builder.Definition
-
-	return builder, nil
-}
-
-// Delete removes a placementrule from a cluster.
-func (builder *PlacementRuleBuilder) Delete() (*PlacementRuleBuilder, error) {
-	if valid, err := builder.validate(); !valid {
-		return builder, err
-	}
-
-	klog.V(100).Infof("Deleting the placementrule %s in namespace %s",
-		builder.Definition.Name, builder.Definition.Namespace)
-
-	if !builder.Exists() {
-		klog.V(100).Infof("placementrule %s cannot be deleted because it does not exist",
-			builder.Definition.Name)
-
-		builder.Object = nil
-
-		return builder, nil
-	}
-
-	err := builder.apiClient.Delete(logging.DiscardContext(), builder.Definition)
-	if err != nil {
-		return builder, fmt.Errorf("cannot delete placementrule: %w", err)
-	}
-
-	builder.Object = nil
-
-	return builder, nil
-}
-
-// Update renovates the existing placementrule object with the placementrule definition in builder.
-func (builder *PlacementRuleBuilder) Update(force bool) (*PlacementRuleBuilder, error) {
-	if valid, err := builder.validate(); !valid {
-		return builder, err
-	}
-
-	if !builder.Exists() {
-		klog.V(100).Infof(
-			"PlacementRule %s does not exist in namespace %s", builder.Definition.Name, builder.Definition.Namespace)
-
-		return nil, fmt.Errorf("cannot update non-existent placementrule")
-	}
-
-	klog.V(100).Infof("Updating the placementrule object: %s in namespace: %s",
-		builder.Definition.Name, builder.Definition.Namespace)
-
-	builder.Definition.ResourceVersion = builder.Object.ResourceVersion
-
-	err := builder.apiClient.Update(logging.DiscardContext(), builder.Definition)
-	if err != nil {
-		if force {
-			klog.V(100).Infof("%v", msg.FailToUpdateNotification("placementrule", builder.Definition.Name, builder.Definition.Namespace))
-
-			builder, err := builder.Delete()
-			builder.Definition.ResourceVersion = ""
-
-			if err != nil {
-				klog.V(100).Infof("%v", msg.FailToUpdateError("placementrule", builder.Definition.Name, builder.Definition.Namespace))
-
-				return nil, err
-			}
-
-			return builder.Create()
-		}
-	}
-
-	builder.Object = builder.Definition
-
-	return builder, nil
-}
-
-// validate will check that the builder and builder definition are properly initialized before
-// accessing any member fields.
-func (builder *PlacementRuleBuilder) validate() (bool, error) {
-	resourceCRD := "placementRule"
-
-	if builder == nil {
-		klog.V(100).Infof("The %s builder is uninitialized", resourceCRD)
-
-		return false, fmt.Errorf("error: received nil %s builder", resourceCRD)
-	}
-
-	if builder.Definition == nil {
-		klog.V(100).Infof("The %s is undefined", resourceCRD)
-
-		return false, fmt.Errorf("%s", msg.UndefinedCrdObjectErrString(resourceCRD))
-	}
-
-	if builder.apiClient == nil {
-		klog.V(100).Infof("The %s builder apiclient is nil", resourceCRD)
-
-		return false, fmt.Errorf("%s builder cannot have nil apiClient", resourceCRD)
-	}
-
-	if builder.errorMsg != "" {
-		klog.V(100).Infof("The %s builder has error message: %s", resourceCRD, builder.errorMsg)
-
-		return false, fmt.Errorf("%s", builder.errorMsg)
-	}
-
-	return true, nil
+	return common.PullNamespacedBuilder[placementrulev1.PlacementRule, PlacementRuleBuilder](
+		context.TODO(), apiClient, placementrulev1.AddToScheme, name, nsname)
 }

--- a/pkg/ocm/placementrule_test.go
+++ b/pkg/ocm/placementrule_test.go
@@ -3,10 +3,7 @@ package ocm
 import (
 	"testing"
 
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common/testhelper"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	placementrulev1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/placementrule/v1"
 )
 
@@ -45,26 +42,4 @@ func TestPlacementRuleBuilderMethods(t *testing.T) {
 		With(testhelper.NewDeleteReturnerTestConfig(commonTestConfig)).
 		With(testhelper.NewForceUpdateTestConfig(commonTestConfig)).
 		Run(t)
-}
-
-// buildDummyPlacementRule returns a PlacementRule with the provided name and namespace.
-func buildDummyPlacementRule(name, nsname string) *placementrulev1.PlacementRule {
-	return &placementrulev1.PlacementRule{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: nsname,
-		},
-	}
-}
-
-// buildTestClientWithDummyPlacementRule returns a client with a mock dummy PlacementRule.
-func buildTestClientWithDummyPlacementRule() *clients.Settings {
-	return clients.GetTestClients(clients.TestClientParams{
-		K8sMockObjects: []runtime.Object{
-			buildDummyPlacementRule(defaultPlacementRuleName, defaultPlacementRuleNsName),
-		},
-		SchemeAttachers: []clients.SchemeAttacher{
-			placementrulev1.AddToScheme,
-		},
-	})
 }

--- a/pkg/ocm/placementrule_test.go
+++ b/pkg/ocm/placementrule_test.go
@@ -1,12 +1,10 @@
 package ocm
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
-	"github.com/stretchr/testify/assert"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common/testhelper"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	placementrulev1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/placementrule/v1"
@@ -17,372 +15,36 @@ const (
 	defaultPlacementRuleNsName = "test-ns"
 )
 
-var placementRuleTestSchemes = []clients.SchemeAttacher{
-	placementrulev1.AddToScheme,
-}
-
 func TestNewPlacementRuleBuilder(t *testing.T) {
-	testCases := []struct {
-		placementRuleName      string
-		placementRuleNamespace string
-		client                 bool
-		expectedErrorText      string
-	}{
-		{
-			placementRuleName:      defaultPlacementRuleName,
-			placementRuleNamespace: defaultPlacementRuleNsName,
-			client:                 true,
-			expectedErrorText:      "",
-		},
-		{
-			placementRuleName:      "",
-			placementRuleNamespace: defaultPlacementRuleNsName,
-			client:                 true,
-			expectedErrorText:      "placementrule's 'name' cannot be empty",
-		},
-		{
-			placementRuleName:      defaultPlacementRuleName,
-			placementRuleNamespace: "",
-			client:                 true,
-			expectedErrorText:      "placementrule's 'nsname' cannot be empty",
-		},
-		{
-			placementRuleName:      defaultPlacementRuleName,
-			placementRuleNamespace: defaultPlacementRuleNsName,
-			client:                 false,
-			expectedErrorText:      "",
-		},
-	}
+	t.Parallel()
 
-	for _, testCase := range testCases {
-		var client *clients.Settings
-
-		if testCase.client {
-			client = buildTestClientWithPlacementRuleScheme()
-		}
-
-		placementRuleBuilder := NewPlacementRuleBuilder(client, testCase.placementRuleName, testCase.placementRuleNamespace)
-
-		if testCase.client {
-			assert.Equal(t, testCase.expectedErrorText, placementRuleBuilder.errorMsg)
-
-			if testCase.expectedErrorText == "" {
-				assert.Equal(t, testCase.placementRuleName, placementRuleBuilder.Definition.Name)
-				assert.Equal(t, testCase.placementRuleNamespace, placementRuleBuilder.Definition.Namespace)
-			}
-		} else {
-			assert.Nil(t, placementRuleBuilder)
-		}
-	}
+	testhelper.NewNamespacedBuilderTestConfig(
+		NewPlacementRuleBuilder, placementrulev1.AddToScheme, placementRuleGVK).ExecuteTests(t)
 }
 
 func TestPullPlacementRule(t *testing.T) {
-	testCases := []struct {
-		placementRuleName      string
-		placementRuleNamespace string
-		addToRuntimeObjects    bool
-		client                 bool
-		expectedError          error
-	}{
-		{
-			placementRuleName:      defaultPlacementRuleName,
-			placementRuleNamespace: defaultPlacementRuleNsName,
-			addToRuntimeObjects:    true,
-			client:                 true,
-			expectedError:          nil,
-		},
-		{
-			placementRuleName:      defaultPlacementRuleName,
-			placementRuleNamespace: defaultPlacementRuleNsName,
-			addToRuntimeObjects:    false,
-			client:                 true,
-			expectedError: fmt.Errorf(
-				"placementrule object %s does not exist in namespace %s", defaultPlacementRuleName, defaultPlacementRuleNsName),
-		},
-		{
-			placementRuleName:      "",
-			placementRuleNamespace: defaultPlacementRuleNsName,
-			addToRuntimeObjects:    false,
-			client:                 true,
-			expectedError:          fmt.Errorf("placementrule's 'name' cannot be empty"),
-		},
-		{
-			placementRuleName:      defaultPlacementRuleName,
-			placementRuleNamespace: "",
-			addToRuntimeObjects:    false,
-			client:                 true,
-			expectedError:          fmt.Errorf("placementrule's 'namespace' cannot be empty"),
-		},
-		{
-			placementRuleName:      defaultPlacementRuleName,
-			placementRuleNamespace: defaultPlacementRuleNsName,
-			addToRuntimeObjects:    false,
-			client:                 false,
-			expectedError:          fmt.Errorf("placementrule's 'apiClient' cannot be empty"),
-		},
-	}
+	t.Parallel()
 
-	for _, testCase := range testCases {
-		var (
-			runtimeObjects []runtime.Object
-			testSettings   *clients.Settings
-		)
-
-		testPlacementRule := buildDummyPlacementRule(testCase.placementRuleName, testCase.placementRuleNamespace)
-
-		if testCase.addToRuntimeObjects {
-			runtimeObjects = append(runtimeObjects, testPlacementRule)
-		}
-
-		if testCase.client {
-			testSettings = clients.GetTestClients(clients.TestClientParams{
-				K8sMockObjects:  runtimeObjects,
-				SchemeAttachers: placementRuleTestSchemes,
-			})
-		}
-
-		placementRuleBuilder, err := PullPlacementRule(testSettings, testPlacementRule.Name, testPlacementRule.Namespace)
-		assert.Equal(t, testCase.expectedError, err)
-
-		if testCase.expectedError == nil {
-			assert.Equal(t, testPlacementRule.Name, placementRuleBuilder.Object.Name)
-			assert.Equal(t, testPlacementRule.Namespace, placementRuleBuilder.Object.Namespace)
-		}
-	}
+	testhelper.NewNamespacedPullTestConfig(
+		PullPlacementRule, placementrulev1.AddToScheme, placementRuleGVK).ExecuteTests(t)
 }
 
-func TestPlacementRuleExists(t *testing.T) {
-	testCases := []struct {
-		testBuilder *PlacementRuleBuilder
-		exists      bool
-	}{
-		{
-			testBuilder: buildValidPlacementRuleTestBuilder(buildTestClientWithDummyPlacementRule()),
-			exists:      true,
-		},
-		{
-			testBuilder: buildInvalidPlacementRuleTestBuilder(buildTestClientWithDummyPlacementRule()),
-			exists:      false,
-		},
-		{
-			testBuilder: buildValidPlacementRuleTestBuilder(buildTestClientWithPlacementRuleScheme()),
-			exists:      false,
-		},
-	}
+func TestPlacementRuleBuilderMethods(t *testing.T) {
+	t.Parallel()
 
-	for _, testCase := range testCases {
-		exists := testCase.testBuilder.Exists()
-		assert.Equal(t, testCase.exists, exists)
-	}
-}
+	commonTestConfig := testhelper.NewCommonTestConfig[placementrulev1.PlacementRule, PlacementRuleBuilder](
+		placementrulev1.AddToScheme,
+		placementRuleGVK,
+		testhelper.ResourceScopeNamespaced,
+	)
 
-func TestPlacementRuleGet(t *testing.T) {
-	testCases := []struct {
-		testBuilder           *PlacementRuleBuilder
-		expectedPlacementRule *placementrulev1.PlacementRule
-	}{
-		{
-			testBuilder:           buildValidPlacementRuleTestBuilder(buildTestClientWithDummyPlacementRule()),
-			expectedPlacementRule: buildDummyPlacementRule(defaultPlacementRuleName, defaultPlacementRuleNsName),
-		},
-		{
-			testBuilder:           buildValidPlacementRuleTestBuilder(buildTestClientWithPlacementRuleScheme()),
-			expectedPlacementRule: nil,
-		},
-	}
-
-	for _, testCase := range testCases {
-		placementRule, err := testCase.testBuilder.Get()
-
-		if testCase.expectedPlacementRule == nil {
-			assert.Nil(t, placementRule)
-			assert.True(t, k8serrors.IsNotFound(err))
-		} else {
-			assert.Nil(t, err)
-			assert.Equal(t, testCase.expectedPlacementRule.Name, placementRule.Name)
-			assert.Equal(t, testCase.expectedPlacementRule.Namespace, placementRule.Namespace)
-		}
-	}
-}
-
-func TestPlacementRuleCreate(t *testing.T) {
-	testCases := []struct {
-		testBuilder   *PlacementRuleBuilder
-		expectedError error
-	}{
-		{
-			testBuilder:   buildValidPlacementRuleTestBuilder(buildTestClientWithPlacementRuleScheme()),
-			expectedError: nil,
-		},
-		{
-			testBuilder:   buildInvalidPlacementRuleTestBuilder(buildTestClientWithPlacementRuleScheme()),
-			expectedError: fmt.Errorf("placementrule's 'nsname' cannot be empty"),
-		},
-	}
-
-	for _, testCase := range testCases {
-		placementRuleBuilder, err := testCase.testBuilder.Create()
-		assert.Equal(t, testCase.expectedError, err)
-
-		if testCase.expectedError == nil {
-			assert.Equal(t, placementRuleBuilder.Definition, placementRuleBuilder.Object)
-		}
-	}
-}
-
-func TestPlacementRuleDelete(t *testing.T) {
-	testCases := []struct {
-		testBuilder   *PlacementRuleBuilder
-		expectedError error
-	}{
-		{
-			testBuilder:   buildValidPlacementRuleTestBuilder(buildTestClientWithDummyPlacementRule()),
-			expectedError: nil,
-		},
-		{
-			testBuilder:   buildInvalidPlacementRuleTestBuilder(buildTestClientWithDummyPlacementRule()),
-			expectedError: fmt.Errorf("placementrule's 'nsname' cannot be empty"),
-		},
-	}
-
-	for _, testCase := range testCases {
-		_, err := testCase.testBuilder.Delete()
-		assert.Equal(t, testCase.expectedError, err)
-
-		if testCase.expectedError == nil {
-			assert.Nil(t, testCase.testBuilder.Object)
-		}
-	}
-}
-
-func TestPlacementRuleUpdate(t *testing.T) {
-	testCases := []struct {
-		alreadyExists bool
-		force         bool
-	}{
-		{
-			alreadyExists: false,
-			force:         false,
-		},
-		{
-			alreadyExists: true,
-			force:         false,
-		},
-		{
-			alreadyExists: false,
-			force:         true,
-		},
-		{
-			alreadyExists: true,
-			force:         true,
-		},
-	}
-
-	for _, testCase := range testCases {
-		testBuilder := buildValidPlacementRuleTestBuilder(buildTestClientWithPlacementRuleScheme())
-
-		// Create the builder rather than just adding it to the client so that the proper metadata is added and
-		// the update will not fail.
-		if testCase.alreadyExists {
-			var err error
-
-			testBuilder = buildValidPlacementRuleTestBuilder(buildTestClientWithPlacementRuleScheme())
-			testBuilder, err = testBuilder.Create()
-			assert.Nil(t, err)
-		}
-
-		assert.NotNil(t, testBuilder.Definition)
-		assert.Empty(t, testBuilder.Definition.Spec.SchedulerName)
-
-		testBuilder.Definition.Spec.SchedulerName = "test-scheduler"
-
-		placementRuleBuilder, err := testBuilder.Update(testCase.force)
-		assert.NotNil(t, testBuilder.Definition)
-
-		if testCase.alreadyExists {
-			assert.Nil(t, err)
-			assert.Equal(t, testBuilder.Definition.Name, placementRuleBuilder.Definition.Name)
-			assert.Equal(t, testBuilder.Definition.Spec.SchedulerName, placementRuleBuilder.Definition.Spec.SchedulerName)
-		} else {
-			assert.NotNil(t, err)
-		}
-	}
-}
-
-func TestPlacementRuleValidate(t *testing.T) {
-	testCases := []struct {
-		builderNil      bool
-		definitionNil   bool
-		apiClientNil    bool
-		builderErrorMsg string
-		expectedError   error
-	}{
-		{
-			builderNil:      false,
-			definitionNil:   false,
-			apiClientNil:    false,
-			builderErrorMsg: "",
-			expectedError:   nil,
-		},
-		{
-			builderNil:      true,
-			definitionNil:   false,
-			apiClientNil:    false,
-			builderErrorMsg: "",
-			expectedError:   fmt.Errorf("error: received nil placementRule builder"),
-		},
-		{
-			builderNil:      false,
-			definitionNil:   true,
-			apiClientNil:    false,
-			builderErrorMsg: "",
-			expectedError:   fmt.Errorf("can not redefine the undefined placementRule"),
-		},
-		{
-			builderNil:      false,
-			definitionNil:   false,
-			apiClientNil:    true,
-			builderErrorMsg: "",
-			expectedError:   fmt.Errorf("placementRule builder cannot have nil apiClient"),
-		},
-		{
-			builderNil:      false,
-			definitionNil:   false,
-			apiClientNil:    false,
-			builderErrorMsg: "test error",
-			expectedError:   fmt.Errorf("test error"),
-		},
-	}
-
-	for _, testCase := range testCases {
-		placementRuleBuilder := buildValidPlacementRuleTestBuilder(buildTestClientWithPlacementRuleScheme())
-
-		if testCase.builderNil {
-			placementRuleBuilder = nil
-		}
-
-		if testCase.definitionNil {
-			placementRuleBuilder.Definition = nil
-		}
-
-		if testCase.apiClientNil {
-			placementRuleBuilder.apiClient = nil
-		}
-
-		if testCase.builderErrorMsg != "" {
-			placementRuleBuilder.errorMsg = testCase.builderErrorMsg
-		}
-
-		valid, err := placementRuleBuilder.validate()
-
-		if testCase.expectedError != nil {
-			assert.False(t, valid)
-			assert.Equal(t, testCase.expectedError, err)
-		} else {
-			assert.True(t, valid)
-			assert.Nil(t, err)
-		}
-	}
+	testhelper.NewTestSuite().
+		With(testhelper.NewGetTestConfig(commonTestConfig)).
+		With(testhelper.NewExistsTestConfig(commonTestConfig)).
+		With(testhelper.NewCreateTestConfig(commonTestConfig)).
+		With(testhelper.NewDeleteReturnerTestConfig(commonTestConfig)).
+		With(testhelper.NewForceUpdateTestConfig(commonTestConfig)).
+		Run(t)
 }
 
 // buildDummyPlacementRule returns a PlacementRule with the provided name and namespace.
@@ -401,23 +63,8 @@ func buildTestClientWithDummyPlacementRule() *clients.Settings {
 		K8sMockObjects: []runtime.Object{
 			buildDummyPlacementRule(defaultPlacementRuleName, defaultPlacementRuleNsName),
 		},
-		SchemeAttachers: placementRuleTestSchemes,
+		SchemeAttachers: []clients.SchemeAttacher{
+			placementrulev1.AddToScheme,
+		},
 	})
-}
-
-// buildTestClientWithPlacementRuleScheme returns a client with no objects but the PlacementRule scheme attached.
-func buildTestClientWithPlacementRuleScheme() *clients.Settings {
-	return clients.GetTestClients(clients.TestClientParams{
-		SchemeAttachers: placementRuleTestSchemes,
-	})
-}
-
-// buildValidPlacementRuleTestBuilder returns a valid PlacementRuleBuilder for testing.
-func buildValidPlacementRuleTestBuilder(apiClient *clients.Settings) *PlacementRuleBuilder {
-	return NewPlacementRuleBuilder(apiClient, defaultPlacementRuleName, defaultPlacementRuleNsName)
-}
-
-// buildInvalidPlacementRuleTestBuilder returns an invalid PlacementRuleBuilder for testing.
-func buildInvalidPlacementRuleTestBuilder(apiClient *clients.Settings) *PlacementRuleBuilder {
-	return NewPlacementRuleBuilder(apiClient, defaultPlacementRuleName, "")
 }

--- a/pkg/ocm/placementrulelist.go
+++ b/pkg/ocm/placementrulelist.go
@@ -1,11 +1,11 @@
 package ocm
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/logging"
-	"k8s.io/klog/v2"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common"
 	placementrulev1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/placementrule/v1"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -14,56 +14,10 @@ import (
 func ListPlacementrulesInAllNamespaces(apiClient *clients.Settings,
 	options ...runtimeclient.ListOptions) (
 	[]*PlacementRuleBuilder, error) {
-	if apiClient == nil {
-		klog.V(100).Info("PlacementRules 'apiClient' parameter cannot be nil")
-
-		return nil, fmt.Errorf("failed to list placementrules, 'apiClient' parameter is nil")
-	}
-
-	err := apiClient.AttachScheme(placementrulev1.AddToScheme)
-	if err != nil {
-		klog.V(100).Info("Failed to add PlacementRule scheme to client schemes")
-
-		return nil, err
-	}
-
-	logMessage := string("Listing all placementrules in all namespaces")
-	passedOptions := runtimeclient.ListOptions{}
-
 	if len(options) > 1 {
-		klog.V(100).Info("'options' parameter must be empty or single-valued")
-
 		return nil, fmt.Errorf("error: more than one ListOptions was passed")
 	}
 
-	if len(options) == 1 {
-		passedOptions = options[0]
-		logMessage += fmt.Sprintf(" with the options %v", passedOptions)
-	}
-
-	klog.V(100).Infof("%v", logMessage)
-
-	placementRuleList := new(placementrulev1.PlacementRuleList)
-
-	err = apiClient.List(logging.DiscardContext(), placementRuleList, &passedOptions)
-	if err != nil {
-		klog.V(100).Infof("Failed to list all placementrules in all namespaces due to %s", err.Error())
-
-		return nil, err
-	}
-
-	var placementRuleObjects []*PlacementRuleBuilder
-
-	for _, placementRule := range placementRuleList.Items {
-		copiedPlacementRule := placementRule
-		placementRuleBuilder := &PlacementRuleBuilder{
-			apiClient:  apiClient.Client,
-			Object:     &copiedPlacementRule,
-			Definition: &copiedPlacementRule,
-		}
-
-		placementRuleObjects = append(placementRuleObjects, placementRuleBuilder)
-	}
-
-	return placementRuleObjects, nil
+	return common.List[placementrulev1.PlacementRule, placementrulev1.PlacementRuleList, PlacementRuleBuilder](
+		context.TODO(), apiClient, placementrulev1.AddToScheme, common.ConvertListOptionsToOptions(options)...)
 }

--- a/pkg/ocm/placementrulelist.go
+++ b/pkg/ocm/placementrulelist.go
@@ -2,7 +2,6 @@ package ocm
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common"
@@ -14,10 +13,6 @@ import (
 func ListPlacementrulesInAllNamespaces(apiClient *clients.Settings,
 	options ...runtimeclient.ListOptions) (
 	[]*PlacementRuleBuilder, error) {
-	if len(options) > 1 {
-		return nil, fmt.Errorf("error: more than one ListOptions was passed")
-	}
-
 	return common.List[placementrulev1.PlacementRule, placementrulev1.PlacementRuleList, PlacementRuleBuilder](
 		context.TODO(), apiClient, placementrulev1.AddToScheme, common.ConvertListOptionsToOptions(options)...)
 }

--- a/pkg/ocm/placementrulelist_test.go
+++ b/pkg/ocm/placementrulelist_test.go
@@ -1,81 +1,18 @@
 package ocm
 
 import (
-	"fmt"
 	"testing"
 
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
-	commonerrors "github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common/errors"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"k8s.io/apimachinery/pkg/labels"
-	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common/testhelper"
+	placementrulev1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/placementrule/v1"
 )
 
 func TestListPlacementrulesInAllNamespaces(t *testing.T) {
 	t.Parallel()
 
-	testCases := []struct {
-		name          string
-		listOptions   []runtimeclient.ListOptions
-		expectedError error
-		client        bool
-	}{
-		{
-			name:          "list all",
-			listOptions:   nil,
-			expectedError: nil,
-			client:        true,
-		},
-		{
-			name:          "list with options",
-			listOptions:   []runtimeclient.ListOptions{{LabelSelector: labels.NewSelector()}},
-			expectedError: nil,
-			client:        true,
-		},
-		{
-			name: "too many list options",
-			listOptions: []runtimeclient.ListOptions{
-				{LabelSelector: labels.NewSelector()},
-				{LabelSelector: labels.NewSelector()},
-			},
-			expectedError: fmt.Errorf("error: more than one ListOptions was passed"),
-			client:        true,
-		},
-		{
-			name:          "nil client",
-			listOptions:   []runtimeclient.ListOptions{{LabelSelector: labels.NewSelector()}},
-			expectedError: fmt.Errorf("apiClient for PlacementRule is nil"),
-			client:        false,
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			t.Parallel()
-
-			var testSettings *clients.Settings
-
-			if testCase.client {
-				testSettings = buildTestClientWithDummyPlacementRule()
-			}
-
-			builders, err := ListPlacementrulesInAllNamespaces(testSettings, testCase.listOptions...)
-
-			switch {
-			case testCase.name == "nil client":
-				require.Error(t, err)
-				assert.True(t, commonerrors.IsAPIClientNil(err))
-				assert.Nil(t, builders)
-			case testCase.expectedError != nil:
-				assert.Equal(t, testCase.expectedError, err)
-			default:
-				assert.NoError(t, err)
-
-				if len(testCase.listOptions) == 0 {
-					assert.Len(t, builders, 1)
-				}
-			}
-		})
-	}
+	testhelper.NewListTestConfig(
+		ListPlacementrulesInAllNamespaces,
+		placementrulev1.AddToScheme,
+		placementRuleGVK,
+	).ExecuteTests(t)
 }

--- a/pkg/ocm/placementrulelist_test.go
+++ b/pkg/ocm/placementrulelist_test.go
@@ -5,38 +5,36 @@ import (
 	"testing"
 
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	commonerrors "github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/labels"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestListPlacementrulesInAllNamespaces(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
-		placementRules []*PlacementRuleBuilder
-		listOptions    []runtimeclient.ListOptions
-		expectedError  error
-		client         bool
+		name          string
+		listOptions   []runtimeclient.ListOptions
+		expectedError error
+		client        bool
 	}{
 		{
-			placementRules: []*PlacementRuleBuilder{
-				buildValidPlacementRuleTestBuilder(buildTestClientWithDummyPlacementRule()),
-			},
+			name:          "list all",
 			listOptions:   nil,
 			expectedError: nil,
 			client:        true,
 		},
 		{
-			placementRules: []*PlacementRuleBuilder{
-				buildValidPlacementRuleTestBuilder(buildTestClientWithDummyPlacementRule()),
-			},
+			name:          "list with options",
 			listOptions:   []runtimeclient.ListOptions{{LabelSelector: labels.NewSelector()}},
 			expectedError: nil,
 			client:        true,
 		},
 		{
-			placementRules: []*PlacementRuleBuilder{
-				buildValidPlacementRuleTestBuilder(buildTestClientWithDummyPlacementRule()),
-			},
+			name: "too many list options",
 			listOptions: []runtimeclient.ListOptions{
 				{LabelSelector: labels.NewSelector()},
 				{LabelSelector: labels.NewSelector()},
@@ -45,27 +43,39 @@ func TestListPlacementrulesInAllNamespaces(t *testing.T) {
 			client:        true,
 		},
 		{
-			placementRules: []*PlacementRuleBuilder{
-				buildValidPlacementRuleTestBuilder(buildTestClientWithDummyPlacementRule()),
-			},
+			name:          "nil client",
 			listOptions:   []runtimeclient.ListOptions{{LabelSelector: labels.NewSelector()}},
-			expectedError: fmt.Errorf("failed to list placementrules, 'apiClient' parameter is nil"),
+			expectedError: fmt.Errorf("apiClient for PlacementRule is nil"),
 			client:        false,
 		},
 	}
 
 	for _, testCase := range testCases {
-		var testSettings *clients.Settings
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 
-		if testCase.client {
-			testSettings = buildTestClientWithDummyPlacementRule()
-		}
+			var testSettings *clients.Settings
 
-		builders, err := ListPlacementrulesInAllNamespaces(testSettings, testCase.listOptions...)
-		assert.Equal(t, testCase.expectedError, err)
+			if testCase.client {
+				testSettings = buildTestClientWithDummyPlacementRule()
+			}
 
-		if testCase.expectedError == nil && len(testCase.listOptions) == 0 {
-			assert.Equal(t, len(testCase.placementRules), len(builders))
-		}
+			builders, err := ListPlacementrulesInAllNamespaces(testSettings, testCase.listOptions...)
+
+			switch {
+			case testCase.name == "nil client":
+				require.Error(t, err)
+				assert.True(t, commonerrors.IsAPIClientNil(err))
+				assert.Nil(t, builders)
+			case testCase.expectedError != nil:
+				assert.Equal(t, testCase.expectedError, err)
+			default:
+				assert.NoError(t, err)
+
+				if len(testCase.listOptions) == 0 {
+					assert.Len(t, builders, 1)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
Migrate placementrule builder in pkg/ocm to the common builder framework.

Closes #1455

Made with [Cursor](https://cursor.com)