### PR TITLE
ocm: migrate policyset to common builder

### DIFF
--- a/pkg/ocm/policyset.go
+++ b/pkg/ocm/policyset.go
@@ -1,275 +1,70 @@
 package ocm
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/logging"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/msg"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog/v2"
 	policiesv1beta1 "open-cluster-management.io/governance-policy-propagator/api/v1beta1"
-	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+var policySetGVK = policiesv1beta1.GroupVersion.WithKind("PolicySet")
 
 // PolicySetBuilder provides struct for the policySet object containing connection to
 // the cluster and the policySet definitions.
 type PolicySetBuilder struct {
-	// policySet Definition, used to create the policySet object.
-	Definition *policiesv1beta1.PolicySet
-	// created policySet object.
-	Object *policiesv1beta1.PolicySet
-	// api client to interact with the cluster.
-	apiClient runtimeclient.Client
-	// used to store latest error message upon defining or mutating policySet definition.
-	errorMsg string
+	common.EmbeddableBuilder[policiesv1beta1.PolicySet, *policiesv1beta1.PolicySet]
+	common.EmbeddableCreator[policiesv1beta1.PolicySet, PolicySetBuilder, *policiesv1beta1.PolicySet, *PolicySetBuilder]
+	common.EmbeddableDeleteReturner[policiesv1beta1.PolicySet, PolicySetBuilder, *policiesv1beta1.PolicySet, *PolicySetBuilder]
+	common.EmbeddableForceUpdater[policiesv1beta1.PolicySet, PolicySetBuilder, *policiesv1beta1.PolicySet, *PolicySetBuilder]
+}
+
+// AttachMixins wires the embedded CRUD mixins to this builder instance.
+func (builder *PolicySetBuilder) AttachMixins() {
+	builder.EmbeddableCreator.SetBase(builder)
+	builder.EmbeddableDeleteReturner.SetBase(builder)
+	builder.EmbeddableForceUpdater.SetBase(builder)
+}
+
+// GetGVK returns the PolicySet GVK for this builder.
+func (builder *PolicySetBuilder) GetGVK() schema.GroupVersionKind {
+	return policySetGVK
 }
 
 // NewPolicySetBuilder creates a new instance of PolicySetBuilder.
 func NewPolicySetBuilder(
 	apiClient *clients.Settings, name, nsname string, policy policiesv1beta1.NonEmptyString) *PolicySetBuilder {
-	klog.V(100).Infof(
-		"Initializing new policy set structure with the following params: name: %s, nsname: %s, policy: %v",
-		name, nsname, policy)
-
-	if apiClient == nil {
-		klog.V(100).Info("The apiClient is nil")
-
-		return nil
-	}
-
-	err := apiClient.AttachScheme(policiesv1beta1.AddToScheme)
-	if err != nil {
-		klog.V(100).Info("Failed to add PolicySet scheme to client schemes")
-
-		return nil
-	}
-
-	builder := &PolicySetBuilder{
-		apiClient: apiClient.Client,
-		Definition: &policiesv1beta1.PolicySet{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: nsname,
-			},
-			Spec: policiesv1beta1.PolicySetSpec{
-				Policies: []policiesv1beta1.NonEmptyString{policy},
-			},
-		},
-	}
-
-	if name == "" {
-		klog.V(100).Info("The name of the PolicySet is empty")
-
-		builder.errorMsg = "policyset's 'name' cannot be empty"
-
-		return builder
-	}
-
-	if nsname == "" {
-		klog.V(100).Info("The namespace of the PolicySet is empty")
-
-		builder.errorMsg = "policyset's 'nsname' cannot be empty"
-
+	builder := common.NewNamespacedBuilder[policiesv1beta1.PolicySet, PolicySetBuilder](
+		apiClient, policiesv1beta1.AddToScheme, name, nsname)
+	if builder.GetError() != nil {
 		return builder
 	}
 
 	if policy == "" {
 		klog.V(100).Info("The policy of the PolicySet is empty")
 
-		builder.errorMsg = "policyset's 'policy' cannot be empty"
+		builder.SetError(fmt.Errorf("policyset's 'policy' cannot be empty"))
 
 		return builder
 	}
+
+	builder.Definition.Spec.Policies = []policiesv1beta1.NonEmptyString{policy}
 
 	return builder
 }
 
 // PullPolicySet pulls existing policySet into Builder struct.
 func PullPolicySet(apiClient *clients.Settings, name, nsname string) (*PolicySetBuilder, error) {
-	klog.V(100).Infof("Pulling existing policySet name %s under namespace %s from cluster", name, nsname)
-
-	if apiClient == nil {
-		klog.V(100).Info("The apiClient is nil")
-
-		return nil, fmt.Errorf("policyset's 'apiClient' cannot be nil")
-	}
-
-	err := apiClient.AttachScheme(policiesv1beta1.AddToScheme)
-	if err != nil {
-		klog.V(100).Info("Failed to add PolicySet scheme to client schemes")
-
-		return nil, err
-	}
-
-	builder := &PolicySetBuilder{
-		apiClient: apiClient.Client,
-		Definition: &policiesv1beta1.PolicySet{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: nsname,
-			},
-		},
-	}
-
-	if name == "" {
-		klog.V(100).Info("The name of the policyset is empty")
-
-		return nil, fmt.Errorf("policyset's 'name' cannot be empty")
-	}
-
-	if nsname == "" {
-		klog.V(100).Info("The namespace of the policyset is empty")
-
-		return nil, fmt.Errorf("policyset's 'namespace' cannot be empty")
-	}
-
-	if !builder.Exists() {
-		return nil, fmt.Errorf("policyset object %s does not exist in namespace %s", name, nsname)
-	}
-
-	builder.Definition = builder.Object
-
-	return builder, nil
-}
-
-// Exists checks whether the given policySet exists.
-func (builder *PolicySetBuilder) Exists() bool {
-	if valid, _ := builder.validate(); !valid {
-		return false
-	}
-
-	klog.V(100).Infof("Checking if policySet %s exists in namespace %s",
-		builder.Definition.Name, builder.Definition.Namespace)
-
-	var err error
-
-	builder.Object, err = builder.Get()
-
-	return err == nil || !k8serrors.IsNotFound(err)
-}
-
-// Get returns a policySet object if found.
-func (builder *PolicySetBuilder) Get() (*policiesv1beta1.PolicySet, error) {
-	if valid, err := builder.validate(); !valid {
-		return nil, err
-	}
-
-	klog.V(100).Infof("Getting policySet %s in namespace %s",
-		builder.Definition.Name, builder.Definition.Namespace)
-
-	policySet := &policiesv1beta1.PolicySet{}
-
-	err := builder.apiClient.Get(logging.DiscardContext(), runtimeclient.ObjectKey{
-		Name:      builder.Definition.Name,
-		Namespace: builder.Definition.Namespace,
-	}, policySet)
-	if err != nil {
-		klog.V(100).Infof("Failed to get policySet %s in namespace %s: %v",
-			builder.Definition.Name, builder.Definition.Namespace, err)
-
-		return nil, err
-	}
-
-	return policySet, nil
-}
-
-// Create makes a policySet in the cluster and stores the created object in struct.
-func (builder *PolicySetBuilder) Create() (*PolicySetBuilder, error) {
-	if valid, err := builder.validate(); !valid {
-		return builder, err
-	}
-
-	klog.V(100).Infof("Creating the policySet %s in namespace %s",
-		builder.Definition.Name, builder.Definition.Namespace)
-
-	if builder.Exists() {
-		return builder, nil
-	}
-
-	err := builder.apiClient.Create(logging.DiscardContext(), builder.Definition)
-	if err != nil {
-		return builder, err
-	}
-
-	builder.Object = builder.Definition
-
-	return builder, nil
-}
-
-// Delete removes a policySet from a cluster.
-func (builder *PolicySetBuilder) Delete() (*PolicySetBuilder, error) {
-	if valid, err := builder.validate(); !valid {
-		return builder, err
-	}
-
-	klog.V(100).Infof("Deleting the policySet %s in namespace %s",
-		builder.Definition.Name, builder.Definition.Namespace)
-
-	if !builder.Exists() {
-		klog.V(100).Infof("PolicySet %s does not exist in namespace %s",
-			builder.Definition.Name, builder.Definition.Namespace)
-
-		builder.Object = nil
-
-		return builder, nil
-	}
-
-	err := builder.apiClient.Delete(logging.DiscardContext(), builder.Definition)
-	if err != nil {
-		return builder, fmt.Errorf("can not delete policySet: %w", err)
-	}
-
-	builder.Object = nil
-
-	return builder, nil
-}
-
-// Update renovates the existing policySet object with the policySet's definition in builder.
-func (builder *PolicySetBuilder) Update(force bool) (*PolicySetBuilder, error) {
-	if valid, err := builder.validate(); !valid {
-		return builder, err
-	}
-
-	if !builder.Exists() {
-		klog.V(100).Infof(
-			"PolicySet %s does not exist in namespace %s", builder.Definition.Name, builder.Definition.Namespace)
-
-		return nil, fmt.Errorf("cannot update non-existent policySet")
-	}
-
-	klog.V(100).Infof("Updating the policySet object: %s in namespace: %s",
-		builder.Definition.Name, builder.Definition.Namespace)
-
-	builder.Definition.ResourceVersion = builder.Object.ResourceVersion
-
-	err := builder.apiClient.Update(logging.DiscardContext(), builder.Definition)
-	if err != nil {
-		if force {
-			klog.V(100).Infof("%v", msg.FailToUpdateNotification("policySet", builder.Definition.Name, builder.Definition.Namespace))
-
-			builder, err := builder.Delete()
-			builder.Definition.ResourceVersion = ""
-
-			if err != nil {
-				klog.V(100).Infof("%v", msg.FailToUpdateError("policySet", builder.Definition.Name, builder.Definition.Namespace))
-
-				return nil, err
-			}
-
-			return builder.Create()
-		}
-	}
-
-	builder.Object = builder.Definition
-
-	return builder, nil
+	return common.PullNamespacedBuilder[policiesv1beta1.PolicySet, PolicySetBuilder](
+		context.TODO(), apiClient, policiesv1beta1.AddToScheme, name, nsname)
 }
 
 // WithAdditionalPolicy appends a policy to the policies list in the PolicySet definition.
 func (builder *PolicySetBuilder) WithAdditionalPolicy(policy policiesv1beta1.NonEmptyString) *PolicySetBuilder {
-	if valid, _ := builder.validate(); !valid {
+	if err := common.Validate(builder); err != nil {
 		return builder
 	}
 
@@ -279,7 +74,7 @@ func (builder *PolicySetBuilder) WithAdditionalPolicy(policy policiesv1beta1.Non
 	if policy == "" {
 		klog.V(100).Info("The policy to be added to the PolicySet's Policies is empty")
 
-		builder.errorMsg = "policy in PolicySet Policies spec cannot be empty"
+		builder.SetError(fmt.Errorf("policy in PolicySet Policies spec cannot be empty"))
 
 		return builder
 	}
@@ -287,36 +82,4 @@ func (builder *PolicySetBuilder) WithAdditionalPolicy(policy policiesv1beta1.Non
 	builder.Definition.Spec.Policies = append(builder.Definition.Spec.Policies, policy)
 
 	return builder
-}
-
-// validate will check that the builder and builder definition are properly initialized before
-// accessing any member fields.
-func (builder *PolicySetBuilder) validate() (bool, error) {
-	resourceCRD := "policySet"
-
-	if builder == nil {
-		klog.V(100).Infof("The %s builder is uninitialized", resourceCRD)
-
-		return false, fmt.Errorf("error: received nil %s builder", resourceCRD)
-	}
-
-	if builder.Definition == nil {
-		klog.V(100).Infof("The %s is undefined", resourceCRD)
-
-		return false, fmt.Errorf("%s", msg.UndefinedCrdObjectErrString(resourceCRD))
-	}
-
-	if builder.apiClient == nil {
-		klog.V(100).Infof("The %s builder apiclient is nil", resourceCRD)
-
-		return false, fmt.Errorf("%s builder cannot have nil apiClient", resourceCRD)
-	}
-
-	if builder.errorMsg != "" {
-		klog.V(100).Infof("The %s builder has error message: %s", resourceCRD, builder.errorMsg)
-
-		return false, fmt.Errorf("%s", builder.errorMsg)
-	}
-
-	return true, nil
 }

--- a/pkg/ocm/policyset_test.go
+++ b/pkg/ocm/policyset_test.go
@@ -5,8 +5,10 @@ import (
 	"testing"
 
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	commonerrors "github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common/errors"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common/testhelper"
 	"github.com/stretchr/testify/assert"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	policiesv1beta1 "open-cluster-management.io/governance-policy-propagator/api/v1beta1"
@@ -17,417 +19,148 @@ const (
 	defaultPolicySetNsName = "test-ns"
 )
 
-var policySetTestSchemes = []clients.SchemeAttacher{
-	policiesv1beta1.AddToScheme,
-}
-
 func TestNewPolicySetBuilder(t *testing.T) {
+	t.Parallel()
+
+	t.Run("common namespaced builder behavior", func(t *testing.T) {
+		t.Parallel()
+
+		testhelper.NewNamespacedBuilderTestConfig(
+			func(apiClient *clients.Settings, name, nsname string) *PolicySetBuilder {
+				return NewPolicySetBuilder(apiClient, name, nsname, policiesv1beta1.NonEmptyString(defaultPolicyName))
+			},
+			policiesv1beta1.AddToScheme,
+			policySetGVK,
+		).ExecuteTests(t)
+	})
+
 	testCases := []struct {
-		policySetName      string
-		policySetNamespace string
-		policyName         string
-		client             bool
-		expectedErrorText  string
+		name          string
+		policyName    policiesv1beta1.NonEmptyString
+		expectedError error
 	}{
 		{
-			policySetName:      defaultPolicySetName,
-			policySetNamespace: defaultPolicySetNsName,
-			policyName:         defaultPolicyName,
-			client:             true,
-			expectedErrorText:  "",
+			name:          "valid policy",
+			policyName:    policiesv1beta1.NonEmptyString(defaultPolicyName),
+			expectedError: nil,
 		},
 		{
-			policySetName:      "",
-			policySetNamespace: defaultPolicySetNsName,
-			policyName:         defaultPolicyName,
-			client:             true,
-			expectedErrorText:  "policyset's 'name' cannot be empty",
-		},
-		{
-			policySetName:      defaultPolicySetName,
-			policySetNamespace: "",
-			policyName:         defaultPolicyName,
-			client:             true,
-			expectedErrorText:  "policyset's 'nsname' cannot be empty",
-		},
-		{
-			policySetName:      defaultPolicySetName,
-			policySetNamespace: defaultPolicySetNsName,
-			policyName:         "",
-			client:             true,
-			expectedErrorText:  "policyset's 'policy' cannot be empty",
-		},
-		{
-			policySetName:      defaultPolicySetName,
-			policySetNamespace: defaultPolicySetNsName,
-			policyName:         defaultPolicyName,
-			client:             false,
-			expectedErrorText:  "",
+			name:          "empty policy",
+			policyName:    "",
+			expectedError: fmt.Errorf("policyset's 'policy' cannot be empty"),
 		},
 	}
 
 	for _, testCase := range testCases {
-		var client *clients.Settings
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 
-		if testCase.client {
-			client = buildTestClientWithPolicySetScheme()
-		}
+			testBuilder := NewPolicySetBuilder(
+				clients.GetTestClients(clients.TestClientParams{
+					SchemeAttachers: []clients.SchemeAttacher{policiesv1beta1.AddToScheme},
+				}),
+				defaultPolicySetName,
+				defaultPolicySetNsName,
+				testCase.policyName,
+			)
 
-		policySetBuilder := NewPolicySetBuilder(
-			client,
-			testCase.policySetName,
-			testCase.policySetNamespace,
-			policiesv1beta1.NonEmptyString(testCase.policyName))
+			assert.Equal(t, testCase.expectedError, testBuilder.GetError())
 
-		if testCase.client {
-			assert.Equal(t, testCase.expectedErrorText, policySetBuilder.errorMsg)
-
-			if testCase.expectedErrorText == "" {
-				assert.Equal(t, testCase.expectedErrorText, policySetBuilder.errorMsg)
-				assert.Equal(t, testCase.policySetName, policySetBuilder.Definition.Name)
-				assert.Equal(t, testCase.policySetNamespace, policySetBuilder.Definition.Namespace)
+			if testCase.expectedError == nil {
+				assert.Equal(
+					t,
+					[]policiesv1beta1.NonEmptyString{testCase.policyName},
+					testBuilder.Definition.Spec.Policies,
+				)
 			}
-		} else {
-			assert.Nil(t, policySetBuilder)
-		}
+		})
 	}
 }
 
 func TestPullPolicySet(t *testing.T) {
-	testCases := []struct {
-		policySetName       string
-		policySetNamespace  string
-		addToRuntimeObjects bool
-		client              bool
-		expectedError       error
-	}{
-		{
-			policySetName:       defaultPolicySetName,
-			policySetNamespace:  defaultPolicySetNsName,
-			addToRuntimeObjects: true,
-			client:              true,
-			expectedError:       nil,
-		},
-		{
-			policySetName:       defaultPolicySetName,
-			policySetNamespace:  defaultPolicySetNsName,
-			addToRuntimeObjects: false,
-			client:              true,
-			expectedError: fmt.Errorf(
-				"policyset object %s does not exist in namespace %s", defaultPolicySetName, defaultPolicySetNsName),
-		},
-		{
-			policySetName:       "",
-			policySetNamespace:  defaultPolicySetNsName,
-			addToRuntimeObjects: false,
-			client:              true,
-			expectedError:       fmt.Errorf("policyset's 'name' cannot be empty"),
-		},
-		{
-			policySetName:       defaultPolicySetName,
-			policySetNamespace:  "",
-			addToRuntimeObjects: false,
-			client:              true,
-			expectedError:       fmt.Errorf("policyset's 'namespace' cannot be empty"),
-		},
-		{
-			policySetName:       defaultPolicySetName,
-			policySetNamespace:  defaultPolicySetNsName,
-			addToRuntimeObjects: false,
-			client:              false,
-			expectedError:       fmt.Errorf("policyset's 'apiClient' cannot be nil"),
-		},
-	}
+	t.Parallel()
 
-	for _, testCase := range testCases {
-		var (
-			runtimeObjects []runtime.Object
-			testSettings   *clients.Settings
-		)
-
-		testPolicySet := buildDummyPolicySet(testCase.policySetName, testCase.policySetNamespace)
-
-		if testCase.addToRuntimeObjects {
-			runtimeObjects = append(runtimeObjects, testPolicySet)
-		}
-
-		if testCase.client {
-			testSettings = clients.GetTestClients(clients.TestClientParams{
-				K8sMockObjects:  runtimeObjects,
-				SchemeAttachers: policySetTestSchemes,
-			})
-		}
-
-		policySetBuilder, err := PullPolicySet(testSettings, testPolicySet.Name, testPolicySet.Namespace)
-		assert.Equal(t, testCase.expectedError, err)
-
-		if testCase.expectedError == nil {
-			assert.Equal(t, testPolicySet.Name, policySetBuilder.Object.Name)
-			assert.Equal(t, testPolicySet.Namespace, policySetBuilder.Object.Namespace)
-		}
-	}
+	testhelper.NewNamespacedPullTestConfig(
+		PullPolicySet, policiesv1beta1.AddToScheme, policySetGVK).ExecuteTests(t)
 }
 
-func TestPolicySetExists(t *testing.T) {
-	testCases := []struct {
-		testBuilder *PolicySetBuilder
-		exists      bool
-	}{
-		{
-			testBuilder: buildValidPolicySetTestBuilder(buildTestClientWithDummyPolicySet()),
-			exists:      true,
-		},
-		{
-			testBuilder: buildInvalidPolicySetTestBuilder(buildTestClientWithDummyPolicySet()),
-			exists:      false,
-		},
-		{
-			testBuilder: buildValidPolicySetTestBuilder(buildTestClientWithPolicySetScheme()),
-			exists:      false,
-		},
-	}
+func TestPolicySetBuilderMethods(t *testing.T) {
+	t.Parallel()
 
-	for _, testCase := range testCases {
-		exists := testCase.testBuilder.Exists()
-		assert.Equal(t, testCase.exists, exists)
-	}
+	commonTestConfig := testhelper.NewCommonTestConfig[policiesv1beta1.PolicySet, PolicySetBuilder](
+		policiesv1beta1.AddToScheme,
+		policySetGVK,
+		testhelper.ResourceScopeNamespaced,
+	)
+
+	testhelper.NewTestSuite().
+		With(testhelper.NewGetTestConfig(commonTestConfig)).
+		With(testhelper.NewExistsTestConfig(commonTestConfig)).
+		With(testhelper.NewCreateTestConfig(commonTestConfig)).
+		With(testhelper.NewDeleteReturnerTestConfig(commonTestConfig)).
+		With(testhelper.NewForceUpdateTestConfig(commonTestConfig)).
+		Run(t)
 }
 
-func TestPolicySetGet(t *testing.T) {
+func TestPolicySetWithAdditionalPolicy(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
-		testBuilder       *PolicySetBuilder
-		expectedPolicySet *policiesv1beta1.PolicySet
-	}{
-		{
-			testBuilder:       buildValidPolicySetTestBuilder(buildTestClientWithDummyPolicySet()),
-			expectedPolicySet: buildDummyPolicySet(defaultPolicySetName, defaultPolicySetNsName),
-		},
-		{
-			testBuilder:       buildValidPolicySetTestBuilder(buildTestClientWithPolicySetScheme()),
-			expectedPolicySet: nil,
-		},
-	}
-
-	for _, testCase := range testCases {
-		policySet, err := testCase.testBuilder.Get()
-
-		if testCase.expectedPolicySet == nil {
-			assert.Nil(t, policySet)
-			assert.True(t, k8serrors.IsNotFound(err))
-		} else {
-			assert.Nil(t, err)
-			assert.Equal(t, testCase.expectedPolicySet.Name, policySet.Name)
-			assert.Equal(t, testCase.expectedPolicySet.Namespace, policySet.Namespace)
-		}
-	}
-}
-
-func TestPolicySetCreate(t *testing.T) {
-	testCases := []struct {
-		testBuilder   *PolicySetBuilder
+		name          string
+		policyName    policiesv1beta1.NonEmptyString
+		valid         bool
 		expectedError error
 	}{
 		{
-			testBuilder:   buildValidPolicySetTestBuilder(buildTestClientWithPolicySetScheme()),
-			expectedError: nil,
+			name:       "valid additional policy",
+			policyName: policiesv1beta1.NonEmptyString(defaultPolicyName),
+			valid:      true,
 		},
 		{
-			testBuilder:   buildInvalidPolicySetTestBuilder(buildTestClientWithPolicySetScheme()),
-			expectedError: fmt.Errorf("policyset's 'nsname' cannot be empty"),
+			name:          "empty additional policy",
+			policyName:    "",
+			valid:         true,
+			expectedError: fmt.Errorf("policy in PolicySet Policies spec cannot be empty"),
+		},
+		{
+			name:       "invalid builder",
+			policyName: policiesv1beta1.NonEmptyString(defaultPolicyName),
+			valid:      false,
 		},
 	}
 
 	for _, testCase := range testCases {
-		policySetBuilder, err := testCase.testBuilder.Create()
-		assert.Equal(t, testCase.expectedError, err)
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 
-		if testCase.expectedError == nil {
-			assert.Equal(t, policySetBuilder.Definition, policySetBuilder.Object)
-		}
-	}
-}
+			var policySetBuilder *PolicySetBuilder
+			if testCase.valid {
+				policySetBuilder = buildValidPolicySetTestBuilder(buildTestClientWithPolicySetScheme())
+			} else {
+				policySetBuilder = buildInvalidPolicySetTestBuilder(buildTestClientWithPolicySetScheme())
+			}
 
-func TestPolicySetDelete(t *testing.T) {
-	testCases := []struct {
-		testBuilder   *PolicySetBuilder
-		expectedError error
-	}{
-		{
-			testBuilder:   buildValidPolicySetTestBuilder(buildTestClientWithDummyPolicySet()),
-			expectedError: nil,
-		},
-		{
-			testBuilder:   buildInvalidPolicySetTestBuilder(buildTestClientWithDummyPolicySet()),
-			expectedError: fmt.Errorf("policyset's 'nsname' cannot be empty"),
-		},
-	}
+			policySetBuilder = policySetBuilder.WithAdditionalPolicy(testCase.policyName)
 
-	for _, testCase := range testCases {
-		_, err := testCase.testBuilder.Delete()
-		assert.Equal(t, testCase.expectedError, err)
+			switch testCase.name {
+			case "invalid builder":
+				require.Error(t, policySetBuilder.GetError())
+				assert.True(t, commonerrors.IsBuilderNamespaceEmpty(policySetBuilder.GetError()))
+			default:
+				assert.Equal(t, testCase.expectedError, policySetBuilder.GetError())
 
-		if testCase.expectedError == nil {
-			assert.Nil(t, testCase.testBuilder.Object)
-		}
-	}
-}
-
-func TestPolicySetUpdate(t *testing.T) {
-	testCases := []struct {
-		alreadyExists bool
-		force         bool
-	}{
-		{
-			alreadyExists: false,
-			force:         false,
-		},
-		{
-			alreadyExists: true,
-			force:         false,
-		},
-		{
-			alreadyExists: false,
-			force:         true,
-		},
-		{
-			alreadyExists: true,
-			force:         true,
-		},
-	}
-
-	for _, testCase := range testCases {
-		testBuilder := buildValidPolicySetTestBuilder(buildTestClientWithPolicySetScheme())
-
-		// Create the builder rather than just adding it to the client so that the proper metadata is added and
-		// the update will not fail.
-		if testCase.alreadyExists {
-			var err error
-
-			testBuilder = buildValidPolicySetTestBuilder(buildTestClientWithPolicySetScheme())
-			testBuilder, err = testBuilder.Create()
-			assert.Nil(t, err)
-		}
-
-		assert.NotNil(t, testBuilder.Definition)
-		assert.Empty(t, testBuilder.Definition.Spec.Description)
-
-		testBuilder.Definition.Spec.Description = "test description"
-
-		policySetBuilder, err := testBuilder.Update(testCase.force)
-		assert.NotNil(t, testBuilder.Definition)
-
-		if testCase.alreadyExists {
-			assert.Nil(t, err)
-			assert.Equal(t, testBuilder.Definition.Name, policySetBuilder.Definition.Name)
-			assert.Equal(t, testBuilder.Definition.Spec.Description, policySetBuilder.Definition.Spec.Description)
-		} else {
-			assert.NotNil(t, err)
-		}
-	}
-}
-
-func TestPolicySetWithPolicy(t *testing.T) {
-	testCases := []struct {
-		policyName        policiesv1beta1.NonEmptyString
-		expectedErrorText string
-	}{
-		{
-			policyName:        "",
-			expectedErrorText: "policy in PolicySet Policies spec cannot be empty",
-		},
-		{
-			policyName:        policiesv1beta1.NonEmptyString(defaultPolicyName),
-			expectedErrorText: "",
-		},
-	}
-
-	for _, testCase := range testCases {
-		testSettings := buildTestClientWithPolicySetScheme()
-		policySetBuilder := buildValidPolicySetTestBuilder(testSettings).WithAdditionalPolicy(testCase.policyName)
-		assert.Equal(t, testCase.expectedErrorText, policySetBuilder.errorMsg)
-
-		if testCase.expectedErrorText == "" {
-			assert.Equal(
-				t,
-				[]policiesv1beta1.NonEmptyString{policiesv1beta1.NonEmptyString(defaultPolicyName), testCase.policyName},
-				policySetBuilder.Definition.Spec.Policies)
-		}
-	}
-}
-
-func TestPolicySetValidate(t *testing.T) {
-	testCases := []struct {
-		builderNil      bool
-		definitionNil   bool
-		apiClientNil    bool
-		builderErrorMsg string
-		expectedError   error
-	}{
-		{
-			builderNil:      false,
-			definitionNil:   false,
-			apiClientNil:    false,
-			builderErrorMsg: "",
-			expectedError:   nil,
-		},
-		{
-			builderNil:      true,
-			definitionNil:   false,
-			apiClientNil:    false,
-			builderErrorMsg: "",
-			expectedError:   fmt.Errorf("error: received nil policySet builder"),
-		},
-		{
-			builderNil:      false,
-			definitionNil:   true,
-			apiClientNil:    false,
-			builderErrorMsg: "",
-			expectedError:   fmt.Errorf("can not redefine the undefined policySet"),
-		},
-		{
-			builderNil:      false,
-			definitionNil:   false,
-			apiClientNil:    true,
-			builderErrorMsg: "",
-			expectedError:   fmt.Errorf("policySet builder cannot have nil apiClient"),
-		},
-		{
-			builderNil:      false,
-			definitionNil:   false,
-			apiClientNil:    false,
-			builderErrorMsg: "test error",
-			expectedError:   fmt.Errorf("test error"),
-		},
-	}
-
-	for _, testCase := range testCases {
-		policySetBuilder := buildValidPolicySetTestBuilder(buildTestClientWithPolicySetScheme())
-
-		if testCase.builderNil {
-			policySetBuilder = nil
-		}
-
-		if testCase.definitionNil {
-			policySetBuilder.Definition = nil
-		}
-
-		if testCase.apiClientNil {
-			policySetBuilder.apiClient = nil
-		}
-
-		if testCase.builderErrorMsg != "" {
-			policySetBuilder.errorMsg = testCase.builderErrorMsg
-		}
-
-		valid, err := policySetBuilder.validate()
-
-		if testCase.expectedError != nil {
-			assert.False(t, valid)
-			assert.Equal(t, testCase.expectedError, err)
-		} else {
-			assert.True(t, valid)
-			assert.Nil(t, err)
-		}
+				if testCase.expectedError == nil {
+					assert.Equal(
+						t,
+						[]policiesv1beta1.NonEmptyString{
+							policiesv1beta1.NonEmptyString(defaultPolicyName),
+							testCase.policyName,
+						},
+						policySetBuilder.Definition.Spec.Policies,
+					)
+				}
+			}
+		})
 	}
 }
 
@@ -447,14 +180,18 @@ func buildTestClientWithDummyPolicySet() *clients.Settings {
 		K8sMockObjects: []runtime.Object{
 			buildDummyPolicySet(defaultPolicySetName, defaultPolicySetNsName),
 		},
-		SchemeAttachers: policySetTestSchemes,
+		SchemeAttachers: []clients.SchemeAttacher{
+			policiesv1beta1.AddToScheme,
+		},
 	})
 }
 
 // buildTestClientWithPolicySetScheme returns a client with no objects but the PolicySet scheme attached.
 func buildTestClientWithPolicySetScheme() *clients.Settings {
 	return clients.GetTestClients(clients.TestClientParams{
-		SchemeAttachers: policySetTestSchemes,
+		SchemeAttachers: []clients.SchemeAttacher{
+			policiesv1beta1.AddToScheme,
+		},
 	})
 }
 

