### PR TITLE
ocm: migrate policy to common builder

### DIFF
--- a/pkg/ocm/policy.go
+++ b/pkg/ocm/policy.go
@@ -7,272 +7,68 @@ import (
 	"time"
 
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/logging"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/msg"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
-	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+var policyGVK = policiesv1.GroupVersion.WithKind("Policy")
 
 // PolicyBuilder provides struct for the policy object containing connection to
 // the cluster and the policy definitions.
 type PolicyBuilder struct {
-	// policy Definition, used to create the policy object.
-	Definition *policiesv1.Policy
-	// created policy object.
-	Object *policiesv1.Policy
-	// api client to interact with the cluster.
-	apiClient runtimeclient.Client
-	// used to store latest error message upon defining or mutating application definition.
-	errorMsg string
+	common.EmbeddableBuilder[policiesv1.Policy, *policiesv1.Policy]
+	common.EmbeddableCreator[policiesv1.Policy, PolicyBuilder, *policiesv1.Policy, *PolicyBuilder]
+	common.EmbeddableDeleteReturner[policiesv1.Policy, PolicyBuilder, *policiesv1.Policy, *PolicyBuilder]
+	common.EmbeddableForceUpdater[policiesv1.Policy, PolicyBuilder, *policiesv1.Policy, *PolicyBuilder]
+}
+
+// AttachMixins wires the embedded CRUD mixins to this builder instance.
+func (builder *PolicyBuilder) AttachMixins() {
+	builder.EmbeddableCreator.SetBase(builder)
+	builder.EmbeddableDeleteReturner.SetBase(builder)
+	builder.EmbeddableForceUpdater.SetBase(builder)
+}
+
+// GetGVK returns the Policy GVK for this builder.
+func (builder *PolicyBuilder) GetGVK() schema.GroupVersionKind {
+	return policyGVK
 }
 
 // NewPolicyBuilder creates a new instance of PolicyBuilder.
 func NewPolicyBuilder(
 	apiClient *clients.Settings, name, nsname string, template *policiesv1.PolicyTemplate) *PolicyBuilder {
-	klog.V(100).Infof(
-		"Initializing new policy structure with the following params: name: %s, nsname: %s",
-		name, nsname)
-
-	if apiClient == nil {
-		klog.V(100).Info("The apiClient of the Policy is nil")
-
-		return nil
-	}
-
-	err := apiClient.AttachScheme(policiesv1.AddToScheme)
-	if err != nil {
-		klog.V(100).Info("Failed to add Policy scheme to client schemes")
-
-		return nil
-	}
-
-	builder := &PolicyBuilder{
-		apiClient: apiClient.Client,
-		Definition: &policiesv1.Policy{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: nsname,
-			},
-			Spec: policiesv1.PolicySpec{
-				PolicyTemplates: []*policiesv1.PolicyTemplate{template},
-			},
-		},
-	}
-
-	if name == "" {
-		klog.V(100).Info("The name of the Policy is empty")
-
-		builder.errorMsg = "policy 'name' cannot be empty"
-
-		return builder
-	}
-
-	if nsname == "" {
-		klog.V(100).Info("The namespace of the Policy is empty")
-
-		builder.errorMsg = "policy 'nsname' cannot be empty"
-
+	builder := common.NewNamespacedBuilder[policiesv1.Policy, PolicyBuilder](
+		apiClient, policiesv1.AddToScheme, name, nsname)
+	if builder.GetError() != nil {
 		return builder
 	}
 
 	if template == nil {
 		klog.V(100).Info("The PolicyTemplate of the Policy is nil")
 
-		builder.errorMsg = "policy 'template' cannot be nil"
+		builder.SetError(fmt.Errorf("policy 'template' cannot be nil"))
 
 		return builder
 	}
+
+	builder.Definition.Spec.PolicyTemplates = []*policiesv1.PolicyTemplate{template}
 
 	return builder
 }
 
 // PullPolicy pulls existing policy into Builder struct.
 func PullPolicy(apiClient *clients.Settings, name, nsname string) (*PolicyBuilder, error) {
-	klog.V(100).Infof("Pulling existing policy name %s under namespace %s from cluster", name, nsname)
-
-	if apiClient == nil {
-		klog.V(100).Info("The apiClient is nil")
-
-		return nil, fmt.Errorf("policy 'apiClient' cannot be nil")
-	}
-
-	err := apiClient.AttachScheme(policiesv1.AddToScheme)
-	if err != nil {
-		klog.V(100).Info("Failed to add Policy scheme to client schemes")
-
-		return nil, err
-	}
-
-	builder := &PolicyBuilder{
-		apiClient: apiClient.Client,
-		Definition: &policiesv1.Policy{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: nsname,
-			},
-		},
-	}
-
-	if name == "" {
-		klog.V(100).Info("The name of the policy is empty")
-
-		return nil, fmt.Errorf("policy's 'name' cannot be empty")
-	}
-
-	if nsname == "" {
-		klog.V(100).Info("The namespace of the policy is empty")
-
-		return nil, fmt.Errorf("policy's 'namespace' cannot be empty")
-	}
-
-	if !builder.Exists() {
-		return nil, fmt.Errorf("policy object %s does not exist in namespace %s", name, nsname)
-	}
-
-	builder.Definition = builder.Object
-
-	return builder, nil
-}
-
-// Exists checks whether the given policy exists.
-func (builder *PolicyBuilder) Exists() bool {
-	if valid, _ := builder.validate(); !valid {
-		return false
-	}
-
-	klog.V(100).Infof("Checking if policy %s exists in namespace %s",
-		builder.Definition.Name, builder.Definition.Namespace)
-
-	var err error
-
-	builder.Object, err = builder.Get()
-
-	return err == nil || !k8serrors.IsNotFound(err)
-}
-
-// Get returns a policy object if found.
-func (builder *PolicyBuilder) Get() (*policiesv1.Policy, error) {
-	if valid, err := builder.validate(); !valid {
-		return nil, err
-	}
-
-	klog.V(100).Infof("Getting policy %s in namespace %s",
-		builder.Definition.Name, builder.Definition.Namespace)
-
-	policy := &policiesv1.Policy{}
-
-	err := builder.apiClient.Get(logging.DiscardContext(), runtimeclient.ObjectKey{
-		Name:      builder.Definition.Name,
-		Namespace: builder.Definition.Namespace,
-	}, policy)
-	if err != nil {
-		klog.V(100).Infof("Failed to get policy %s in namespace %s: %v",
-			builder.Definition.Name, builder.Definition.Namespace, err)
-
-		return nil, err
-	}
-
-	return policy, nil
-}
-
-// Create makes a policy in the cluster and stores the created object in struct.
-func (builder *PolicyBuilder) Create() (*PolicyBuilder, error) {
-	if valid, err := builder.validate(); !valid {
-		return builder, err
-	}
-
-	klog.V(100).Infof("Creating the policy %s in namespace %s",
-		builder.Definition.Name, builder.Definition.Namespace)
-
-	if builder.Exists() {
-		return builder, nil
-	}
-
-	err := builder.apiClient.Create(logging.DiscardContext(), builder.Definition)
-	if err != nil {
-		return builder, err
-	}
-
-	builder.Object = builder.Definition
-
-	return builder, nil
-}
-
-// Delete removes a policy from a cluster.
-func (builder *PolicyBuilder) Delete() (*PolicyBuilder, error) {
-	if valid, err := builder.validate(); !valid {
-		return builder, err
-	}
-
-	klog.V(100).Infof("Deleting the policy %s in namespace %s",
-		builder.Definition.Name, builder.Definition.Namespace)
-
-	if !builder.Exists() {
-		klog.V(100).Infof("policy %s namespace %s cannot be deleted because it does not exist",
-			builder.Definition.Name, builder.Definition.Namespace)
-
-		builder.Object = nil
-
-		return builder, nil
-	}
-
-	err := builder.apiClient.Delete(logging.DiscardContext(), builder.Definition)
-	if err != nil {
-		return builder, fmt.Errorf("can not delete policy: %w", err)
-	}
-
-	builder.Object = nil
-
-	return builder, nil
-}
-
-// Update renovates the existing policy object with the policy definition in builder.
-func (builder *PolicyBuilder) Update(force bool) (*PolicyBuilder, error) {
-	if valid, err := builder.validate(); !valid {
-		return builder, err
-	}
-
-	if !builder.Exists() {
-		klog.V(100).Infof("Policy %s does not exist in namespace %s", builder.Definition.Name, builder.Definition.Namespace)
-
-		return nil, fmt.Errorf("cannot update non-existent policy")
-	}
-
-	klog.V(100).Infof("Updating the policy object: %s in namespace: %s",
-		builder.Definition.Name, builder.Definition.Namespace)
-
-	builder.Definition.ResourceVersion = builder.Object.ResourceVersion
-
-	err := builder.apiClient.Update(logging.DiscardContext(), builder.Definition)
-	if err != nil {
-		if force {
-			klog.V(100).Infof("%v", msg.FailToUpdateNotification("policy", builder.Definition.Name, builder.Definition.Namespace))
-
-			builder, err := builder.Delete()
-			builder.Definition.ResourceVersion = ""
-
-			if err != nil {
-				klog.V(100).Infof("%v", msg.FailToUpdateError("policy", builder.Definition.Name, builder.Definition.Namespace))
-
-				return nil, err
-			}
-
-			return builder.Create()
-		}
-	}
-
-	builder.Object = builder.Definition
-
-	return builder, nil
+	return common.PullNamespacedBuilder[policiesv1.Policy, PolicyBuilder](
+		context.TODO(), apiClient, policiesv1.AddToScheme, name, nsname)
 }
 
 // WithRemediationAction sets a RemediationAction in the policy definition.
 func (builder *PolicyBuilder) WithRemediationAction(action policiesv1.RemediationAction) *PolicyBuilder {
-	if valid, _ := builder.validate(); !valid {
+	if err := common.Validate(builder); err != nil {
 		return builder
 	}
 
@@ -282,7 +78,7 @@ func (builder *PolicyBuilder) WithRemediationAction(action policiesv1.Remediatio
 	if action != policiesv1.Inform && action != policiesv1.Enforce && action != "inform" && action != "enforce" {
 		klog.V(100).Info("The RemediationAction to be set in the Policy spec is neither 'Inform' nor 'Enforce'")
 
-		builder.errorMsg = "remediation action in policy spec must be either 'Inform' or 'Enforce'"
+		builder.SetError(fmt.Errorf("remediation action in policy spec must be either 'Inform' or 'Enforce'"))
 
 		return builder
 	}
@@ -294,7 +90,7 @@ func (builder *PolicyBuilder) WithRemediationAction(action policiesv1.Remediatio
 
 // WithAdditionalPolicyTemplate appends a PolicyTemplate to the PolicyTemplates in the policy definition.
 func (builder *PolicyBuilder) WithAdditionalPolicyTemplate(template *policiesv1.PolicyTemplate) *PolicyBuilder {
-	if valid, _ := builder.validate(); !valid {
+	if err := common.Validate(builder); err != nil {
 		return builder
 	}
 
@@ -303,7 +99,7 @@ func (builder *PolicyBuilder) WithAdditionalPolicyTemplate(template *policiesv1.
 	if template == nil {
 		klog.V(100).Info("The PolicyTemplate to be added to the Policy's PolicyTemplates is nil")
 
-		builder.errorMsg = "policy template in policy policytemplates cannot be nil"
+		builder.SetError(fmt.Errorf("policy template in policy policytemplates cannot be nil"))
 
 		return builder
 	}
@@ -315,7 +111,7 @@ func (builder *PolicyBuilder) WithAdditionalPolicyTemplate(template *policiesv1.
 
 // WaitUntilDeleted waits for the duration of the defined timeout or until the policy is deleted.
 func (builder *PolicyBuilder) WaitUntilDeleted(timeout time.Duration) error {
-	if valid, err := builder.validate(); !valid {
+	if err := common.Validate(builder); err != nil {
 		return err
 	}
 
@@ -347,7 +143,7 @@ func (builder *PolicyBuilder) WaitUntilDeleted(timeout time.Duration) error {
 // WaitUntilComplianceState waits for the duration of the defined timeout or until the policy is in the provided
 // compliance state.
 func (builder *PolicyBuilder) WaitUntilComplianceState(state policiesv1.ComplianceState, timeout time.Duration) error {
-	if valid, err := builder.validate(); !valid {
+	if err := common.Validate(builder); err != nil {
 		return err
 	}
 
@@ -373,7 +169,7 @@ func (builder *PolicyBuilder) WaitUntilComplianceState(state policiesv1.Complian
 // expectedMessage.
 func (builder *PolicyBuilder) WaitForStatusMessageToContain(
 	expectedMessage string, timeout time.Duration) (*PolicyBuilder, error) {
-	if valid, err := builder.validate(); !valid {
+	if err := common.Validate(builder); err != nil {
 		return nil, err
 	}
 
@@ -417,36 +213,4 @@ func (builder *PolicyBuilder) WaitForStatusMessageToContain(
 	}
 
 	return builder, nil
-}
-
-// validate will check that the builder and builder definition are properly initialized before
-// accessing any member fields.
-func (builder *PolicyBuilder) validate() (bool, error) {
-	resourceCRD := "policy"
-
-	if builder == nil {
-		klog.V(100).Infof("The %s builder is uninitialized", resourceCRD)
-
-		return false, fmt.Errorf("error: received nil %s builder", resourceCRD)
-	}
-
-	if builder.Definition == nil {
-		klog.V(100).Infof("The %s is undefined", resourceCRD)
-
-		return false, fmt.Errorf("%s", msg.UndefinedCrdObjectErrString(resourceCRD))
-	}
-
-	if builder.apiClient == nil {
-		klog.V(100).Infof("The %s builder apiclient is nil", resourceCRD)
-
-		return false, fmt.Errorf("%s builder cannot have nil apiClient", resourceCRD)
-	}
-
-	if builder.errorMsg != "" {
-		klog.V(100).Infof("The %s builder has error message: %s", resourceCRD, builder.errorMsg)
-
-		return false, fmt.Errorf("%s", builder.errorMsg)
-	}
-
-	return true, nil
 }

--- a/pkg/ocm/policy_test.go
+++ b/pkg/ocm/policy_test.go
@@ -7,8 +7,10 @@ import (
 	"time"
 
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	commonerrors "github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common/errors"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common/testhelper"
 	"github.com/stretchr/testify/assert"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
@@ -21,452 +23,305 @@ const (
 	defaultPolicyExpectedMessage = "wrong type for value"
 )
 
-var policyTestSchemes = []clients.SchemeAttacher{
-	policiesv1.AddToScheme,
-}
-
 func TestNewPolicyBuilder(t *testing.T) {
+	t.Parallel()
+
+	t.Run("common namespaced builder behavior", func(t *testing.T) {
+		t.Parallel()
+
+		testhelper.NewNamespacedBuilderTestConfig(
+			func(apiClient *clients.Settings, name, nsname string) *PolicyBuilder {
+				return NewPolicyBuilder(apiClient, name, nsname, &policiesv1.PolicyTemplate{})
+			},
+			policiesv1.AddToScheme,
+			policyGVK,
+		).ExecuteTests(t)
+	})
+
 	testCases := []struct {
-		policyName        string
-		policyNamespace   string
-		policyTemplate    *policiesv1.PolicyTemplate
-		client            bool
-		expectedErrorText string
+		name          string
+		template      *policiesv1.PolicyTemplate
+		expectedError error
 	}{
 		{
-			policyName:        defaultPolicyName,
-			policyNamespace:   defaultPolicyNsName,
-			policyTemplate:    &policiesv1.PolicyTemplate{},
-			client:            true,
-			expectedErrorText: "",
+			name:          "valid template",
+			template:      &policiesv1.PolicyTemplate{},
+			expectedError: nil,
 		},
 		{
-			policyName:        "",
-			policyNamespace:   defaultPolicyNsName,
-			policyTemplate:    &policiesv1.PolicyTemplate{},
-			client:            true,
-			expectedErrorText: "policy 'name' cannot be empty",
-		},
-		{
-			policyName:        defaultPolicyName,
-			policyNamespace:   "",
-			policyTemplate:    &policiesv1.PolicyTemplate{},
-			client:            true,
-			expectedErrorText: "policy 'nsname' cannot be empty",
-		},
-		{
-			policyName:        defaultPolicyName,
-			policyNamespace:   defaultPolicyNsName,
-			policyTemplate:    nil,
-			client:            true,
-			expectedErrorText: "policy 'template' cannot be nil",
-		},
-		{
-			policyName:        defaultPolicyName,
-			policyNamespace:   defaultPolicyNsName,
-			policyTemplate:    &policiesv1.PolicyTemplate{},
-			client:            false,
-			expectedErrorText: "",
+			name:          "nil template",
+			template:      nil,
+			expectedError: fmt.Errorf("policy 'template' cannot be nil"),
 		},
 	}
 
 	for _, testCase := range testCases {
-		var client *clients.Settings
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 
-		if testCase.client {
-			client = buildTestClientWithPolicyScheme()
-		}
+			testBuilder := NewPolicyBuilder(
+				clients.GetTestClients(clients.TestClientParams{
+					SchemeAttachers: []clients.SchemeAttacher{policiesv1.AddToScheme},
+				}),
+				defaultPolicyName,
+				defaultPolicyNsName,
+				testCase.template,
+			)
 
-		policyBuilder := NewPolicyBuilder(client, testCase.policyName, testCase.policyNamespace, testCase.policyTemplate)
+			assert.Equal(t, testCase.expectedError, testBuilder.GetError())
 
-		if testCase.client {
-			assert.Equal(t, testCase.expectedErrorText, policyBuilder.errorMsg)
-
-			if testCase.expectedErrorText == "" {
-				assert.Equal(t, testCase.policyName, policyBuilder.Definition.Name)
-				assert.Equal(t, testCase.policyNamespace, policyBuilder.Definition.Namespace)
-				assert.Equal(t, testCase.policyTemplate, policyBuilder.Definition.Spec.PolicyTemplates[0])
+			if testCase.expectedError == nil {
+				assert.Equal(t, testCase.template, testBuilder.Definition.Spec.PolicyTemplates[0])
 			}
-		} else {
-			assert.Nil(t, policyBuilder)
-		}
+		})
 	}
 }
 
 func TestPullPolicy(t *testing.T) {
-	testCases := []struct {
-		policyName          string
-		policyNamespace     string
-		addToRuntimeObjects bool
-		client              bool
-		expectedError       error
-	}{
-		{
-			policyName:          defaultPolicyName,
-			policyNamespace:     defaultPolicyNsName,
-			addToRuntimeObjects: true,
-			client:              true,
-			expectedError:       nil,
-		},
-		{
-			policyName:          defaultPolicyName,
-			policyNamespace:     defaultPolicyNsName,
-			addToRuntimeObjects: false,
-			client:              true,
-			expectedError: fmt.Errorf(
-				"policy object %s does not exist in namespace %s", defaultPolicyName, defaultPolicyNsName),
-		},
-		{
-			policyName:          "",
-			policyNamespace:     defaultPolicyNsName,
-			addToRuntimeObjects: false,
-			client:              true,
-			expectedError:       fmt.Errorf("policy's 'name' cannot be empty"),
-		},
-		{
-			policyName:          defaultPolicyName,
-			policyNamespace:     "",
-			addToRuntimeObjects: false,
-			client:              true,
-			expectedError:       fmt.Errorf("policy's 'namespace' cannot be empty"),
-		},
-		{
-			policyName:          defaultPolicyName,
-			policyNamespace:     defaultPolicyNsName,
-			addToRuntimeObjects: false,
-			client:              false,
-			expectedError:       fmt.Errorf("policy 'apiClient' cannot be nil"),
-		},
-	}
+	t.Parallel()
 
-	for _, testCase := range testCases {
-		var (
-			runtimeObjects []runtime.Object
-			testSettings   *clients.Settings
-		)
-
-		testPolicy := buildDummyPolicy(testCase.policyName, testCase.policyNamespace)
-
-		if testCase.addToRuntimeObjects {
-			runtimeObjects = append(runtimeObjects, testPolicy)
-		}
-
-		if testCase.client {
-			testSettings = clients.GetTestClients(clients.TestClientParams{
-				K8sMockObjects:  runtimeObjects,
-				SchemeAttachers: policyTestSchemes,
-			})
-		}
-
-		policyBuilder, err := PullPolicy(testSettings, testPolicy.Name, testPolicy.Namespace)
-		assert.Equal(t, testCase.expectedError, err)
-
-		if testCase.expectedError == nil {
-			assert.Equal(t, testPolicy.Name, policyBuilder.Definition.Name)
-			assert.Equal(t, testPolicy.Namespace, policyBuilder.Definition.Namespace)
-		}
-	}
+	testhelper.NewNamespacedPullTestConfig(
+		PullPolicy, policiesv1.AddToScheme, policyGVK).ExecuteTests(t)
 }
 
-func TestPolicyExists(t *testing.T) {
-	testCases := []struct {
-		testBuilder *PolicyBuilder
-		exists      bool
-	}{
-		{
-			testBuilder: buildValidPolicyTestBuilder(buildTestClientWithDummyPolicy()),
-			exists:      true,
-		},
-		{
-			testBuilder: buildInvalidPolicyTestBuilder(buildTestClientWithDummyPolicy()),
-			exists:      false,
-		},
-	}
+func TestPolicyBuilderMethods(t *testing.T) {
+	t.Parallel()
 
-	for _, testCase := range testCases {
-		exists := testCase.testBuilder.Exists()
-		assert.Equal(t, testCase.exists, exists)
-	}
-}
+	commonTestConfig := testhelper.NewCommonTestConfig[policiesv1.Policy, PolicyBuilder](
+		policiesv1.AddToScheme,
+		policyGVK,
+		testhelper.ResourceScopeNamespaced,
+	)
 
-func TestPolicyGet(t *testing.T) {
-	testCases := []struct {
-		testBuilder    *PolicyBuilder
-		expectedPolicy *policiesv1.Policy
-	}{
-		{
-			testBuilder:    buildValidPolicyTestBuilder(buildTestClientWithDummyPolicy()),
-			expectedPolicy: buildDummyPolicy(defaultPolicyName, defaultPolicyNsName),
-		},
-		{
-			testBuilder:    buildValidPolicyTestBuilder(buildTestClientWithPolicyScheme()),
-			expectedPolicy: nil,
-		},
-	}
-
-	for _, testCase := range testCases {
-		policy, err := testCase.testBuilder.Get()
-
-		if testCase.expectedPolicy == nil {
-			assert.Nil(t, policy)
-			assert.True(t, k8serrors.IsNotFound(err))
-		} else {
-			assert.Nil(t, err)
-			assert.Equal(t, testCase.expectedPolicy.Name, policy.Name)
-			assert.Equal(t, testCase.expectedPolicy.Namespace, policy.Namespace)
-		}
-	}
-}
-
-func TestPolicyCreate(t *testing.T) {
-	testCases := []struct {
-		testBuilder   *PolicyBuilder
-		expectedError error
-	}{
-		{
-			testBuilder:   buildValidPolicyTestBuilder(buildTestClientWithPolicyScheme()),
-			expectedError: nil,
-		},
-		{
-			testBuilder:   buildInvalidPolicyTestBuilder(buildTestClientWithPolicyScheme()),
-			expectedError: fmt.Errorf("policy 'nsname' cannot be empty"),
-		},
-	}
-
-	for _, testCase := range testCases {
-		policyBuilder, err := testCase.testBuilder.Create()
-		assert.Equal(t, testCase.expectedError, err)
-
-		if testCase.expectedError == nil {
-			assert.Equal(t, policyBuilder.Definition, policyBuilder.Object)
-		}
-	}
-}
-
-func TestPolicyDelete(t *testing.T) {
-	testCases := []struct {
-		testBuilder   *PolicyBuilder
-		expectedError error
-	}{
-		{
-			testBuilder:   buildValidPolicyTestBuilder(buildTestClientWithDummyPolicy()),
-			expectedError: nil,
-		},
-		{
-			testBuilder:   buildValidPolicyTestBuilder(buildTestClientWithPolicyScheme()),
-			expectedError: nil,
-		},
-		{
-			testBuilder:   buildInvalidPolicyTestBuilder(buildTestClientWithDummyPolicy()),
-			expectedError: fmt.Errorf("policy 'nsname' cannot be empty"),
-		},
-	}
-
-	for _, testCase := range testCases {
-		_, err := testCase.testBuilder.Delete()
-		assert.Equal(t, testCase.expectedError, err)
-
-		if testCase.expectedError == nil {
-			assert.Nil(t, testCase.testBuilder.Object)
-		}
-	}
-}
-
-func TestPolicyUpdate(t *testing.T) {
-	testCases := []struct {
-		alreadyExists bool
-		force         bool
-	}{
-		{
-			alreadyExists: false,
-			force:         false,
-		},
-		{
-			alreadyExists: true,
-			force:         false,
-		},
-		{
-			alreadyExists: false,
-			force:         true,
-		},
-		{
-			alreadyExists: true,
-			force:         true,
-		},
-	}
-
-	for _, testCase := range testCases {
-		testBuilder := buildValidPolicyTestBuilder(buildTestClientWithPolicyScheme())
-
-		// Create the builder rather than just adding it to the client so that the proper metadata is added and
-		// the update will not fail.
-		if testCase.alreadyExists {
-			var err error
-
-			testBuilder = buildValidPolicyTestBuilder(buildTestClientWithPolicyScheme())
-			testBuilder, err = testBuilder.Create()
-			assert.Nil(t, err)
-		}
-
-		assert.NotNil(t, testBuilder.Definition)
-		assert.False(t, testBuilder.Definition.Spec.Disabled)
-
-		testBuilder.Definition.Spec.Disabled = true
-
-		policyBuilder, err := testBuilder.Update(testCase.force)
-		assert.NotNil(t, testBuilder.Definition)
-
-		if testCase.alreadyExists {
-			assert.Nil(t, err)
-			assert.Equal(t, testBuilder.Definition.Name, policyBuilder.Definition.Name)
-			assert.Equal(t, testBuilder.Definition.Spec.Disabled, policyBuilder.Definition.Spec.Disabled)
-		} else {
-			assert.NotNil(t, err)
-		}
-	}
+	testhelper.NewTestSuite().
+		With(testhelper.NewGetTestConfig(commonTestConfig)).
+		With(testhelper.NewExistsTestConfig(commonTestConfig)).
+		With(testhelper.NewCreateTestConfig(commonTestConfig)).
+		With(testhelper.NewDeleteReturnerTestConfig(commonTestConfig)).
+		With(testhelper.NewForceUpdateTestConfig(commonTestConfig)).
+		Run(t)
 }
 
 func TestWithRemediationAction(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
-		action            policiesv1.RemediationAction
-		expectedErrorText string
+		name          string
+		action        policiesv1.RemediationAction
+		valid         bool
+		expectedError error
 	}{
 		{
-			action:            "Inform",
-			expectedErrorText: "",
+			name:   "inform action",
+			action: policiesv1.Inform,
+			valid:  true,
 		},
 		{
-			action:            "inform",
-			expectedErrorText: "",
+			name:          "invalid action",
+			action:        "",
+			valid:         true,
+			expectedError: fmt.Errorf("remediation action in policy spec must be either 'Inform' or 'Enforce'"),
 		},
 		{
-			action:            "Enforce",
-			expectedErrorText: "",
-		},
-		{
-			action:            "enforce",
-			expectedErrorText: "",
-		},
-		{
-			action:            "",
-			expectedErrorText: "remediation action in policy spec must be either 'Inform' or 'Enforce'",
+			name:   "invalid builder",
+			action: policiesv1.Inform,
+			valid:  false,
 		},
 	}
 
 	for _, testCase := range testCases {
-		testSettings := buildTestClientWithPolicyScheme()
-		policyBuilder := buildValidPolicyTestBuilder(testSettings).WithRemediationAction(testCase.action)
-		assert.Equal(t, testCase.expectedErrorText, policyBuilder.errorMsg)
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 
-		if testCase.expectedErrorText == "" {
-			assert.Equal(t, testCase.action, policyBuilder.Definition.Spec.RemediationAction)
-		}
+			var policyBuilder *PolicyBuilder
+			if testCase.valid {
+				policyBuilder = buildValidPolicyTestBuilder(buildTestClientWithPolicyScheme())
+			} else {
+				policyBuilder = buildInvalidPolicyTestBuilder(buildTestClientWithPolicyScheme())
+			}
+
+			policyBuilder = policyBuilder.WithRemediationAction(testCase.action)
+
+			switch testCase.name {
+			case "invalid builder":
+				require.Error(t, policyBuilder.GetError())
+				assert.True(t, commonerrors.IsBuilderNamespaceEmpty(policyBuilder.GetError()))
+			default:
+				assert.Equal(t, testCase.expectedError, policyBuilder.GetError())
+
+				if testCase.expectedError == nil {
+					assert.Equal(t, testCase.action, policyBuilder.Definition.Spec.RemediationAction)
+				}
+			}
+		})
 	}
 }
 
 func TestWithAdditionalPolicyTemplate(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
-		policyTemplate    *policiesv1.PolicyTemplate
-		expectedErrorText string
+		name           string
+		policyTemplate *policiesv1.PolicyTemplate
+		valid          bool
+		expectedError  error
 	}{
 		{
-			policyTemplate:    &policiesv1.PolicyTemplate{},
-			expectedErrorText: "",
+			name:           "valid template",
+			policyTemplate: &policiesv1.PolicyTemplate{},
+			valid:          true,
 		},
 		{
-			policyTemplate:    nil,
-			expectedErrorText: "policy template in policy policytemplates cannot be nil",
+			name:           "nil template",
+			policyTemplate: nil,
+			valid:          true,
+			expectedError:  fmt.Errorf("policy template in policy policytemplates cannot be nil"),
+		},
+		{
+			name:           "invalid builder",
+			policyTemplate: &policiesv1.PolicyTemplate{},
+			valid:          false,
 		},
 	}
 
 	for _, testCase := range testCases {
-		testSettings := buildTestClientWithPolicyScheme()
-		policyBuilder := buildValidPolicyTestBuilder(testSettings).WithAdditionalPolicyTemplate(testCase.policyTemplate)
-		assert.Equal(t, testCase.expectedErrorText, policyBuilder.errorMsg)
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 
-		if testCase.expectedErrorText == "" {
-			assert.Equal(
-				t, []*policiesv1.PolicyTemplate{{}, testCase.policyTemplate}, policyBuilder.Definition.Spec.PolicyTemplates)
-		}
+			var policyBuilder *PolicyBuilder
+			if testCase.valid {
+				policyBuilder = buildValidPolicyTestBuilder(buildTestClientWithPolicyScheme())
+			} else {
+				policyBuilder = buildInvalidPolicyTestBuilder(buildTestClientWithPolicyScheme())
+			}
+
+			policyBuilder = policyBuilder.WithAdditionalPolicyTemplate(testCase.policyTemplate)
+
+			switch testCase.name {
+			case "invalid builder":
+				require.Error(t, policyBuilder.GetError())
+				assert.True(t, commonerrors.IsBuilderNamespaceEmpty(policyBuilder.GetError()))
+			default:
+				assert.Equal(t, testCase.expectedError, policyBuilder.GetError())
+
+				if testCase.expectedError == nil {
+					assert.Equal(
+						t,
+						[]*policiesv1.PolicyTemplate{{}, testCase.policyTemplate},
+						policyBuilder.Definition.Spec.PolicyTemplates,
+					)
+				}
+			}
+		})
 	}
 }
 
 func TestPolicyWaitUntilDeleted(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
-		testBuilder   *PolicyBuilder
+		name          string
+		valid         bool
+		policyExists  bool
 		expectedError error
 	}{
 		{
-			testBuilder:   buildValidPolicyTestBuilder(buildTestClientWithPolicyScheme()),
-			expectedError: nil,
+			name:         "deleted policy",
+			valid:        true,
+			policyExists: false,
 		},
 		{
-			testBuilder:   buildValidPolicyTestBuilder(buildTestClientWithDummyPolicy()),
+			name:          "timeout waiting for deletion",
+			valid:         true,
+			policyExists:  true,
 			expectedError: context.DeadlineExceeded,
 		},
 		{
-			testBuilder:   buildInvalidPolicyTestBuilder(buildTestClientWithDummyPolicy()),
-			expectedError: fmt.Errorf("policy 'nsname' cannot be empty"),
+			name:         "invalid builder",
+			valid:        false,
+			policyExists: true,
 		},
 	}
 
 	for _, testCase := range testCases {
-		err := testCase.testBuilder.WaitUntilDeleted(time.Second)
-		assert.Equal(t, testCase.expectedError, err)
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 
-		if testCase.expectedError == nil {
-			assert.Nil(t, testCase.testBuilder.Object)
-		}
+			var testSettings *clients.Settings
+			if testCase.policyExists {
+				testSettings = buildTestClientWithDummyPolicy()
+			} else {
+				testSettings = buildTestClientWithPolicyScheme()
+			}
+
+			var policyBuilder *PolicyBuilder
+			if testCase.valid {
+				policyBuilder = buildValidPolicyTestBuilder(testSettings)
+			} else {
+				policyBuilder = buildInvalidPolicyTestBuilder(testSettings)
+			}
+
+			err := policyBuilder.WaitUntilDeleted(time.Second)
+
+			switch testCase.name {
+			case "invalid builder":
+				require.Error(t, err)
+				assert.True(t, commonerrors.IsBuilderNamespaceEmpty(err))
+			case "timeout waiting for deletion":
+				assert.Equal(t, context.DeadlineExceeded, err)
+			default:
+				assert.NoError(t, err)
+			}
+		})
 	}
 }
 
 func TestPolicyWaitUntilComplianceState(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		state policiesv1.ComplianceState
 	}{
-		{
-			state: policiesv1.Compliant,
-		},
-		{
-			state: policiesv1.NonCompliant,
-		},
-		{
-			state: policiesv1.Pending,
-		},
+		{state: policiesv1.Compliant},
+		{state: policiesv1.NonCompliant},
+		{state: policiesv1.Pending},
 	}
 
 	for _, testCase := range testCases {
-		dummyPolicy := buildDummyPolicy(defaultPolicyName, defaultPolicyNsName)
-		dummyPolicy.Status.ComplianceState = testCase.state
+		t.Run(string(testCase.state), func(t *testing.T) {
+			t.Parallel()
 
-		testSettings := clients.GetTestClients(clients.TestClientParams{
-			K8sMockObjects:  []runtime.Object{dummyPolicy},
-			SchemeAttachers: policyTestSchemes,
+			dummyPolicy := buildDummyPolicy()
+			dummyPolicy.Status.ComplianceState = testCase.state
+
+			testSettings := clients.GetTestClients(clients.TestClientParams{
+				K8sMockObjects: []runtime.Object{dummyPolicy},
+				SchemeAttachers: []clients.SchemeAttacher{
+					policiesv1.AddToScheme,
+				},
+			})
+
+			policyBuilder := buildValidPolicyTestBuilder(testSettings)
+			err := policyBuilder.WaitUntilComplianceState(testCase.state, 5*time.Second)
+
+			assert.NoError(t, err)
 		})
-
-		policyBuilder := buildValidPolicyTestBuilder(testSettings)
-		err := policyBuilder.WaitUntilComplianceState(testCase.state, 5*time.Second)
-
-		assert.Nil(t, err)
 	}
 }
 
 func TestPolicyWaitForStatusMessageToContain(t *testing.T) {
-	testCases := []struct {
-		expectedMessage string
-		valid           bool
-		exists          bool
-		hasMessage      bool
-		expectedError   error
-	}{
+	t.Parallel()
+
+	testCases := []policyWaitForStatusMessageTestCase{
 		{
+			name:            "message found",
 			expectedMessage: defaultPolicyExpectedMessage,
 			valid:           true,
 			exists:          true,
 			hasMessage:      true,
-			expectedError:   nil,
 		},
 		{
+			name:            "empty expected message",
 			expectedMessage: "",
 			valid:           true,
 			exists:          true,
@@ -474,13 +329,14 @@ func TestPolicyWaitForStatusMessageToContain(t *testing.T) {
 			expectedError:   fmt.Errorf("policy expectedMessage is empty"),
 		},
 		{
+			name:            "invalid builder",
 			expectedMessage: defaultPolicyExpectedMessage,
 			valid:           false,
 			exists:          true,
 			hasMessage:      true,
-			expectedError:   fmt.Errorf("policy 'nsname' cannot be empty"),
 		},
 		{
+			name:            "policy not exists",
 			expectedMessage: defaultPolicyExpectedMessage,
 			valid:           true,
 			exists:          false,
@@ -489,6 +345,7 @@ func TestPolicyWaitForStatusMessageToContain(t *testing.T) {
 				"policy object %s does not exist in namespace %s", defaultPolicyName, defaultPolicyNsName),
 		},
 		{
+			name:            "timeout waiting for message",
 			expectedMessage: defaultPolicyExpectedMessage,
 			valid:           true,
 			exists:          true,
@@ -498,121 +355,72 @@ func TestPolicyWaitForStatusMessageToContain(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		var (
-			runtimeObjects []runtime.Object
-			policyBuilder  *PolicyBuilder
-		)
-
-		if testCase.exists {
-			policy := buildDummyPolicy(defaultPolicyName, defaultPolicyNsName)
-
-			if testCase.hasMessage {
-				policy.Status.Details = []*policiesv1.DetailsPerTemplate{
-					{History: []policiesv1.ComplianceHistory{{Message: defaultPolicyMessage}}},
-				}
-			}
-
-			runtimeObjects = append(runtimeObjects, policy)
-		}
-
-		testSettings := clients.GetTestClients(clients.TestClientParams{
-			K8sMockObjects:  runtimeObjects,
-			SchemeAttachers: policyTestSchemes,
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			runPolicyWaitForStatusMessageTestCase(t, testCase)
 		})
+	}
+}
 
-		if testCase.valid {
-			policyBuilder = buildValidPolicyTestBuilder(testSettings)
-		} else {
-			policyBuilder = buildInvalidPolicyTestBuilder(testSettings)
+type policyWaitForStatusMessageTestCase struct {
+	name            string
+	expectedMessage string
+	valid           bool
+	exists          bool
+	hasMessage      bool
+	expectedError   error
+}
+
+func runPolicyWaitForStatusMessageTestCase(t *testing.T, testCase policyWaitForStatusMessageTestCase) {
+	t.Helper()
+
+	var runtimeObjects []runtime.Object
+
+	if testCase.exists {
+		policy := buildDummyPolicy()
+
+		if testCase.hasMessage {
+			policy.Status.Details = []*policiesv1.DetailsPerTemplate{
+				{History: []policiesv1.ComplianceHistory{{Message: defaultPolicyMessage}}},
+			}
 		}
 
-		_, err := policyBuilder.WaitForStatusMessageToContain(testCase.expectedMessage, time.Second)
+		runtimeObjects = append(runtimeObjects, policy)
+	}
+
+	testSettings := clients.GetTestClients(clients.TestClientParams{
+		K8sMockObjects: runtimeObjects,
+		SchemeAttachers: []clients.SchemeAttacher{
+			policiesv1.AddToScheme,
+		},
+	})
+
+	var policyBuilder *PolicyBuilder
+	if testCase.valid {
+		policyBuilder = buildValidPolicyTestBuilder(testSettings)
+	} else {
+		policyBuilder = buildInvalidPolicyTestBuilder(testSettings)
+	}
+
+	_, err := policyBuilder.WaitForStatusMessageToContain(testCase.expectedMessage, time.Second)
+
+	switch testCase.name {
+	case "invalid builder":
+		require.Error(t, err)
+		assert.True(t, commonerrors.IsBuilderNamespaceEmpty(err))
+	case "empty expected message", "policy not exists", "timeout waiting for message":
 		assert.Equal(t, testCase.expectedError, err)
+	default:
+		assert.NoError(t, err)
 	}
 }
 
-func TestPolicyValidate(t *testing.T) {
-	testCases := []struct {
-		builderNil      bool
-		definitionNil   bool
-		apiClientNil    bool
-		builderErrorMsg string
-		expectedError   error
-	}{
-		{
-			builderNil:      false,
-			definitionNil:   false,
-			apiClientNil:    false,
-			builderErrorMsg: "",
-			expectedError:   nil,
-		},
-		{
-			builderNil:      true,
-			definitionNil:   false,
-			apiClientNil:    false,
-			builderErrorMsg: "",
-			expectedError:   fmt.Errorf("error: received nil policy builder"),
-		},
-		{
-			builderNil:      false,
-			definitionNil:   true,
-			apiClientNil:    false,
-			builderErrorMsg: "",
-			expectedError:   fmt.Errorf("can not redefine the undefined policy"),
-		},
-		{
-			builderNil:      false,
-			definitionNil:   false,
-			apiClientNil:    true,
-			builderErrorMsg: "",
-			expectedError:   fmt.Errorf("policy builder cannot have nil apiClient"),
-		},
-		{
-			builderNil:      false,
-			definitionNil:   false,
-			apiClientNil:    false,
-			builderErrorMsg: "test error",
-			expectedError:   fmt.Errorf("test error"),
-		},
-	}
-
-	for _, testCase := range testCases {
-		policyBuilder := buildValidPolicyTestBuilder(buildTestClientWithPolicyScheme())
-
-		if testCase.builderNil {
-			policyBuilder = nil
-		}
-
-		if testCase.definitionNil {
-			policyBuilder.Definition = nil
-		}
-
-		if testCase.apiClientNil {
-			policyBuilder.apiClient = nil
-		}
-
-		if testCase.builderErrorMsg != "" {
-			policyBuilder.errorMsg = testCase.builderErrorMsg
-		}
-
-		valid, err := policyBuilder.validate()
-
-		if testCase.expectedError != nil {
-			assert.False(t, valid)
-			assert.Equal(t, testCase.expectedError, err)
-		} else {
-			assert.True(t, valid)
-			assert.Nil(t, err)
-		}
-	}
-}
-
-// buildDummyPolicy returns a Policy with the provided name and namespace.
-func buildDummyPolicy(name, nsname string) *policiesv1.Policy {
+// buildDummyPolicy returns a Policy with the default test name and namespace.
+func buildDummyPolicy() *policiesv1.Policy {
 	return &policiesv1.Policy{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: nsname,
+			Name:      defaultPolicyName,
+			Namespace: defaultPolicyNsName,
 		},
 		Spec: policiesv1.PolicySpec{
 			PolicyTemplates: []*policiesv1.PolicyTemplate{{}},
@@ -624,16 +432,20 @@ func buildDummyPolicy(name, nsname string) *policiesv1.Policy {
 func buildTestClientWithDummyPolicy() *clients.Settings {
 	return clients.GetTestClients(clients.TestClientParams{
 		K8sMockObjects: []runtime.Object{
-			buildDummyPolicy(defaultPolicyName, defaultPolicyNsName),
+			buildDummyPolicy(),
 		},
-		SchemeAttachers: policyTestSchemes,
+		SchemeAttachers: []clients.SchemeAttacher{
+			policiesv1.AddToScheme,
+		},
 	})
 }
 
 // buildTestClientWithPolicyScheme returns a client with no objects but the Policy scheme attached.
 func buildTestClientWithPolicyScheme() *clients.Settings {
 	return clients.GetTestClients(clients.TestClientParams{
-		SchemeAttachers: policyTestSchemes,
+		SchemeAttachers: []clients.SchemeAttacher{
+			policiesv1.AddToScheme,
+		},
 	})
 }
 

--- a/pkg/ocm/policylist.go
+++ b/pkg/ocm/policylist.go
@@ -6,7 +6,9 @@ import (
 	"time"
 
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/logging"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common"
+	commonerrors "github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common/errors"
+	commonkey "github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common/key"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
@@ -17,58 +19,12 @@ import (
 func ListPoliciesInAllNamespaces(apiClient *clients.Settings,
 	options ...runtimeclient.ListOptions) (
 	[]*PolicyBuilder, error) {
-	if apiClient == nil {
-		klog.V(100).Info("Policies 'apiClient' parameter cannot be nil")
-
-		return nil, fmt.Errorf("failed to list policies, 'apiClient' parameter is nil")
-	}
-
-	err := apiClient.AttachScheme(policiesv1.AddToScheme)
-	if err != nil {
-		klog.V(100).Info("Failed to add Policy scheme to client schemes")
-
-		return nil, err
-	}
-
-	logMessage := string("Listing all policies in all namespaces")
-	passedOptions := runtimeclient.ListOptions{}
-
 	if len(options) > 1 {
-		klog.V(100).Info("'options' parameter must be empty or single-valued")
-
 		return nil, fmt.Errorf("error: more than one ListOptions was passed")
 	}
 
-	if len(options) == 1 {
-		passedOptions = options[0]
-		logMessage += fmt.Sprintf(" with the options %v", passedOptions)
-	}
-
-	klog.V(100).Infof("%v", logMessage)
-
-	policyList := new(policiesv1.PolicyList)
-
-	err = apiClient.List(logging.DiscardContext(), policyList, &passedOptions)
-	if err != nil {
-		klog.V(100).Infof("Failed to list all policies in all namespaces due to %s", err.Error())
-
-		return nil, err
-	}
-
-	var policyObjects []*PolicyBuilder
-
-	for _, policy := range policyList.Items {
-		copiedPolicy := policy
-		policyBuilder := &PolicyBuilder{
-			apiClient:  apiClient.Client,
-			Object:     &copiedPolicy,
-			Definition: &copiedPolicy,
-		}
-
-		policyObjects = append(policyObjects, policyBuilder)
-	}
-
-	return policyObjects, nil
+	return common.List[policiesv1.Policy, policiesv1.PolicyList, PolicyBuilder](
+		context.TODO(), apiClient, policiesv1.AddToScheme, common.ConvertListOptionsToOptions(options)...)
 }
 
 // WaitForAllPoliciesComplianceState wait up to timeout until all policies have complianceState. Policies are listed
@@ -78,38 +34,26 @@ func WaitForAllPoliciesComplianceState(
 	complianceState policiesv1.ComplianceState,
 	timeout time.Duration,
 	options ...runtimeclient.ListOptions) error {
-	if apiClient == nil {
-		klog.V(100).Info("Policies 'apiClient' parameter cannot be nil")
-
-		return fmt.Errorf("failed to wait for policies compliance state, 'apiClient' parameter is nil")
-	}
-
-	err := apiClient.AttachScheme(policiesv1.AddToScheme)
-	if err != nil {
-		klog.V(100).Info("Failed to add Policy scheme to client schemes")
-
-		return err
-	}
-
-	logMessage := fmt.Sprintf("Waiting up to %s until policies have compliance state %s", timeout, complianceState)
-	passedOptions := runtimeclient.ListOptions{}
-
 	if len(options) > 1 {
-		klog.V(100).Info("'options' parameter must be empty or single-valued")
-
 		return fmt.Errorf("error: more than one ListOptions was passed")
 	}
 
+	if apiClient == nil {
+		klog.V(100).Info("Policies 'apiClient' parameter cannot be nil")
+
+		return commonerrors.NewAPIClientNil(commonkey.NewResourceKey(policyGVK.Kind, "", ""))
+	}
+
+	logMessage := fmt.Sprintf("Waiting up to %s until policies have compliance state %s", timeout, complianceState)
 	if len(options) == 1 {
-		passedOptions = options[0]
-		logMessage += fmt.Sprintf(", listing with the options %v", passedOptions)
+		logMessage += fmt.Sprintf(", listing with the options %v", options[0])
 	}
 
 	klog.V(100).Info(logMessage)
 
 	return wait.PollUntilContextTimeout(
 		context.TODO(), time.Second, timeout, true, func(ctx context.Context) (bool, error) {
-			policies, err := ListPoliciesInAllNamespaces(apiClient, passedOptions)
+			policies, err := ListPoliciesInAllNamespaces(apiClient, options...)
 			if err != nil {
 				klog.V(100).Infof("Failed to list policies while waiting for compliance state: %v", err)
 

--- a/pkg/ocm/policylist.go
+++ b/pkg/ocm/policylist.go
@@ -19,10 +19,6 @@ import (
 func ListPoliciesInAllNamespaces(apiClient *clients.Settings,
 	options ...runtimeclient.ListOptions) (
 	[]*PolicyBuilder, error) {
-	if len(options) > 1 {
-		return nil, fmt.Errorf("error: more than one ListOptions was passed")
-	}
-
 	return common.List[policiesv1.Policy, policiesv1.PolicyList, PolicyBuilder](
 		context.TODO(), apiClient, policiesv1.AddToScheme, common.ConvertListOptionsToOptions(options)...)
 }
@@ -34,10 +30,6 @@ func WaitForAllPoliciesComplianceState(
 	complianceState policiesv1.ComplianceState,
 	timeout time.Duration,
 	options ...runtimeclient.ListOptions) error {
-	if len(options) > 1 {
-		return fmt.Errorf("error: more than one ListOptions was passed")
-	}
-
 	if apiClient == nil {
 		klog.V(100).Info("Policies 'apiClient' parameter cannot be nil")
 
@@ -45,8 +37,8 @@ func WaitForAllPoliciesComplianceState(
 	}
 
 	logMessage := fmt.Sprintf("Waiting up to %s until policies have compliance state %s", timeout, complianceState)
-	if len(options) == 1 {
-		logMessage += fmt.Sprintf(", listing with the options %v", options[0])
+	if len(options) > 0 {
+		logMessage += fmt.Sprintf(", listing with the options %v", options)
 	}
 
 	klog.V(100).Info(logMessage)

--- a/pkg/ocm/policylist_test.go
+++ b/pkg/ocm/policylist_test.go
@@ -8,80 +8,21 @@ import (
 
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
 	commonerrors "github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common/errors"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common/testhelper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
-	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestListPoliciesInAllNamespaces(t *testing.T) {
 	t.Parallel()
 
-	testCases := []struct {
-		name          string
-		listOptions   []runtimeclient.ListOptions
-		expectedError error
-		client        bool
-	}{
-		{
-			name:          "list all",
-			listOptions:   nil,
-			expectedError: nil,
-			client:        true,
-		},
-		{
-			name:          "list with options",
-			listOptions:   []runtimeclient.ListOptions{{LabelSelector: labels.NewSelector()}},
-			expectedError: nil,
-			client:        true,
-		},
-		{
-			name: "too many list options",
-			listOptions: []runtimeclient.ListOptions{
-				{LabelSelector: labels.NewSelector()},
-				{LabelSelector: labels.NewSelector()},
-			},
-			expectedError: fmt.Errorf("error: more than one ListOptions was passed"),
-			client:        true,
-		},
-		{
-			name:          "nil client",
-			listOptions:   []runtimeclient.ListOptions{{LabelSelector: labels.NewSelector()}},
-			expectedError: fmt.Errorf("apiClient for Policy is nil"),
-			client:        false,
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			t.Parallel()
-
-			var testSettings *clients.Settings
-
-			if testCase.client {
-				testSettings = buildTestClientWithDummyPolicy()
-			}
-
-			builders, err := ListPoliciesInAllNamespaces(testSettings, testCase.listOptions...)
-
-			switch testCase.name {
-			case "nil client":
-				require.Error(t, err)
-				assert.True(t, commonerrors.IsAPIClientNil(err))
-				assert.Nil(t, builders)
-			case "too many list options":
-				assert.Equal(t, testCase.expectedError, err)
-			default:
-				assert.NoError(t, err)
-
-				if len(testCase.listOptions) == 0 {
-					assert.Len(t, builders, 1)
-				}
-			}
-		})
-	}
+	testhelper.NewListTestConfig(
+		ListPoliciesInAllNamespaces,
+		policiesv1.AddToScheme,
+		policyGVK,
+	).ExecuteTests(t)
 }
 
 func TestWaitForAllPoliciesComplianceState(t *testing.T) {
@@ -91,7 +32,6 @@ func TestWaitForAllPoliciesComplianceState(t *testing.T) {
 		name          string
 		compliant     bool
 		client        bool
-		listOptions   []runtimeclient.ListOptions
 		expectedError error
 	}{
 		{
@@ -109,16 +49,6 @@ func TestWaitForAllPoliciesComplianceState(t *testing.T) {
 			name:          "nil client",
 			client:        false,
 			expectedError: fmt.Errorf("apiClient for Policy is nil"),
-		},
-		{
-			name:      "too many list options",
-			compliant: true,
-			client:    true,
-			listOptions: []runtimeclient.ListOptions{
-				{LabelSelector: labels.NewSelector()},
-				{LabelSelector: labels.NewSelector()},
-			},
-			expectedError: fmt.Errorf("error: more than one ListOptions was passed"),
 		},
 	}
 
@@ -144,13 +74,13 @@ func TestWaitForAllPoliciesComplianceState(t *testing.T) {
 			}
 
 			err := WaitForAllPoliciesComplianceState(
-				testSettings, policiesv1.Compliant, time.Second, testCase.listOptions...)
+				testSettings, policiesv1.Compliant, time.Second)
 
 			switch testCase.name {
 			case "nil client":
 				require.Error(t, err)
 				assert.True(t, commonerrors.IsAPIClientNil(err))
-			case "not compliant", "too many list options":
+			case "not compliant":
 				assert.Equal(t, testCase.expectedError, err)
 			default:
 				assert.NoError(t, err)

--- a/pkg/ocm/policylist_test.go
+++ b/pkg/ocm/policylist_test.go
@@ -7,7 +7,9 @@ import (
 	"time"
 
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	commonerrors "github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
@@ -15,32 +17,28 @@ import (
 )
 
 func TestListPoliciesInAllNamespaces(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
-		policies      []*PolicyBuilder
+		name          string
 		listOptions   []runtimeclient.ListOptions
 		expectedError error
 		client        bool
 	}{
 		{
-			policies: []*PolicyBuilder{
-				buildValidPolicyTestBuilder(buildTestClientWithDummyPolicy()),
-			},
+			name:          "list all",
 			listOptions:   nil,
 			expectedError: nil,
 			client:        true,
 		},
 		{
-			policies: []*PolicyBuilder{
-				buildValidPolicyTestBuilder(buildTestClientWithDummyPolicy()),
-			},
+			name:          "list with options",
 			listOptions:   []runtimeclient.ListOptions{{LabelSelector: labels.NewSelector()}},
 			expectedError: nil,
 			client:        true,
 		},
 		{
-			policies: []*PolicyBuilder{
-				buildValidPolicyTestBuilder(buildTestClientWithDummyPolicy()),
-			},
+			name: "too many list options",
 			listOptions: []runtimeclient.ListOptions{
 				{LabelSelector: labels.NewSelector()},
 				{LabelSelector: labels.NewSelector()},
@@ -49,57 +47,71 @@ func TestListPoliciesInAllNamespaces(t *testing.T) {
 			client:        true,
 		},
 		{
-			policies: []*PolicyBuilder{
-				buildValidPolicyTestBuilder(buildTestClientWithDummyPolicy()),
-			},
+			name:          "nil client",
 			listOptions:   []runtimeclient.ListOptions{{LabelSelector: labels.NewSelector()}},
-			expectedError: fmt.Errorf("failed to list policies, 'apiClient' parameter is nil"),
+			expectedError: fmt.Errorf("apiClient for Policy is nil"),
 			client:        false,
 		},
 	}
 
 	for _, testCase := range testCases {
-		var testSettings *clients.Settings
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 
-		if testCase.client {
-			testSettings = buildTestClientWithDummyPolicy()
-		}
+			var testSettings *clients.Settings
 
-		builders, err := ListPoliciesInAllNamespaces(testSettings, testCase.listOptions...)
-		assert.Equal(t, testCase.expectedError, err)
+			if testCase.client {
+				testSettings = buildTestClientWithDummyPolicy()
+			}
 
-		if testCase.expectedError == nil && len(testCase.listOptions) == 0 {
-			assert.Equal(t, len(testCase.policies), len(builders))
-		}
+			builders, err := ListPoliciesInAllNamespaces(testSettings, testCase.listOptions...)
+
+			switch testCase.name {
+			case "nil client":
+				require.Error(t, err)
+				assert.True(t, commonerrors.IsAPIClientNil(err))
+				assert.Nil(t, builders)
+			case "too many list options":
+				assert.Equal(t, testCase.expectedError, err)
+			default:
+				assert.NoError(t, err)
+
+				if len(testCase.listOptions) == 0 {
+					assert.Len(t, builders, 1)
+				}
+			}
+		})
 	}
 }
 
 func TestWaitForAllPoliciesComplianceState(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
+		name          string
 		compliant     bool
 		client        bool
 		listOptions   []runtimeclient.ListOptions
 		expectedError error
 	}{
 		{
-			compliant:     true,
-			client:        true,
-			listOptions:   nil,
-			expectedError: nil,
+			name:      "all compliant",
+			compliant: true,
+			client:    true,
 		},
 		{
+			name:          "not compliant",
 			compliant:     false,
 			client:        true,
-			listOptions:   nil,
 			expectedError: context.DeadlineExceeded,
 		},
 		{
-			compliant:     true,
+			name:          "nil client",
 			client:        false,
-			listOptions:   nil,
-			expectedError: fmt.Errorf("failed to wait for policies compliance state, 'apiClient' parameter is nil"),
+			expectedError: fmt.Errorf("apiClient for Policy is nil"),
 		},
 		{
+			name:      "too many list options",
 			compliant: true,
 			client:    true,
 			listOptions: []runtimeclient.ListOptions{
@@ -111,22 +123,38 @@ func TestWaitForAllPoliciesComplianceState(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		var testSettings *clients.Settings
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 
-		if testCase.client {
-			policy := buildDummyPolicy(defaultPolicyName, defaultPolicyNsName)
+			var testSettings *clients.Settings
 
-			if testCase.compliant {
-				policy.Status.ComplianceState = policiesv1.Compliant
+			if testCase.client {
+				policy := buildDummyPolicy()
+
+				if testCase.compliant {
+					policy.Status.ComplianceState = policiesv1.Compliant
+				}
+
+				testSettings = clients.GetTestClients(clients.TestClientParams{
+					K8sMockObjects: []runtime.Object{policy},
+					SchemeAttachers: []clients.SchemeAttacher{
+						policiesv1.AddToScheme,
+					},
+				})
 			}
 
-			testSettings = clients.GetTestClients(clients.TestClientParams{
-				K8sMockObjects:  []runtime.Object{policy},
-				SchemeAttachers: policyTestSchemes,
-			})
-		}
+			err := WaitForAllPoliciesComplianceState(
+				testSettings, policiesv1.Compliant, time.Second, testCase.listOptions...)
 
-		err := WaitForAllPoliciesComplianceState(testSettings, policiesv1.Compliant, time.Second, testCase.listOptions...)
-		assert.Equal(t, testCase.expectedError, err)
+			switch testCase.name {
+			case "nil client":
+				require.Error(t, err)
+				assert.True(t, commonerrors.IsAPIClientNil(err))
+			case "not compliant", "too many list options":
+				assert.Equal(t, testCase.expectedError, err)
+			default:
+				assert.NoError(t, err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
Migrate policy builder in pkg/ocm to the common builder framework.

Closes #1456

Made with [Cursor](https://cursor.com)