### PR TITLE
Add masterbondplugin xmithashpolicy

### DIFF
--- a/pkg/nad/builder.go
+++ b/pkg/nad/builder.go
@@ -335,14 +335,14 @@ func (builder *Builder) WithMasterPlugin(masterPlugin *MasterPlugin) *Builder {
 		return builder
 	}
 
-	masterPluginSting, err := json.Marshal(masterPlugin)
+	masterPluginString, err := json.Marshal(masterPlugin)
 	if err != nil {
 		builder.errorMsg = err.Error()
 
 		return builder
 	}
 
-	builder.Definition.Spec.Config = string(masterPluginSting)
+	builder.Definition.Spec.Config = string(masterPluginString)
 
 	return builder
 }

--- a/pkg/nad/masterplugin.go
+++ b/pkg/nad/masterplugin.go
@@ -16,8 +16,9 @@ const (
 
 var (
 	// allowedMacVlanMode represents all allowed modes for macvlan plugin type.
-	allowedMacVlanMode      = []string{"bridge", "passthru", "private", "vepa"}
-	invalidIpamParameterMsg = "invalid ipam parameter"
+	allowedMacVlanMode       = []string{"bridge", "passthru", "private", "vepa"}
+	invalidIpamParameterMsg  = "invalid ipam parameter"
+	invalidXmitHashPolicyMsg = "error adding incorrect xmitHashPolicy value to MasterBondPlugin"
 )
 
 // MasterMacVlanPlugin provides struct for NetworkAttachmentDefinition Master plugin with macvlan configuration.
@@ -492,7 +493,7 @@ func (plugin *MasterBondPlugin) WithFailOverMac(failOverMac int) *MasterBondPlug
 
 // WithMiimon defines Miimon configuration to MasterBondPlugin.
 func (plugin *MasterBondPlugin) WithMiimon(miimon int) *MasterBondPlugin {
-	klog.V(100).Infof("Adding miimon %d to MasterBoundPlugin", miimon)
+	klog.V(100).Infof("Adding miimon %d to MasterBondPlugin", miimon)
 
 	if miimon < 0 {
 		klog.V(100).Infof("error adding incorrect miimon value %d to MasterBondPlugin", miimon)
@@ -503,6 +504,29 @@ func (plugin *MasterBondPlugin) WithMiimon(miimon int) *MasterBondPlugin {
 	}
 
 	plugin.masterPlugin.Miimon = fmt.Sprintf("%d", miimon)
+
+	return plugin
+}
+
+// WithXmitHashPolicy defines xmitHashPolicy configuration to MasterBondPlugin.
+func (plugin *MasterBondPlugin) WithXmitHashPolicy(xmitHashPolicy string) *MasterBondPlugin {
+	klog.V(100).Infof("Adding xmitHashPolicy %s to MasterBondPlugin", xmitHashPolicy)
+
+	validPolicies := map[string]bool{
+		"layer2":   true,
+		"layer2+3": true,
+		"layer3+4": true,
+	}
+
+	if !validPolicies[xmitHashPolicy] {
+		klog.V(100).Infof("error adding incorrect xmitHashPolicy value %s to MasterBondPlugin", xmitHashPolicy)
+
+		plugin.errorMsg = invalidXmitHashPolicyMsg
+
+		return plugin
+	}
+
+	plugin.masterPlugin.XmitHashPolicy = xmitHashPolicy
 
 	return plugin
 }

--- a/pkg/nad/masterplugin_test.go
+++ b/pkg/nad/masterplugin_test.go
@@ -1,0 +1,92 @@
+package nad
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMasterBondPluginWithXmitHashPolicy(t *testing.T) {
+	testCases := []struct {
+		name            string
+		xmitHashPolicy  string
+		expectError     bool
+		expectedError   string
+		expectJSONField string
+	}{
+		{
+			name:            "valid layer2",
+			xmitHashPolicy:  "layer2",
+			expectError:     false,
+			expectJSONField: `"xmitHashPolicy":"layer2"`,
+		},
+		{
+			name:            "valid layer2+3",
+			xmitHashPolicy:  "layer2+3",
+			expectError:     false,
+			expectJSONField: `"xmitHashPolicy":"layer2+3"`,
+		},
+		{
+			name:            "valid layer3+4",
+			xmitHashPolicy:  "layer3+4",
+			expectError:     false,
+			expectJSONField: `"xmitHashPolicy":"layer3+4"`,
+		},
+		{
+			name:           "invalid policy",
+			xmitHashPolicy: "invalid",
+			expectError:    true,
+			expectedError:  invalidXmitHashPolicyMsg,
+		},
+		{
+			name:           "empty policy",
+			xmitHashPolicy: "",
+			expectError:    true,
+			expectedError:  invalidXmitHashPolicyMsg,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			cfg, err := NewMasterBondPlugin("bond0", "balance-xor").
+				WithXmitHashPolicy(testCase.xmitHashPolicy).
+				GetMasterPluginConfig()
+
+			if testCase.expectError {
+				assert.Nil(t, cfg)
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), testCase.expectedError)
+
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.NotNil(t, cfg)
+			assert.Equal(t, testCase.xmitHashPolicy, cfg.XmitHashPolicy)
+
+			marshaled, marshalErr := json.Marshal(cfg)
+			assert.NoError(t, marshalErr)
+			assert.Contains(t, string(marshaled), testCase.expectJSONField)
+		})
+	}
+}
+
+func TestMasterBondPluginWithXmitHashPolicyAcceptance(t *testing.T) {
+	cfg, err := NewMasterBondPlugin("bond0", "balance-xor").
+		WithLinksInContainer(true).
+		WithFailOverMac(1).
+		WithMiimon(100).
+		WithLinks([]Link{{Name: "net1"}, {Name: "net2"}}).
+		WithXmitHashPolicy("layer2+3").
+		WithIPAM(&IPAM{Type: "static"}).
+		GetMasterPluginConfig()
+
+	assert.NoError(t, err)
+	assert.NotNil(t, cfg)
+	assert.Equal(t, "layer2+3", cfg.XmitHashPolicy)
+
+	marshaled, marshalErr := json.Marshal(cfg)
+	assert.NoError(t, marshalErr)
+	assert.Contains(t, string(marshaled), `"xmitHashPolicy":"layer2+3"`)
+}

--- a/pkg/nad/nadtypes.go
+++ b/pkg/nad/nadtypes.go
@@ -58,6 +58,7 @@ type (
 		VlanID           uint16      `json:"vlanId,omitempty"`
 		FailOverMac      int         `json:"failOverMac,omitempty"`
 		Miimon           string      `json:"miimon,omitempty"`
+		XmitHashPolicy   string      `json:"xmitHashPolicy,omitempty"`
 		Mtu              int         `json:"mtu,omitempty"`
 		Links            []Link      `json:"links,omitempty"`
 		Capabilities     *Capability `json:"capabilities,omitempty"`


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the bond transmit hash policy.
  * Supports `layer2`, `layer2+3`, and `layer3+4` policies.
  * Valid policies are included in serialized network configuration output.

* **Bug Fixes**
  * Invalid or empty transmit hash policies are now rejected.
  * Corrected bond plugin logging terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->