--- a/pkg/ocm/policyset_test.go
+++ b/pkg/ocm/policyset_test.go
@@ -9,8 +9,6 @@ import (
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common/testhelper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	policiesv1beta1 "open-cluster-management.io/governance-policy-propagator/api/v1beta1"
 )
 
@@ -162,28 +160,6 @@ func TestPolicySetWithAdditionalPolicy(t *testing.T) {
 			}
 		})
 	}
-}
-
-// buildDummyPolicySet returns a PolicySet with the provided name and namespace.
-func buildDummyPolicySet(name, nsname string) *policiesv1beta1.PolicySet {
-	return &policiesv1beta1.PolicySet{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: nsname,
-		},
-	}
-}
-
-// buildTestClientWithDummyPolicySet returns a client with a mock dummy PolicySet.
-func buildTestClientWithDummyPolicySet() *clients.Settings {
-	return clients.GetTestClients(clients.TestClientParams{
-		K8sMockObjects: []runtime.Object{
-			buildDummyPolicySet(defaultPolicySetName, defaultPolicySetNsName),
-		},
-		SchemeAttachers: []clients.SchemeAttacher{
-			policiesv1beta1.AddToScheme,
-		},
-	})
 }
 
 // buildTestClientWithPolicySetScheme returns a client with no objects but the PolicySet scheme attached.

