### PR TITLE
ocm: add ManagedCluster list functions

### DIFF
--- a/pkg/ocm/managedclusterlist.go
+++ b/pkg/ocm/managedclusterlist.go
@@ -1,0 +1,155 @@
+package ocm
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/google/uuid"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/internal/logging"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/ocm/clusterv1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	clusterVendorLabel            = "vendor"
+	clusterIDLabel                = "clusterID"
+	openshiftVersionLabel         = "openshiftVersion"
+	localClusterLabel             = "local-cluster"
+	clusterTemplateArtifactsLabel = "clustertemplates.clcm.openshift.io/templateId"
+	openshiftVendor               = "OpenShift"
+)
+
+// ListManagedClusters returns all ManagedCluster CRs on the hub.
+func ListManagedClusters(apiClient *clients.Settings, options ...runtimeclient.ListOption) ([]*ManagedClusterBuilder, error) {
+	if apiClient == nil {
+		klog.V(100).Info("ManagedClusters 'apiClient' parameter cannot be nil")
+
+		return nil, fmt.Errorf("failed to list managedClusters, 'apiClient' parameter is nil")
+	}
+
+	err := apiClient.AttachScheme(clusterv1.Install)
+	if err != nil {
+		klog.V(100).Info("Failed to add ManagedCluster scheme to client schemes")
+
+		return nil, err
+	}
+
+	klog.V(100).Info("Listing all managedClusters")
+
+	managedClusterList := new(clusterv1.ManagedClusterList)
+
+	err = apiClient.List(logging.DiscardContext(), managedClusterList, options...)
+	if err != nil {
+		klog.V(100).Infof("Failed to list all managedClusters due to %s", err.Error())
+
+		return nil, err
+	}
+
+	var managedClusterObjects []*ManagedClusterBuilder
+
+	for _, managedCluster := range managedClusterList.Items {
+		copiedManagedCluster := managedCluster
+		managedClusterBuilder := &ManagedClusterBuilder{
+			apiClient:  apiClient.Client,
+			Object:     &copiedManagedCluster,
+			Definition: &copiedManagedCluster,
+		}
+
+		managedClusterObjects = append(managedClusterObjects, managedClusterBuilder)
+	}
+
+	return managedClusterObjects, nil
+}
+
+// ListORANEligibleManagedClusters returns ManagedClusters that match the O2IMS node cluster collector criteria.
+func ListORANEligibleManagedClusters(
+	apiClient *clients.Settings, options ...runtimeclient.ListOption) ([]*ManagedClusterBuilder, error) {
+	managedClusters, err := ListManagedClusters(apiClient, options...)
+	if err != nil {
+		return nil, err
+	}
+
+	var eligibleManagedClusters []*ManagedClusterBuilder
+
+	for _, managedCluster := range managedClusters {
+		if IsORANEligibleManagedCluster(managedCluster.Definition) {
+			eligibleManagedClusters = append(eligibleManagedClusters, managedCluster)
+		}
+	}
+
+	return eligibleManagedClusters, nil
+}
+
+// IsORANEligibleManagedCluster reports whether a ManagedCluster would be ingested by the O2IMS cluster collector.
+func IsORANEligibleManagedCluster(cluster *clusterv1.ManagedCluster) bool {
+	if cluster == nil {
+		return false
+	}
+
+	condition := meta.FindStatusCondition(cluster.Status.Conditions, clusterv1.ManagedClusterConditionAvailable)
+	if condition == nil || condition.Status == metav1.ConditionFalse {
+		return false
+	}
+
+	if !isLocalManagedCluster(cluster) {
+		if cluster.Labels == nil {
+			return false
+		}
+
+		if _, found := cluster.Labels[clusterTemplateArtifactsLabel]; !found {
+			return false
+		}
+	}
+
+	return canConvertManagedClusterToNodeCluster(cluster)
+}
+
+// isLocalManagedCluster reports whether cluster is the ACM hub cluster (local-cluster=true).
+func isLocalManagedCluster(cluster *clusterv1.ManagedCluster) bool {
+	if cluster.Labels == nil {
+		return false
+	}
+
+	value, found := cluster.Labels[localClusterLabel]
+	if !found {
+		return false
+	}
+
+	localCluster, err := strconv.ParseBool(value)
+	if err != nil {
+		return false
+	}
+
+	return localCluster
+}
+
+// canConvertManagedClusterToNodeCluster reports whether cluster has the labels required for O2IMS node cluster conversion.
+func canConvertManagedClusterToNodeCluster(cluster *clusterv1.ManagedCluster) bool {
+	if cluster.Labels == nil {
+		return false
+	}
+
+	vendor, found := cluster.Labels[clusterVendorLabel]
+	if !found {
+		return false
+	}
+
+	if vendor == openshiftVendor {
+		if _, found := cluster.Labels[openshiftVersionLabel]; !found {
+			return false
+		}
+	}
+
+	clusterID, found := cluster.Labels[clusterIDLabel]
+	if !found {
+		return false
+	}
+
+	_, err := uuid.Parse(clusterID)
+
+	return err == nil
+}

--- a/pkg/ocm/managedclusterlist_test.go
+++ b/pkg/ocm/managedclusterlist_test.go
@@ -1,0 +1,194 @@
+package ocm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/ocm/clusterv1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	testSpokeClusterName = "spoke-cluster"
+	testHubClusterName   = "local-cluster"
+)
+
+func TestListManagedClusters(t *testing.T) {
+	testCases := []struct {
+		managedClusters []*ManagedClusterBuilder
+		listOptions     []runtimeclient.ListOption
+		client          bool
+		expectedError   error
+	}{
+		{
+			managedClusters: []*ManagedClusterBuilder{
+				buildValidManagedClusterTestBuilder(buildTestClientWithDummyManagedCluster()),
+			},
+			listOptions:   nil,
+			client:        true,
+			expectedError: nil,
+		},
+		{
+			managedClusters: []*ManagedClusterBuilder{
+				buildValidManagedClusterTestBuilder(buildTestClientWithDummyManagedCluster()),
+			},
+			listOptions:   []runtimeclient.ListOption{&runtimeclient.ListOptions{LabelSelector: labels.NewSelector()}},
+			client:        true,
+			expectedError: nil,
+		},
+		{
+			managedClusters: []*ManagedClusterBuilder{
+				buildValidManagedClusterTestBuilder(buildTestClientWithDummyManagedCluster()),
+			},
+			listOptions:   nil,
+			client:        false,
+			expectedError: fmt.Errorf("failed to list managedClusters, 'apiClient' parameter is nil"),
+		},
+	}
+
+	for _, testCase := range testCases {
+		var testSettings *clients.Settings
+
+		if testCase.client {
+			testSettings = buildTestClientWithDummyManagedCluster()
+		}
+
+		builders, err := ListManagedClusters(testSettings, testCase.listOptions...)
+		assert.Equal(t, testCase.expectedError, err)
+
+		if testCase.expectedError == nil && len(testCase.listOptions) == 0 {
+			assert.Equal(t, len(testCase.managedClusters), len(builders))
+		}
+	}
+}
+
+func TestListORANEligibleManagedClusters(t *testing.T) {
+	clusterID := uuid.New().String()
+	templateID := uuid.New().String()
+
+	testCases := []struct {
+		name          string
+		clusters      []*clusterv1.ManagedCluster
+		expectedNames []string
+	}{
+		{
+			name: "returns only ORAN-eligible clusters",
+			clusters: []*clusterv1.ManagedCluster{
+				buildORANEligibleSpokeManagedCluster(testSpokeClusterName, clusterID, templateID),
+				buildDummyManagedCluster("not-yet-available"),
+			},
+			expectedNames: []string{testSpokeClusterName},
+		},
+		{
+			name: "includes hub cluster without template id label",
+			clusters: []*clusterv1.ManagedCluster{
+				buildORANEligibleHubManagedCluster(testHubClusterName, clusterID),
+			},
+			expectedNames: []string{testHubClusterName},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			runtimeObjects := make([]runtime.Object, 0, len(testCase.clusters))
+			for _, cluster := range testCase.clusters {
+				runtimeObjects = append(runtimeObjects, cluster)
+			}
+
+			testSettings := clients.GetTestClients(clients.TestClientParams{
+				K8sMockObjects:  runtimeObjects,
+				SchemeAttachers: clusterTestSchemes,
+			})
+
+			builders, err := ListORANEligibleManagedClusters(testSettings)
+			assert.NoError(t, err)
+			assert.Len(t, builders, len(testCase.expectedNames))
+
+			names := make([]string, 0, len(builders))
+			for _, builder := range builders {
+				names = append(names, builder.Definition.Name)
+			}
+
+			assert.ElementsMatch(t, testCase.expectedNames, names)
+		})
+	}
+}
+
+func TestIsORANEligibleManagedCluster(t *testing.T) {
+	clusterID := uuid.New().String()
+	templateID := uuid.New().String()
+
+	testCases := []struct {
+		name    string
+		cluster *clusterv1.ManagedCluster
+	}{
+		{
+			name:    "eligible spoke cluster",
+			cluster: buildORANEligibleSpokeManagedCluster(testSpokeClusterName, clusterID, templateID),
+		},
+		{
+			name:    "eligible hub cluster",
+			cluster: buildORANEligibleHubManagedCluster(testHubClusterName, clusterID),
+		},
+		{
+			name: "non-openshift vendor without openshift version",
+			cluster: func() *clusterv1.ManagedCluster {
+				cluster := buildORANEligibleSpokeManagedCluster(testSpokeClusterName, clusterID, templateID)
+				cluster.Labels[clusterVendorLabel] = "OtherVendor"
+				delete(cluster.Labels, openshiftVersionLabel)
+
+				return cluster
+			}(),
+		},
+		{
+			name: "available condition unknown",
+			cluster: func() *clusterv1.ManagedCluster {
+				cluster := buildORANEligibleSpokeManagedCluster(testSpokeClusterName, clusterID, templateID)
+				cluster.Status.Conditions = []metav1.Condition{{
+					Type:   clusterv1.ManagedClusterConditionAvailable,
+					Status: metav1.ConditionUnknown,
+				}}
+
+				return cluster
+			}(),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			assert.True(t, IsORANEligibleManagedCluster(testCase.cluster))
+		})
+	}
+}
+
+// buildORANEligibleSpokeManagedCluster returns a spoke ManagedCluster that passes all ORAN eligibility checks.
+func buildORANEligibleSpokeManagedCluster(name, clusterID, templateID string) *clusterv1.ManagedCluster {
+	cluster := buildDummyManagedCluster(name)
+	cluster.Labels = map[string]string{
+		clusterVendorLabel:            openshiftVendor,
+		clusterIDLabel:                clusterID,
+		openshiftVersionLabel:         "4.20.0",
+		clusterTemplateArtifactsLabel: templateID,
+	}
+	cluster.Status.Conditions = []metav1.Condition{{
+		Type:   clusterv1.ManagedClusterConditionAvailable,
+		Status: metav1.ConditionTrue,
+	}}
+
+	return cluster
+}
+
+// buildORANEligibleHubManagedCluster returns a hub ManagedCluster that passes all ORAN eligibility checks.
+func buildORANEligibleHubManagedCluster(name, clusterID string) *clusterv1.ManagedCluster {
+	cluster := buildORANEligibleSpokeManagedCluster(name, clusterID, uuid.New().String())
+	cluster.Labels[localClusterLabel] = "true"
+	delete(cluster.Labels, clusterTemplateArtifactsLabel)
+
+	return cluster
+}


### PR DESCRIPTION
This commit adds two list functions for the ManagedCluster builder in pkg/ocm. The first is a generic ListManagedClusters to return all ManagedClusters matching the provided ListOptions. The second is a function specific to the o-cloud-manager, which returns a subset of ManagedClusters via its API. This list function returns the ones part of that subset.

Assisted-by: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added managed cluster discovery from ACM hub clusters.
  * Added filtering to identify clusters eligible for O2IMS ingestion.
  * Added validation for cluster availability, required metadata, and valid cluster identifiers.
  * Added special handling for local hub clusters.

* **Tests**
  * Added coverage for cluster listing, eligibility filtering, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->