--- a/pkg/ocm/policysetlist.go
+++ b/pkg/ocm/policysetlist.go
@@ -2,7 +2,6 @@ package ocm
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common"
@@ -14,10 +13,6 @@ import (
 func ListPolicieSetsInAllNamespaces(apiClient *clients.Settings,
 	options ...runtimeclient.ListOptions) (
 	[]*PolicySetBuilder, error) {
-	if len(options) > 1 {
-		return nil, fmt.Errorf("error: more than one ListOptions was passed")
-	}
-
 	return common.List[policiesv1beta1.PolicySet, policiesv1beta1.PolicySetList, PolicySetBuilder](
 		context.TODO(), apiClient, policiesv1beta1.AddToScheme, common.ConvertListOptionsToOptions(options)...)
 }

--- a/pkg/ocm/policysetlist.go
+++ b/pkg/ocm/policysetlist.go
@@ -1,11 +1,11 @@
 package ocm
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/logging"
-	"k8s.io/klog/v2"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common"
 	policiesv1beta1 "open-cluster-management.io/governance-policy-propagator/api/v1beta1"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -14,56 +14,10 @@ import (
 func ListPolicieSetsInAllNamespaces(apiClient *clients.Settings,
 	options ...runtimeclient.ListOptions) (
 	[]*PolicySetBuilder, error) {
-	if apiClient == nil {
-		klog.V(100).Info("PolicySets 'apiClient' parameter cannot be nil")
-
-		return nil, fmt.Errorf("failed to list policySets, 'apiClient' parameter is nil")
-	}
-
-	err := apiClient.AttachScheme(policiesv1beta1.AddToScheme)
-	if err != nil {
-		klog.V(100).Info("Failed to add PolicySet scheme to client schemes")
-
-		return nil, err
-	}
-
-	logMessage := string("Listing all policySets in all namespaces")
-	passedOptions := runtimeclient.ListOptions{}
-
 	if len(options) > 1 {
-		klog.V(100).Info("'options' parameter must be empty or single-valued")
-
 		return nil, fmt.Errorf("error: more than one ListOptions was passed")
 	}
 
-	if len(options) == 1 {
-		passedOptions = options[0]
-		logMessage += fmt.Sprintf(" with the options %v", passedOptions)
-	}
-
-	klog.V(100).Infof("%v", logMessage)
-
-	policySetList := new(policiesv1beta1.PolicySetList)
-
-	err = apiClient.List(logging.DiscardContext(), policySetList, &passedOptions)
-	if err != nil {
-		klog.V(100).Infof("Failed to list all policySets in all namespaces due to %s", err.Error())
-
-		return nil, err
-	}
-
-	var policySetObjects []*PolicySetBuilder
-
-	for _, policy := range policySetList.Items {
-		copiedPolicySet := policy
-		policySetBuilder := &PolicySetBuilder{
-			apiClient:  apiClient.Client,
-			Object:     &copiedPolicySet,
-			Definition: &copiedPolicySet,
-		}
-
-		policySetObjects = append(policySetObjects, policySetBuilder)
-	}
-
-	return policySetObjects, nil
+	return common.List[policiesv1beta1.PolicySet, policiesv1beta1.PolicySetList, PolicySetBuilder](
+		context.TODO(), apiClient, policiesv1beta1.AddToScheme, common.ConvertListOptionsToOptions(options)...)
 }

--- a/pkg/ocm/policysetlist_test.go
+++ b/pkg/ocm/policysetlist_test.go
@@ -1,81 +1,18 @@
 package ocm
 
 import (
-	"fmt"
 	"testing"
 
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
-	commonerrors "github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common/errors"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"k8s.io/apimachinery/pkg/labels"
-	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common/testhelper"
+	policiesv1beta1 "open-cluster-management.io/governance-policy-propagator/api/v1beta1"
 )
 
 func TestListPolicieSetsInAllNamespaces(t *testing.T) {
 	t.Parallel()
 
-	testCases := []struct {
-		name          string
-		listOptions   []runtimeclient.ListOptions
-		expectedError error
-		client        bool
-	}{
-		{
-			name:          "list all",
-			listOptions:   nil,
-			expectedError: nil,
-			client:        true,
-		},
-		{
-			name:          "list with options",
-			listOptions:   []runtimeclient.ListOptions{{LabelSelector: labels.NewSelector()}},
-			expectedError: nil,
-			client:        true,
-		},
-		{
-			name: "too many list options",
-			listOptions: []runtimeclient.ListOptions{
-				{LabelSelector: labels.NewSelector()},
-				{LabelSelector: labels.NewSelector()},
-			},
-			expectedError: fmt.Errorf("error: more than one ListOptions was passed"),
-			client:        true,
-		},
-		{
-			name:          "nil client",
-			listOptions:   []runtimeclient.ListOptions{{LabelSelector: labels.NewSelector()}},
-			expectedError: fmt.Errorf("apiClient for PolicySet is nil"),
-			client:        false,
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			t.Parallel()
-
-			var testSettings *clients.Settings
-
-			if testCase.client {
-				testSettings = buildTestClientWithDummyPolicySet()
-			}
-
-			builders, err := ListPolicieSetsInAllNamespaces(testSettings, testCase.listOptions...)
-
-			switch {
-			case testCase.name == "nil client":
-				require.Error(t, err)
-				assert.True(t, commonerrors.IsAPIClientNil(err))
-				assert.Nil(t, builders)
-			case testCase.expectedError != nil:
-				assert.Equal(t, testCase.expectedError, err)
-			default:
-				assert.NoError(t, err)
-
-				if len(testCase.listOptions) == 0 {
-					assert.Len(t, builders, 1)
-				}
-			}
-		})
-	}
+	testhelper.NewListTestConfig(
+		ListPolicieSetsInAllNamespaces,
+		policiesv1beta1.AddToScheme,
+		policySetGVK,
+	).ExecuteTests(t)
 }

--- a/pkg/ocm/policysetlist_test.go
+++ b/pkg/ocm/policysetlist_test.go
@@ -5,38 +5,36 @@ import (
 	"testing"
 
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	commonerrors "github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/common/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/labels"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestListPolicieSetsInAllNamespaces(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
-		policySets    []*PolicySetBuilder
+		name          string
 		listOptions   []runtimeclient.ListOptions
 		expectedError error
 		client        bool
 	}{
 		{
-			policySets: []*PolicySetBuilder{
-				buildValidPolicySetTestBuilder(buildTestClientWithDummyPolicySet()),
-			},
+			name:          "list all",
 			listOptions:   nil,
 			expectedError: nil,
 			client:        true,
 		},
 		{
-			policySets: []*PolicySetBuilder{
-				buildValidPolicySetTestBuilder(buildTestClientWithDummyPolicySet()),
-			},
+			name:          "list with options",
 			listOptions:   []runtimeclient.ListOptions{{LabelSelector: labels.NewSelector()}},
 			expectedError: nil,
 			client:        true,
 		},
 		{
-			policySets: []*PolicySetBuilder{
-				buildValidPolicySetTestBuilder(buildTestClientWithDummyPolicySet()),
-			},
+			name: "too many list options",
 			listOptions: []runtimeclient.ListOptions{
 				{LabelSelector: labels.NewSelector()},
 				{LabelSelector: labels.NewSelector()},
@@ -45,27 +43,39 @@ func TestListPolicieSetsInAllNamespaces(t *testing.T) {
 			client:        true,
 		},
 		{
-			policySets: []*PolicySetBuilder{
-				buildValidPolicySetTestBuilder(buildTestClientWithDummyPolicySet()),
-			},
+			name:          "nil client",
 			listOptions:   []runtimeclient.ListOptions{{LabelSelector: labels.NewSelector()}},
-			expectedError: fmt.Errorf("failed to list policySets, 'apiClient' parameter is nil"),
+			expectedError: fmt.Errorf("apiClient for PolicySet is nil"),
 			client:        false,
 		},
 	}
 
 	for _, testCase := range testCases {
-		var testSettings *clients.Settings
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 
-		if testCase.client {
-			testSettings = buildTestClientWithDummyPolicySet()
-		}
+			var testSettings *clients.Settings
 
-		builders, err := ListPolicieSetsInAllNamespaces(testSettings, testCase.listOptions...)
-		assert.Equal(t, testCase.expectedError, err)
+			if testCase.client {
+				testSettings = buildTestClientWithDummyPolicySet()
+			}
 
-		if testCase.expectedError == nil && len(testCase.listOptions) == 0 {
-			assert.Equal(t, len(testCase.policySets), len(builders))
-		}
+			builders, err := ListPolicieSetsInAllNamespaces(testSettings, testCase.listOptions...)
+
+			switch {
+			case testCase.name == "nil client":
+				require.Error(t, err)
+				assert.True(t, commonerrors.IsAPIClientNil(err))
+				assert.Nil(t, builders)
+			case testCase.expectedError != nil:
+				assert.Equal(t, testCase.expectedError, err)
+			default:
+				assert.NoError(t, err)
+
+				if len(testCase.listOptions) == 0 {
+					assert.Len(t, builders, 1)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
Migrate policyset builder in pkg/ocm to the common builder framework.

Closes #1457

Made with [Cursor](https://cursor.com)